### PR TITLE
Add additional element-wise mathematical functions

### DIFF
--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -353,7 +353,7 @@ Calculates an implementation-dependent approximation to `exp(x)-1`, having domai
 
 .. note::
 
-    The purpose of this API, which is particularly useful in financial applications, is to calculate `exp(x)-1.0` more accurately when `x` is close to zero. Accordingly, conforming implementations should avoid implementing this API as simply `exp(x)-1.0`. See FDLIBM, or some other IEEE 754-2019 compliant mathematical library, for a potential reference implementation.
+    The purpose of this API is to calculate `exp(x)-1.0` more accurately when `x` is close to zero. Accordingly, conforming implementations should avoid implementing this API as simply `exp(x)-1.0`. See FDLIBM, or some other IEEE 754-2019 compliant mathematical library, for a potential reference implementation.
 
 -   If `x_i` is `NaN`, the result is `NaN`.
 -   If `x_i` is `+0`, the result is `+0`.
@@ -499,7 +499,7 @@ Calculates an implementation-dependent approximation to `log(1+x)`, where `log` 
 
 .. note::
 
-    The purpose of this API, which is particularly useful in financial applications, is to calculate `log(1+x)` more accurately when `x` is close to zero. Accordingly, conforming implementations should avoid implementing this API as simply `log(1+x)`. See FDLIBM, or some other IEEE 754-2019 compliant mathematical library, for a potential reference implementation.
+    The purpose of this API is to calculate `log(1+x)` more accurately when `x` is close to zero. Accordingly, conforming implementations should avoid implementing this API as simply `log(1+x)`. See FDLIBM, or some other IEEE 754-2019 compliant mathematical library, for a potential reference implementation.
 
 -   If `x_i` is `NaN`, the result is `NaN`.
 -   If `x_i` is less than `-1`, the result is `NaN`.


### PR DESCRIPTION
This PR

-   adds specifications for additional element-wise mathematical functions.
-   is derived from comparing API [signatures](https://github.com/data-apis/array-api-comparison/tree/f8fdfa092b74a9415ccf1a6a1543a698b41d1127/signatures/mathematical-functions-elementwise) across array libraries.
-   the APIs are [used](https://github.com/data-apis/array-api-comparison/blob/f8fdfa092b74a9415ccf1a6a1543a698b41d1127/data/common_apis_ranks.csv) by downstream libraries with at least some frequency.
-   The addition of these APIs furthers parity with corresponding C [APIs](https://en.cppreference.com/w/c/numeric/math) (C99) and those present in IEEE 754-2008.

## Notes

-   The list of APIs is as follows:

    -   **expm1**: present in all analyzed array libraries
    -   **log1p**: present in all analyzed array libraries
    -   **log2**: not present in TensorFlow (except in experimental NumPy)
    -   **log10**: not present in TensorFlow (except in experimental NumPy)
    -   **pow**: not present in Dask array (or at least not in its docs)
    -   **sign**: present in all analyzed array libraries
    -   **square**: present in all analyzed array libraries