### PR TITLE
Remove empty backwards compatibility section

### DIFF
--- a/spec/design_topics/backwards_compatibility.md
+++ b/spec/design_topics/backwards_compatibility.md
@@ -1,4 +1,0 @@
-# Backwards compatibility
-
-This section discusses the impact on existing array and tensor libraries of
-choices made in the API standard, and the trade-offs that went into them.

--- a/spec/design_topics/index.rst
+++ b/spec/design_topics/index.rst
@@ -5,7 +5,6 @@ Design topics & constraints
    :caption: Design topics & constraints
    :maxdepth: 1
 
-   backwards_compatibility
    eager_lazy_eval
    parallelism
    static_typing


### PR DESCRIPTION
There's a backwards compatibility section under "Assumptions", and the topic is also dealt with in "How to adopt this API".
The topic is covered, so remove this empty section.