### PR TITLE
Add specifications for array manipulation functions

### DIFF
--- a/spec/API_specification/manipulation_functions.md
+++ b/spec/API_specification/manipulation_functions.md
@@ -34,6 +34,26 @@ Joins a sequence of arrays along an existing axis.
 
             This specification leaves type promotion between data type families (i.e., `intxx` and `floatxx`) unspecified.
 
+### <a name="expand_dims" href="#expand_dims">#</a> expand_dims(x, axis, /)
+
+Expands the shape of an array by inserting a new axis (dimension) of size one at the position specified by `axis`.
+
+#### Parameters
+
+-   **x**: _&lt;array&gt;_
+
+    -   input array.
+
+-   **axis**: _int_ 
+
+    -   axis position. Must follow Python's indexing rules: zero-based and negative indices must be counted backward from the last dimension. If `x` has rank `N`, a valid `axis` must reside on the interval `[-N-1, N+1]`. An `IndexError` exception must be raised if provided an invalid `axis` position.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an expanded output array having the same data type and shape as `x`.
+
 ### <a name="flip" href="#flip">#</a> flip(x, /, *, axis=None)
 
 Reverses the order of elements in an array along the given axis. The shape of the array must be preserved.


### PR DESCRIPTION
This PR

-   adds specifications for array manipulation functions.
-   is derived from comparing API [signatures](https://github.com/data-apis/array-api-comparison/tree/12e1cc44bd08dc527ba2b82e04ddc027f5660c5c/signatures/manipulation) across array libraries.

## Notes

-   This list of array manipulation functions is an initial set of array manipulation functions which can pave the way for additional specs in subsequent pull requests. These functions were identified as the set of functions with the broadest support among array libraries and relatively higher [usage](https://github.com/data-apis/array-api-comparison/blob/99c13c579ee559fc45793a04f44f031b1a3cb736/data/common_apis_ranks.csv) among downstream libraries.

-   Some comments/questions regarding particular APIs...

    -   **concat**: CuPy requires a tuple rather than a sequence for first argument. Went with tuple as more consistent with rest of specification (e.g., we require a list of axes to be specified as a tuple, but not a sequence). What happens if provided arrays having different dtypes? What should we the dtype of the returned array? How do type promotion rules factor in here?

        -   Answer: regular type promotion rules. Between data type families, behavior is left unspecified.

    -   **expand_dims**: NumPy supports providing a tuple or an `int`. All other array libraries considered support only an `int`. Torch names this method `unsqueeze`. Went with `expand_dims` and only accepting an `int` for the second positional argument.

    -   **flip**: TensorFlow lacks this exact API. Torch/CuPy/ spec `axis`/`dims` as position argument. Based proposal on NumPy where `axis` is a keyword argument, as more versatile.

    -   **reshape**: Torch requires a tuple (does not allow `int`). TensorFlow requires shape to be a `int32`/`int64` tensor. NumPy allows providing an `int` as shorthand. Based proposal on Torch's more restricted API for consistency.

    -   **roll**: TensorFlow requires tensors for axis and shifts.

    -   **squeeze**: Torch only allows specifying one axis and does not error if you attempt to squeeze non-singleton dimensions. NumPy/TensorFlow error if you attempt to squeeze a dimension which is not `1`. Sided with Torch regarding error behavior, as not clear why attempting to squeeze a non-singleton dimension should error.

    -   **stack**: CuPy requires a tuple rather than a sequence for the first argument. Went with tuple for same reasons as in `concat`. Same `dtype` question(s) apply as for `concat` above.