### PR TITLE
Remove empty "array duck typing" section

### DIFF
--- a/spec/design_topics/array_ducktyping.md
+++ b/spec/design_topics/array_ducktyping.md
@@ -1,1 +1,0 @@
-# Array duck typing

--- a/spec/design_topics/index.rst
+++ b/spec/design_topics/index.rst
@@ -9,7 +9,6 @@ Design topics & constraints
    eager_lazy_eval
    parallelism
    static_typing
-   array_ducktyping
    data_interchange
    accuracy
    device_support


### PR DESCRIPTION
This is covered throughout the document, from Use Cases and Scope to Assumptions and Static Typing. Having a separate section on this probably doesn't make sense.