### PR TITLE
Add element-wise comparison APIs

### DIFF
--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -320,6 +320,30 @@ Calculates the division for each element `x1_i` of the input array `x1` with the
 
     -   an array containing the element-wise results.
 
+### <a name="equal" href="#equal">#</a> equal(x1, x2, /, *, out=None)
+
+Computes the truth value of `x1_i == x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
+
+#### Parameters
+
+-   **x1**: _&lt;array&gt;_
+
+    -   first input array.
+
+-   **x2**: _&lt;array&gt;_
+
+    -   second input array. Must be compatible with `x1` (see :ref:`broadcasting`). 
+
+-   **out**:  _Optional\[ &lt;array&gt; ]_
+
+    -   output array. If provided, the output array must be compatible with the provided input arrays (see :ref:`broadcasting`). If not provided or is `None`, an uninitialized return array, whose underlying data type is `bool`, must be created and then filled with the result of each element-wise computation. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the element-wise results.
+
 ### <a name="exp" href="#exp">#</a> exp(x, /, *, out=None)
 
 Calculates an implementation-dependent approximation to the exponential function, having domain `[-infinity, +infinity]` and codomain `[+0, +infinity]`, for each element `x_i` of the input array `x` (`e` raised to the power of `x_i`, where `e` is the base of the natural logarithm).
@@ -367,6 +391,102 @@ Rounds each element `x_i` of the input array `x` to the greatest (i.e., closest 
 -   **out**: _&lt;array&gt;_
 
     -   an array containing the rounded result for each element in `x`.
+
+### <a name="greater" href="#greater">#</a> greater(x1, x2, /, *, out=None)
+
+Computes the truth value of `x1_i > x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
+
+#### Parameters
+
+-   **x1**: _&lt;array&gt;_
+
+    -   first input array.
+
+-   **x2**: _&lt;array&gt;_
+
+    -   second input array. Must be compatible with `x1` (see :ref:`broadcasting`). 
+
+-   **out**:  _Optional\[ &lt;array&gt; ]_
+
+    -   output array. If provided, the output array must be compatible with the provided input arrays (see :ref:`broadcasting`). If not provided or is `None`, an uninitialized return array, whose underlying data type is `bool`, must be created and then filled with the result of each element-wise computation. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the element-wise results.
+
+### <a name="greater_equal" href="#greater_equal">#</a> greater_equal(x1, x2, /, *, out=None)
+
+Computes the truth value of `x1_i >= x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
+
+#### Parameters
+
+-   **x1**: _&lt;array&gt;_
+
+    -   first input array.
+
+-   **x2**: _&lt;array&gt;_
+
+    -   second input array. Must be compatible with `x1` (see :ref:`broadcasting`). 
+
+-   **out**:  _Optional\[ &lt;array&gt; ]_
+
+    -   output array. If provided, the output array must be compatible with the provided input arrays (see :ref:`broadcasting`). If not provided or is `None`, an uninitialized return array, whose underlying data type is `bool`, must be created and then filled with the result of each element-wise computation. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the element-wise results.
+
+### <a name="less" href="#less">#</a> less(x1, x2, /, *, out=None)
+
+Computes the truth value of `x1_i < x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
+
+#### Parameters
+
+-   **x1**: _&lt;array&gt;_
+
+    -   first input array.
+
+-   **x2**: _&lt;array&gt;_
+
+    -   second input array. Must be compatible with `x1` (see :ref:`broadcasting`). 
+
+-   **out**:  _Optional\[ &lt;array&gt; ]_
+
+    -   output array. If provided, the output array must be compatible with the provided input arrays (see :ref:`broadcasting`). If not provided or is `None`, an uninitialized return array, whose underlying data type is `bool`, must be created and then filled with the result of each element-wise computation. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the element-wise results.
+
+### <a name="less_equal" href="#less_equal">#</a> less_equal(x1, x2, /, *, out=None)
+
+Computes the truth value of `x1_i <= x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
+
+#### Parameters
+
+-   **x1**: _&lt;array&gt;_
+
+    -   first input array.
+
+-   **x2**: _&lt;array&gt;_
+
+    -   second input array. Must be compatible with `x1` (see :ref:`broadcasting`). 
+
+-   **out**:  _Optional\[ &lt;array&gt; ]_
+
+    -   output array. If provided, the output array must be compatible with the provided input arrays (see :ref:`broadcasting`). If not provided or is `None`, an uninitialized return array, whose underlying data type is `bool`, must be created and then filled with the result of each element-wise computation. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the element-wise results.
 
 ### <a name="log" href="#log">#</a> log(x, /, *, out=None)
 
@@ -419,6 +539,30 @@ Calculates the product for each element `x1_i` of the input array `x1` with the 
 -   **out**: _&lt;array&gt;_
 
     -   an array containing the element-wise products.
+
+### <a name="not_equal" href="#not_equal">#</a> not_equal(x1, x2, /, *, out=None)
+
+Computes the truth value of `x1_i != x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
+
+#### Parameters
+
+-   **x1**: _&lt;array&gt;_
+
+    -   first input array.
+
+-   **x2**: _&lt;array&gt;_
+
+    -   second input array. Must be compatible with `x1` (see :ref:`broadcasting`). 
+
+-   **out**:  _Optional\[ &lt;array&gt; ]_
+
+    -   output array. If provided, the output array must be compatible with the provided input arrays (see :ref:`broadcasting`). If not provided or is `None`, an uninitialized return array, whose underlying data type is `bool`, must be created and then filled with the result of each element-wise computation. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the element-wise results.
 
 ### <a name="round" href="#round">#</a> round(x, /, *, out=None)
 


### PR DESCRIPTION
This PR

-   adds specifications for element-wise comparison functions.
-   is derived from comparing API [signatures](https://github.com/data-apis/array-api-comparison/tree/acb536efbf2eb19964a44a7c9457489cc1dac422/signatures/comparison) across array libraries.

## Notes

-    Element-wise comparison functions are widely implemented across [array libraries](https://github.com/data-apis/array-api-comparison/blob/99c13c579ee559fc45793a04f44f031b1a3cb736/data/common_apis.csv) and are used, to some extent, by downstream [libraries](https://github.com/data-apis/array-api-comparison/blob/99c13c579ee559fc45793a04f44f031b1a3cb736/data/common_apis_ranks.csv). Apart from being widely implemented, a principal reason for their inclusion is to provide standardized public APIs which can be passed around (e.g., when composing functional pipelines, etc).
-    The proposed specifications follow the same general form as arithmetic operations, which are already present in the specification, and share the same concerns as other element-wise interfaces concerning broadcast compatibility.