### PR TITLE
Update colors to indigo/green, bit better than purple.

### DIFF
--- a/spec/conf.py
+++ b/spec/conf.py
@@ -86,8 +86,8 @@ html_theme_options = {
 
     # Set the color and the accent color (see
     # https://material.io/design/color/the-color-system.html)
-    'color_primary': 'deep-purple',
-    'color_accent': 'cyan',
+    'color_primary': 'indigo',
+    'color_accent': 'green',
 
     # Set the repo location to get a badge with stats
     #'repo_url': 'https://github.com/project/project/',


### PR DESCRIPTION
Only named colors work, and which ones they are can be seen in
https://bashtage.github.io/sphinx-material/customization.html#configuration-options

Ref gh-67. These colors are closer to the logo colors, best we can do for now without messing with the raw CSS of the theme. The only color closer to the dark blue in the logo would be grey, but that makes links hard to distinguish. These are the colors now:

<img width="484" alt="image" src="https://user-images.githubusercontent.com/98330/98024159-343e4580-1e08-11eb-8f2b-97e745988fc4.png">
