### PR TITLE
Add bitwise elementwise specifications

### DIFF
--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -298,7 +298,7 @@ Computes the bitwise AND of the underlying binary representation of each element
 
     -   an array containing the element-wise results.
 
-### <a name="bitwise_lshift" href="#bitwise_lshift">#</a> bitwise_lshift(x1, x2, /)
+### <a name="bitwise_left_shift" href="#bitwise_left_shift">#</a> bitwise_left_shift(x1, x2, /)
 
 Shifts the bits of each element `x1_i` of the input array `x1` to the left by appending `x2_i` (i.e., the respective element in the input array `x2`) zeros to the right of `x1_i`.
 
@@ -354,7 +354,7 @@ Computes the bitwise OR of the underlying binary representation of each element 
 
     -   an array containing the element-wise results.
 
-### <a name="bitwise_rshift" href="#bitwise_rshift">#</a> bitwise_rshift(x1, x2, /)
+### <a name="bitwise_right_shift" href="#bitwise_right_shift">#</a> bitwise_right_shift(x1, x2, /)
 
 Shifts the bits of each element `x1_i` of the input array `x1` to the right according to the respective element `x2_i` of the input array `x2`.
 


### PR DESCRIPTION
This PR

-   adds bitwise elementwise functional specification equivalents for the following operators: `&`, `|`, `^`, `~`, `>>`, and `<<`.
-   is derived from comparing API [signatures](https://github.com/data-apis/array-api-comparison/tree/519dd9b5c27af5c39a5f35664f8e64a689703b5b/signatures/bitwise) across array libraries.

## Notes

-   The specifications follow the same form as other elementwise functions.

-   Functional bitwise APIs are, while not ubiquitous, commonly implemented across array libraries. The principle impetus for their inclusion is to have functional equivalents of operators (as discussed and endorsed during a prior consortium meeting).

-   This PR induces a slightly different naming convention. NumPy (and its followers) splits its namespace into non-prefixed and prefixed APIs (e.g., `right_shift` vs `bitwise_and`). TensorFlow puts everything under a `tf.bitwise` namespace, while also using a `bitwise_` prefix for certain APIs.

    This PR chooses to simply put all bitwise operations under a `bitwise_` prefix. This matches, and is consistent with, the current convention of using a `logical_` prefix for logical operations.

-   This PR currently requires that `x2` for both `right_shift` and `left_shift` have nonnegative elements. NumPy's docs for [`left_shift`](https://numpy.org/doc/stable/reference/generated/numpy.left_shift.html) state that this is required; although, from the interpreter, no error is thrown if a negative `x2` is provided. TensorFlow states that negative `x2` results in implementation-dependent behavior.

    This PR takes the stance that negative `x2` for either `left_shift` and `right_shift` is probably a mistake and should not be permitted. Hence, the included requirements that `x2` be greater than or equal to `0`.