### PR TITLE
Add cross-reference targets to all the function, method, constant, and attribute headers

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -179,6 +179,7 @@ For the expected numerical behaviour, see their left-hand equivalents.
 
 <!-- NOTE: please keep the attributes in alphabetical order -->
 
+(attribute-dtype)=
 ### dtype
 
 Data type of the array elements.
@@ -189,6 +190,7 @@ Data type of the array elements.
 
     -   array data type.
 
+(attribute-ndim)=
 ### ndim
 
 Number of array dimensions (axes).
@@ -201,6 +203,7 @@ Number of array dimensions (axes).
 
 _TODO: need to more carefully consider this in order to accommodate, e.g., graph tensors where the number of dimensions may be dynamic._
 
+(attribute-shape)=
 ### shape
 
 Array dimensions.
@@ -213,6 +216,7 @@ Array dimensions.
 
 _TODO: need to more carefully consider this in order to accommodate, e.g., graph tensors where a shape may be dynamic._
 
+(attribute-size)=
 ### size
 
 Number of elements in an array. This should equal the product of the array's dimensions.
@@ -225,6 +229,7 @@ Number of elements in an array. This should equal the product of the array's dim
 
 _TODO: need to more carefully consider this in order to accommodate, e.g., graph tensors where the number of elements may be dynamic._
 
+(attribute-T)=
 ### T
 
 Transpose of the array.
@@ -241,6 +246,7 @@ Transpose of the array.
 
 <!-- NOTE: please keep the methods in alphabetical order -->
 
+(method-__abs__)=
 ### \_\_abs\_\_(x, /)
 
 Calculates the absolute value for each element `x_i` of an array instance `x` (i.e., the element-wise result has the same magnitude as the respective element in `x` but has positive sign).
@@ -268,6 +274,7 @@ Calculates the absolute value for each element `x_i` of an array instance `x` (i
 Element-wise results must equal the results returned by the equivalent element-wise function [`abs(x)`](elementwise_functions.md#absx-).
 ```
 
+(method-__add__)=
 ### \_\_add\_\_(x1, x2, /)
 
 Calculates the sum for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`. For floating-point arithmetic,
@@ -318,6 +325,7 @@ Floating-point addition is a commutative operation, but not always associative.
 Element-wise results must equal the results returned by the equivalent element-wise function [`add(x1, x2)`](elementwise_functions.md#addx1-x2-).
 ```
 
+(method-__and__)=
 ### \_\_and\_\_(x1, x2, /)
 
 Evaluates `x1_i & x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -343,6 +351,7 @@ Evaluates `x1_i & x2_i` for each element `x1_i` of an array instance `x1` with t
 Element-wise results must equal the results returned by the equivalent element-wise function [`bitwise_and(x1, x2)`](elementwise_functions.md#logical_andx1-x2-).
 ```
 
+(method-__eq__)=
 ### \_\_eq\_\_(x1, x2, /)
 
 Computes the truth value of `x1_i == x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -368,6 +377,7 @@ Computes the truth value of `x1_i == x2_i` for each element `x1_i` of an array i
 Element-wise results must equal the results returned by the equivalent element-wise function [`equal(x1, x2)`](elementwise_functions.md#equalx1-x2-).
 ```
 
+(method-__floordiv__)=
 ### \_\_floordiv\_\_(x1, x2, /)
 
 Evaluates `x1_i // x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -393,6 +403,7 @@ Evaluates `x1_i // x2_i` for each element `x1_i` of an array instance `x1` with 
 Element-wise results must equal the results returned by the equivalent element-wise function [`floor_divide(x1, x2)`](elementwise_functions.md#floor_dividex1-x2-).
 ```
 
+(method-__ge__)=
 ### \_\_ge\_\_(x1, x2, /)
 
 Computes the truth value of `x1_i >= x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -418,10 +429,12 @@ Computes the truth value of `x1_i >= x2_i` for each element `x1_i` of an array i
 Element-wise results must equal the results returned by the equivalent element-wise function [`greater_equal(x1, x2)`](elementwise_functions.md#greater_equalx1-x2-).
 ```
 
+(method-__getitem__)=
 ### \_\_getitem\_\_(x, key, /)
 
 _TODO: dependent on the indexing specification._
 
+(method-__gt__)=
 ### \_\_gt\_\_(x1, x2, /)
 
 Computes the truth value of `x1_i > x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -447,6 +460,7 @@ Computes the truth value of `x1_i > x2_i` for each element `x1_i` of an array in
 Element-wise results must equal the results returned by the equivalent element-wise function [`greater(x1, x2)`](elementwise_functions.md#greaterx1-x2-).
 ```
 
+(method-__invert__)=
 ### \_\_invert\_\_(x, /)
 
 Evaluates `~x_i` for each element `x_i` of an array instance `x`.
@@ -468,6 +482,7 @@ Evaluates `~x_i` for each element `x_i` of an array instance `x`.
 Element-wise results must equal the results returned by the equivalent element-wise function [`bitwise_invert(x)`](elementwise_functions.md#bitwise_invertx-).
 ```
 
+(method-__le__)=
 ### \_\_le\_\_(x1, x2, /)
 
 Computes the truth value of `x1_i <= x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -493,10 +508,12 @@ Computes the truth value of `x1_i <= x2_i` for each element `x1_i` of an array i
 Element-wise results must equal the results returned by the equivalent element-wise function [`less_equal(x1, x2)`](elementwise_functions.md#less_equalx1-x2-).
 ```
 
+(method-__len__)=
 ### \_\_len\_\_(x, /)
 
 _TODO: need to more carefully consider this in order to accommodate, e.g., graph tensors where a shape may be dynamic._
 
+(method-__lshift__)=
 ### \_\_lshift\_\_(x1, x2, /)
 
 Evaluates `x1_i << x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -522,6 +539,7 @@ Evaluates `x1_i << x2_i` for each element `x1_i` of an array instance `x1` with 
 Element-wise results must equal the results returned by the equivalent element-wise function [`less_equal(x1, x2)`](elementwise_functions.md#bitwise_left_shiftx1-x2-).
 ```
 
+(method-__lt__)=
 ### \_\_lt\_\_(x1, x2, /)
 
 Computes the truth value of `x1_i < x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -547,6 +565,7 @@ Computes the truth value of `x1_i < x2_i` for each element `x1_i` of an array in
 Element-wise results must equal the results returned by the equivalent element-wise function [`less(x1, x2)`](elementwise_functions.md#lessx1-x2-).
 ```
 
+(method-__matmul__)=
 ### \_\_matmul\_\_(x1, x2, /)
 
 _TODO: awaiting `matmul` functional equivalent._
@@ -567,6 +586,7 @@ _TODO: awaiting `matmul` functional equivalent._
 
     -   _TODO_
 
+(method-__mod__)=
 ### \_\_mod\_\_(x1, x2, /)
 
 Evaluates `x1_i % x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -592,6 +612,7 @@ Evaluates `x1_i % x2_i` for each element `x1_i` of an array instance `x1` with t
 Element-wise results must equal the results returned by the equivalent element-wise function [`remainder(x1, x2)`](elementwise_functions.md#remainderx1-x2-).
 ```
 
+(method-__mul__)=
 ### \_\_mul\_\_(x1, x2, /)
 
 Calculates the product for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`. For floating-point arithmetic,
@@ -634,6 +655,7 @@ Floating-point multiplication is not always associative due to finite precision.
 Element-wise results must equal the results returned by the equivalent element-wise function [`multiply(x1, x2)`](elementwise_functions.md#multiplyx1-x2-).
 ```
 
+(method-__ne__)=
 ### \_\_ne\_\_(x1, x2, /)
 
 Computes the truth value of `x1_i != x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -659,6 +681,7 @@ Computes the truth value of `x1_i != x2_i` for each element `x1_i` of an array i
 Element-wise results must equal the results returned by the equivalent element-wise function [`not_equal(x1, x2)`](elementwise_functions.md#not_equalx1-x2-).
 ```
 
+(method-__neg__)=
 ### \_\_neg\_\_(x, /)
 
 Evaluates `-x_i` for each element `x_i` of an array instance `x`.
@@ -680,6 +703,7 @@ Evaluates `-x_i` for each element `x_i` of an array instance `x`.
 Element-wise results must equal the results returned by the equivalent element-wise function [`negative(x)`](elementwise_functions.md#negativex-).
 ```
 
+(method-__or__)=
 ### \_\_or\_\_(x1, x2, /)
 
 Evaluates `x1_i | x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -705,6 +729,7 @@ Evaluates `x1_i | x2_i` for each element `x1_i` of an array instance `x1` with t
 Element-wise results must equal the results returned by the equivalent element-wise function [`positive(x1, x2)`](elementwise_functions.md#bitwise_orx1-x2-).
 ```
 
+(method-__pos__)=
 ### \_\_pos\_\_(x, /)
 
 Evaluates `+x_i` for each element `x_i` of an array instance `x`.
@@ -726,6 +751,7 @@ Evaluates `+x_i` for each element `x_i` of an array instance `x`.
 Element-wise results must equal the results returned by the equivalent element-wise function [`positive(x)`](elementwise_functions.md#positivex-).
 ```
 
+(method-__pow__)=
 ### \_\_pow\_\_(x1, x2, /)
 
 Calculates an implementation-dependent approximation of exponentiation by raising each element `x1_i` (the base) of an array instance `x1` to the power of `x2_i` (the exponent), where `x2_i` is the corresponding element of the array `x2`.
@@ -778,6 +804,7 @@ Calculates an implementation-dependent approximation of exponentiation by raisin
 Element-wise results must equal the results returned by the equivalent element-wise function [`pow(x1, x2)`](elementwise_functions.md#powx1-x2-).
 ```
 
+(method-__rshift__)=
 ### \_\_rshift\_\_(x1, x2, /)
 
 Evaluates `x1_i >> x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.
@@ -803,10 +830,12 @@ Evaluates `x1_i >> x2_i` for each element `x1_i` of an array instance `x1` with 
 Element-wise results must equal the results returned by the equivalent element-wise function [`bitwise_right_shift(x1, x2)`](elementwise_functions.md#bitwise_right_shiftx1-x2-).
 ```
 
+(method-__setitem__)=
 ### \_\_setitem\_\_(x, key, value, /)
 
 _TODO: dependent on the indexing specification._
 
+(method-__sub__)=
 ### \_\_sub\_\_(x1, x2, /)
 
 Calculates the difference for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`. The result of `x1_i - x2_i` must be the same as `x1_i + (-x2_i)` and is thus governed by the same floating-point rules as addition (see [`__add__()`](#__add__x1-x2-)).
@@ -832,6 +861,7 @@ Calculates the difference for each element `x1_i` of an array instance `x1` with
 Element-wise results must equal the results returned by the equivalent element-wise function [`subtract(x1, x2)`](elementwise_functions.md#subtractx1-x2-).
 ```
 
+(method-__truediv__)=
 ### \_\_truediv\_\_(x1, x2, /)
 
 Evaluates `x1_i / x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`. For floating-point arithmetic,
@@ -882,6 +912,7 @@ Evaluates `x1_i / x2_i` for each element `x1_i` of an array instance `x1` with t
 Element-wise results must equal the results returned by the equivalent element-wise function [`divide(x1, x2)`](elementwise_functions.md#dividex1-x2-).
 ```
 
+(method-__xor__)=
 ### \_\_xor\_\_(x1, x2, /)
 
 Evaluates `x1_i ^ x2_i` for each element `x1_i` of an array instance `x1` with the respective element `x2_i` of the array `x2`.

--- a/spec/API_specification/constants.md
+++ b/spec/API_specification/constants.md
@@ -8,6 +8,7 @@ A conforming implementation of the array API standard must provide and support t
 
 ## Objects in API
 
+(constant-e)=
 ### e
 
 Euler's constant.
@@ -16,14 +17,17 @@ Euler's constant.
 e = 2.71828182845904523536028747135266249775724709369995...
 ```
 
+(constant-inf)=
 ### inf
 
 IEEE 754 floating point representation of (positive) infinity.
 
+(constant-nan)=
 ### nan
 
 IEEE 754 floating point representation of Not a Number (`NaN`).
 
+(constant-pi)=
 ### pi
 
 The mathematical constant `π`.

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -11,6 +11,7 @@ A conforming implementation of the array API standard must provide and support t
 
 <!-- NOTE: please keep the functions in alphabetical order -->
 
+(function-arange)=
 ### arange(start, /, *, stop=None, step=1, dtype=None)
 
 Returns evenly spaced values within the half-open interval `[start, stop)` as a one-dimensional array.
@@ -44,6 +45,7 @@ This function cannot guarantee that the interval does not include the `stop` val
 
     -   a one-dimensional array containing evenly spaced values. The length of the output array must be `ceil((stop-start)/step)`.
 
+(function-empty)=
 ### empty(shape, /, *, dtype=None)
 
 Returns an uninitialized array having a specified `shape`.
@@ -64,6 +66,7 @@ Returns an uninitialized array having a specified `shape`.
 
     -   an array containing uninitialized data.
 
+(function-empty_like)=
 ### empty_like(x, /, *, dtype=None)
 
 Returns an uninitialized array with the same `shape` as an input array `x`.
@@ -84,6 +87,7 @@ Returns an uninitialized array with the same `shape` as an input array `x`.
 
     -   an array having the same shape as `x` and containing uninitialized data.
 
+(function-eye)=
 ### eye(N, /, *, M=None, k=0, dtype=None)
 
 Returns a two-dimensional array with ones on the `k`th diagonal and zeros elsewhere.
@@ -112,6 +116,7 @@ Returns a two-dimensional array with ones on the `k`th diagonal and zeros elsewh
 
     -   an array where all elements are equal to zero, except for the `k`th diagonal, whose values are equal to one.
 
+(function-full)=
 ### full(shape, fill_value, /, *, dtype=None)
 
 Returns a new array having a specified `shape` and filled with `fill_value`.
@@ -136,6 +141,7 @@ Returns a new array having a specified `shape` and filled with `fill_value`.
 
     -   an array where every element is equal to `fill_value`.
 
+(function-full_like)=
 ### full_like(x, fill_value, /, *, dtype=None)
 
 Returns a new array filled with `fill_value` and having the same `shape` as an input array `x`.
@@ -160,6 +166,7 @@ Returns a new array filled with `fill_value` and having the same `shape` as an i
 
     -   an array having the same shape as `x` and where every element is equal to `fill_value`.
 
+(function-linspace)=
 ### linspace(start, stop, num, /, *, dtype=None, endpoint=True)
 
 Returns evenly spaced numbers over a specified interval.
@@ -194,6 +201,7 @@ Returns evenly spaced numbers over a specified interval.
 
     -   a one-dimensional array containing evenly spaced values.
 
+(function-ones)=
 ### ones(shape, /, *, dtype=None)
 
 Returns a new array having a specified `shape` and filled with ones.
@@ -214,6 +222,7 @@ Returns a new array having a specified `shape` and filled with ones.
 
     -   an array containing ones.
 
+(function-ones_like)=
 ### ones_like(x, /, *, dtype=None)
 
 Returns a new array filled with ones and having the same `shape` as an input array `x`.
@@ -234,6 +243,7 @@ Returns a new array filled with ones and having the same `shape` as an input arr
 
     -   an array having the same shape as `x` and filled with ones.
 
+(function-zeros)=
 ### zeros(shape, /, *, dtype=None)
 
 Returns a new array having a specified `shape` and filled with zeros.
@@ -254,6 +264,7 @@ Returns a new array having a specified `shape` and filled with zeros.
 
     -   an array containing zeros.
 
+(function-zeros_like)=
 ### zeros_like(x, /, *, dtype=None)
 
 Returns a new array filled with zeros and having the same `shape` as an input array `x`.

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -18,6 +18,7 @@ A conforming implementation of the array API standard must provide and support t
 
 <!-- NOTE: please keep the functions in alphabetical order -->
 
+(function-abs)=
 ### abs(x, /)
 
 Calculates the absolute value for each element `x_i` of the input array `x` (i.e., the element-wise result has the same magnitude as the respective element in `x` but has positive sign).
@@ -40,6 +41,7 @@ Calculates the absolute value for each element `x_i` of the input array `x` (i.e
 
     -   an array containing the absolute value of each element in `x`. The returned array must have the same data type as `x`.
 
+(function-acos)=
 ### acos(x, /)
 
 Calculates an implementation-dependent approximation of the principal value of the inverse cosine, having domain `[-1, +1]` and codomain `[+0, +π]`, for each element `x_i` of the input array `x`. Each element-wise result is expressed in radians.
@@ -63,6 +65,7 @@ Calculates an implementation-dependent approximation of the principal value of t
 
     -   an array containing the inverse cosine of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-acosh)=
 ### acosh(x, /)
 
 Calculates an implementation-dependent approximation to the inverse hyperbolic cosine, having domain `[+1, +infinity]` and codomain `[+0, +infinity]`, for each element `x_i` of the input array `x`.
@@ -86,6 +89,7 @@ Calculates an implementation-dependent approximation to the inverse hyperbolic c
 
     -   an array containing the inverse hyperbolic cosine of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-add)=
 ### add(x1, x2, /)
 
 Calculates the sum for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`. For floating-point arithmetic,
@@ -131,6 +135,7 @@ Floating-point addition is a commutative operation, but not always associative.
 
     -   an array containing the element-wise sums. The returned array must have a data type determined by {ref}`type-promotion`.
 
+(function-asin)=
 ### asin(x, /)
 
 Calculates an implementation-dependent approximation of the principal value of the inverse sine, having domain `[-1, +1]` and codomain `[-π/2, +π/2]` for each element `x_i` of the input array `x`. Each element-wise result is expressed in radians.
@@ -155,6 +160,7 @@ Calculates an implementation-dependent approximation of the principal value of t
 
     -   an array containing the inverse sine of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-asinh)=
 ### asinh(x, /)
 
 Calculates an implementation-dependent approximation to the inverse hyperbolic sine, having domain `[-infinity, +infinity]` and codomain `[-infinity, +infinity]`, for each element `x_i` in the input array `x`.
@@ -179,6 +185,7 @@ Calculates an implementation-dependent approximation to the inverse hyperbolic s
 
     -   an array containing the inverse hyperbolic sine of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-atan)=
 ### atan(x, /)
 
 Calculates an implementation-dependent approximation of the principal value of the inverse tangent, having domain `[-infinity, +infinity]` and codomain `[-π/2, +π/2]`, for each element `x_i` of the input array `x`. Each element-wise result is expressed in radians.
@@ -203,6 +210,7 @@ Calculates an implementation-dependent approximation of the principal value of t
 
     -   an array containing the inverse tangent of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-atan2)=
 ### atan2(x1, x2, /)
 
 Calculates an implementation-dependent approximation of the inverse tangent of the quotient `x1/x2`, having domain `[-infinity, +infinity] x [-infinity, +infinity]` (where the `x` notation denotes the set of ordered pairs of elements `(x1_i, x2_i)`) and codomain `[-π, +π]`, for each pair of elements `(x1_i, x2_i)` of the input arrays `x1` and `x2`, respectively. Each element-wise result is expressed in radians.
@@ -258,6 +266,7 @@ By IEEE 754 convention, the inverse tangent of the quotient `x1/x2` is defined f
 
     -   an array containing the inverse tangent of the quotient `x1/x2`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-atanh)=
 ### atanh(x, /)
 
 Calculates an implementation-dependent approximation to the inverse hyperbolic tangent, having domain `[-1, +1]` and codomain `[-infinity, +infinity]`, for each element `x_i` of the input array `x`.
@@ -284,6 +293,7 @@ Calculates an implementation-dependent approximation to the inverse hyperbolic t
 
     -   an array containing the inverse hyperbolic tangent of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-bitwise_and)=
 ### bitwise_and(x1, x2, /)
 
 Computes the bitwise AND of the underlying binary representation of each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
@@ -304,6 +314,7 @@ Computes the bitwise AND of the underlying binary representation of each element
 
     -   an array containing the element-wise results. The returned array must have a data type determined by {ref}`type-promotion`.
 
+(function-bitwise_left_shift)=
 ### bitwise_left_shift(x1, x2, /)
 
 Shifts the bits of each element `x1_i` of the input array `x1` to the left by appending `x2_i` (i.e., the respective element in the input array `x2`) zeros to the right of `x1_i`.
@@ -324,6 +335,7 @@ Shifts the bits of each element `x1_i` of the input array `x1` to the left by ap
 
     -   an array containing the element-wise results. The returned array must have the same data type as `x1`.
 
+(function-bitwise_invert)=
 ### bitwise_invert(x, /)
 
 Inverts (flips) each bit for each element `x_i` of the input array `x`.
@@ -340,6 +352,7 @@ Inverts (flips) each bit for each element `x_i` of the input array `x`.
 
     -   an array containing the element-wise results. The returned array must have the same data type as `x`.
 
+(function-bitwise_or)=
 ### bitwise_or(x1, x2, /)
 
 Computes the bitwise OR of the underlying binary representation of each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
@@ -360,6 +373,7 @@ Computes the bitwise OR of the underlying binary representation of each element 
 
     -   an array containing the element-wise results. The returned array must have a data type determined by {ref}`type-promotion`.
 
+(function-bitwise_right_shift)=
 ### bitwise_right_shift(x1, x2, /)
 
 Shifts the bits of each element `x1_i` of the input array `x1` to the right according to the respective element `x2_i` of the input array `x2`.
@@ -380,6 +394,7 @@ Shifts the bits of each element `x1_i` of the input array `x1` to the right acco
 
     -   an array containing the element-wise results. The returned array must have the same data type as `x1`.
 
+(function-bitwise_xor)=
 ### bitwise_xor(x1, x2, /)
 
 Computes the bitwise XOR of the underlying binary representation of each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
@@ -400,6 +415,7 @@ Computes the bitwise XOR of the underlying binary representation of each element
 
     -   an array containing the element-wise results. The returned array must have a data type determined by {ref}`type-promotion`.
 
+(function-ceil)=
 ### ceil(x, /)
 
 Rounds each element `x_i` of the input array `x` to the smallest (i.e., closest to `-infinity`) integer-valued number that is not less than `x_i`.
@@ -420,6 +436,7 @@ Rounds each element `x_i` of the input array `x` to the smallest (i.e., closest 
 
     -   an array containing the rounded result for each element in `x`. The returned array must have the same data type as `x`.
 
+(function-cos)=
 ### cos(x, /)
 
 Calculates an implementation-dependent approximation to the cosine, having domain `(-infinity, +infinity)` and codomain `[-1, +1]`, for each element `x_i` of the input array `x`. Each element `x_i` is assumed to be expressed in radians.
@@ -444,6 +461,7 @@ Calculates an implementation-dependent approximation to the cosine, having domai
 
     -   an array containing the cosine of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-cosh)=
 ### cosh(x, /)
 
 Calculates an implementation-dependent approximation to the hyperbolic cosine, having domain `[-infinity, +infinity]` and codomain `[-infinity, +infinity]`, for each element `x_i` in the input array `x`.
@@ -466,6 +484,7 @@ Calculates an implementation-dependent approximation to the hyperbolic cosine, h
 
     -   an array containing the hyperbolic cosine of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-divide)=
 ### divide(x1, x2, /)
 
 Calculates the division for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`. For floating-point arithmetic,
@@ -511,6 +530,7 @@ Calculates the division for each element `x1_i` of the input array `x1` with the
 
     -   an array containing the element-wise results. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-equal)=
 ### equal(x1, x2, /)
 
 Computes the truth value of `x1_i == x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
@@ -531,6 +551,7 @@ Computes the truth value of `x1_i == x2_i` for each element `x1_i` of the input 
 
     -   an array containing the element-wise results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-exp)=
 ### exp(x, /)
 
 Calculates an implementation-dependent approximation to the exponential function, having domain `[-infinity, +infinity]` and codomain `[+0, +infinity]`, for each element `x_i` of the input array `x` (`e` raised to the power of `x_i`, where `e` is the base of the natural logarithm).
@@ -555,6 +576,7 @@ Calculates an implementation-dependent approximation to the exponential function
 
     -   an array containing the evaluated exponential function result for each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-expm1)=
 ### expm1(x, /)
 
 Calculates an implementation-dependent approximation to `exp(x)-1`, having domain `[-infinity, +infinity]` and codomain `[-1, +infinity]`, for each element `x_i` of the input array `x`.
@@ -584,6 +606,7 @@ The purpose of this function is to calculate `exp(x)-1.0` more accurately when `
 
     -   an array containing the evaluated result for each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-floor)=
 ### floor(x, /)
 
 Rounds each element `x_i` of the input array `x` to the greatest (i.e., closest to `+infinity`) integer-valued number that is not greater than `x_i`.
@@ -604,6 +627,7 @@ Rounds each element `x_i` of the input array `x` to the greatest (i.e., closest 
 
     -   an array containing the rounded result for each element in `x`. The returned array must have the same data type as `x`.
 
+(function-floor_divide)=
 ### floor_divide(x1, x2, /)
 
 Rounds the result of dividing each element `x1_i` of the input array `x1` by the respective element `x2_i` of the input array `x2` to the greatest (i.e., closest to `+infinity`) integer-value number that is not greater than the division result.
@@ -624,6 +648,7 @@ Rounds the result of dividing each element `x1_i` of the input array `x1` by the
 
     -   an array containing the element-wise results. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-greater)=
 ### greater(x1, x2, /)
 
 Computes the truth value of `x1_i > x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
@@ -644,6 +669,7 @@ Computes the truth value of `x1_i > x2_i` for each element `x1_i` of the input a
 
     -   an array containing the element-wise results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-greater_equal)=
 ### greater_equal(x1, x2, /)
 
 Computes the truth value of `x1_i >= x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
@@ -664,6 +690,7 @@ Computes the truth value of `x1_i >= x2_i` for each element `x1_i` of the input 
 
     -   an array containing the element-wise results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-isfinite)=
 ### isfinite(x, /)
 
 Tests each element `x_i` of the input array `x` to determine if finite (i.e., not `NaN` and not equal to positive or negative infinity).
@@ -680,6 +707,7 @@ Tests each element `x_i` of the input array `x` to determine if finite (i.e., no
 
     -   an array containing test results. An element `out_i` is `True` if `x_i` is finite and `False` otherwise. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-isinf)=
 ### isinf(x, /)
 
 Tests each element `x_i` of the input array `x` to determine if equal to positive or negative infinity.
@@ -696,6 +724,7 @@ Tests each element `x_i` of the input array `x` to determine if equal to positiv
 
     -   an array containing test results. An element `out_i` is `True` if `x_i` is either positive or negative infinity and `False` otherwise. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-isnan)=
 ### isnan(x, /)
 
 Tests each element `x_i` of the input array `x` to determine whether the element is `NaN`.
@@ -712,6 +741,7 @@ Tests each element `x_i` of the input array `x` to determine whether the element
 
     -   an array containing test results. An element `out_i` is `True` if `x_i` is `NaN` and `False` otherwise. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-less)=
 ### less(x1, x2, /)
 
 Computes the truth value of `x1_i < x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
@@ -732,6 +762,7 @@ Computes the truth value of `x1_i < x2_i` for each element `x1_i` of the input a
 
     -   an array containing the element-wise results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-less_equal)=
 ### less_equal(x1, x2, /)
 
 Computes the truth value of `x1_i <= x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
@@ -752,6 +783,7 @@ Computes the truth value of `x1_i <= x2_i` for each element `x1_i` of the input 
 
     -   an array containing the element-wise results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-log)=
 ### log(x, /)
 
 Calculates an implementation-dependent approximation to the natural (base `e`) logarithm, having domain `[0, +infinity]` and codomain `[-infinity, +infinity]`, for each element `x_i` of the input array `x`.
@@ -776,6 +808,7 @@ Calculates an implementation-dependent approximation to the natural (base `e`) l
 
     -   an array containing the evaluated natural logarithm for each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-log1p)=
 ### log1p(x, /)
 
 Calculates an implementation-dependent approximation to `log(1+x)`, where `log` refers to the natural (base `e`) logarithm, having domain `[-1, +infinity]` and codomain `[-infinity, +infinity]`, for each element `x_i` of the input array `x`.
@@ -806,6 +839,7 @@ The purpose of this function is to calculate `log(1+x)` more accurately when `x`
 
     -   an array containing the evaluated result for each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-log2)=
 ### log2(x, /)
 
 Calculates an implementation-dependent approximation to the base `2` logarithm, having domain `[0, +infinity]` and codomain `[-infinity, +infinity]`, for each element `x_i` of the input array `x`.
@@ -830,6 +864,7 @@ Calculates an implementation-dependent approximation to the base `2` logarithm, 
 
     -   an array containing the evaluated base `2` logarithm for each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-log10)=
 ### log10(x, /)
 
 Calculates an implementation-dependent approximation to the base `10` logarithm, having domain `[0, +infinity]` and codomain `[-infinity, +infinity]`, for each element `x_i` of the input array `x`.
@@ -854,6 +889,7 @@ Calculates an implementation-dependent approximation to the base `10` logarithm,
 
     -   an array containing the evaluated base `10` logarithm for each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-logical_and)=
 ### logical_and(x1, x2, /)
 
 Computes the logical AND for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`. Zeros should be considered the equivalent of `False`, while non-zeros should be considered the equivalent of `True`.
@@ -874,6 +910,7 @@ Computes the logical AND for each element `x1_i` of the input array `x1` with th
 
     -   an array containing the element-wise results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-logical_not)=
 ### logical_not(x, /)
 
 Computes the logical NOT for each element `x_i` of the input array `x`. Zeros should be considered the equivalent of `False`, while non-zeros should be considered the equivalent of `True`.
@@ -890,6 +927,7 @@ Computes the logical NOT for each element `x_i` of the input array `x`. Zeros sh
 
     -   an array containing the element-wise results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-logical_or)=
 ### logical_or(x1, x2, /)
 
 Computes the logical OR for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`. Zeros should be considered the equivalent of `False`, while non-zeros should be considered the equivalent of `True`.
@@ -910,6 +948,7 @@ Computes the logical OR for each element `x1_i` of the input array `x1` with the
 
     -   an array containing the element-wise results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-logical_xor)=
 ### logical_xor(x1, x2, /)
 
 Computes the logical XOR for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`. Zeros should be considered the equivalent of `False`, while non-zeros should be considered the equivalent of `True`.
@@ -930,6 +969,7 @@ Computes the logical XOR for each element `x1_i` of the input array `x1` with th
 
     -   an array containing the element-wise results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-multiply)=
 ### multiply(x1, x2, /)
 
 Calculates the product for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`. For floating-point arithmetic,
@@ -967,6 +1007,7 @@ Floating-point multiplication is not always associative due to finite precision.
 
     -   an array containing the element-wise products. The returned array must have a data type determined by {ref}`type-promotion`.
 
+(function-negative)=
 ### negative(x, /)
 
 Computes the numerical negative of each element `x_i` (i.e., `y_i = -x_i`) of the input array `x`.
@@ -983,6 +1024,7 @@ Computes the numerical negative of each element `x_i` (i.e., `y_i = -x_i`) of th
 
     -   an array containing the evaluated result for each element in `x`. The returned array must have a data type determined by {ref}`type-promotion`.
 
+(function-not_equal)=
 ### not_equal(x1, x2, /)
 
 Computes the truth value of `x1_i != x2_i` for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
@@ -1003,6 +1045,7 @@ Computes the truth value of `x1_i != x2_i` for each element `x1_i` of the input 
 
     -   an array containing the element-wise results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-positive)=
 ### positive(x, /)
 
 Computes the numerical positive of each element `x_i` (i.e., `y_i = +x_i`) of the input array `x`.
@@ -1019,6 +1062,7 @@ Computes the numerical positive of each element `x_i` (i.e., `y_i = +x_i`) of th
 
     -   an array containing the evaluated result for each element in `x`. The returned array must have the same data type as `x`.
 
+(function-pow)=
 ### pow(x1, x2, /)
 
 Calculates an implementation-dependent approximation of exponentiation by raising each element `x1_i` (the base) of the input array `x1` to the power of `x2_i` (the exponent), where `x2_i` is the corresponding element of the input array `x2`.
@@ -1066,6 +1110,7 @@ Calculates an implementation-dependent approximation of exponentiation by raisin
 
     -   an array containing the element-wise results. The returned array must have a data type determined by {ref}`type-promotion`.
 
+(function-remainder)=
 ### remainder(x1, x2, /)
 
 Returns the remainder of division for each element `x1_i` of the input array `x1` and the respective element `x2_i` of the input array `x2`.
@@ -1086,6 +1131,7 @@ Returns the remainder of division for each element `x1_i` of the input array `x1
 
     -   an array containing the element-wise results. Each element-wise result must have the same sign as the respective element `x2_i`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-round)=
 ### round(x, /)
 
 Rounds each element `x_i` of the input array `x` to the nearest integer-valued number.
@@ -1107,6 +1153,7 @@ Rounds each element `x_i` of the input array `x` to the nearest integer-valued n
 
     -   an array containing the rounded result for each element in `x`. The returned array must have the same data type as `x`.
 
+(function-sign)=
 ### sign(x, /)
 
 Returns an indication of the sign of a number for each element `x_i` of the input array `x`.
@@ -1129,6 +1176,7 @@ Returns an indication of the sign of a number for each element `x_i` of the inpu
 
     -   an array containing the evaluated result for each element in `x`. The returned array must have the same data type as `x`.
 
+(function-sin)=
 ### sin(x, /)
 
 Calculates an implementation-dependent approximation to the sine, having domain `(-infinity, +infinity)` and codomain `[-1, +1]`, for each element `x_i` of the input array `x`. Each element `x_i` is assumed to be expressed in radians.
@@ -1152,6 +1200,7 @@ Calculates an implementation-dependent approximation to the sine, having domain 
 
     -   an array containing the sine of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-sinh)=
 ### sinh(x, /)
 
 Calculates an implementation-dependent approximation to the hyperbolic sine, having domain `[-infinity, +infinity]` and codomain `[-infinity, +infinity]`, for each element `x_i` of the input array `x`.
@@ -1176,6 +1225,7 @@ Calculates an implementation-dependent approximation to the hyperbolic sine, hav
 
     -   an array containing the hyperbolic sine of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-square)=
 ### square(x, /)
 
 Squares (`x_i * x_i`) each element `x_i` of the input array `x`.
@@ -1192,6 +1242,7 @@ Squares (`x_i * x_i`) each element `x_i` of the input array `x`.
 
     -   an array containing the evaluated result for each element in `x`. The returned array must have a data type determined by {ref}`type-promotion`.
 
+(function-sqrt)=
 ### sqrt(x, /)
 
 Calculates the square root, having domain `[0, +infinity]` and codomain `[0, +infinity]`, for each element `x_i` of the input array `x`. After rounding, each result should be indistinguishable from the infinitely precise result (as required by IEEE 754).
@@ -1216,6 +1267,7 @@ Calculates the square root, having domain `[0, +infinity]` and codomain `[0, +in
 
     -   an array containing the square root of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-subtract)=
 ### subtract(x1, x2, /)
 
 Calculates the difference for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`. The result of `x1_i - x2_i` must be the same as `x1_i + (-x2_i)` and is thus governed by the same floating-point rules as addition (see [`add()`](#addx1-x2-)).
@@ -1236,6 +1288,7 @@ Calculates the difference for each element `x1_i` of the input array `x1` with t
 
     -   an array containing the element-wise differences. The returned array must have a data type determined by {ref}`type-promotion`.
 
+(function-tan)=
 ### tan(x, /)
 
 Calculates an implementation-dependent approximation to the tangent, having domain `(-infinity, +infinity)` and codomain `(-infinity, +infinity)`, for each element `x_i` of the input array `x`. Each element `x_i` is assumed to be expressed in radians.
@@ -1259,6 +1312,7 @@ Calculates an implementation-dependent approximation to the tangent, having doma
 
     -   an array containing the tangent of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-tanh)=
 ### tanh(x, /)
 
 Calculates an implementation-dependent approximation to the hyperbolic tangent, having domain `[-infinity, +infinity]` and codomain `[-1, +1]`, for each element `x_i` of the input array `x`.
@@ -1283,6 +1337,7 @@ Calculates an implementation-dependent approximation to the hyperbolic tangent, 
 
     -   an array containing the hyperbolic tangent of each element in `x`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
 
+(function-trunc)=
 ### trunc(x, /)
 
 Rounds each element `x_i` of the input array `x` to the integer-valued number that is closest to but no greater than `x_i`.

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -15,10 +15,12 @@ A conforming implementation of the array API standard must provide and support t
 
 <!-- NOTE: please keep the functions in alphabetical order -->
 
+(function-cholesky)=
 ### cholesky()
 
 TODO
 
+(function-cross)=
 ### cross(x1, x2, /, *, axis=-1)
 
 Returns the cross product of 3-element vectors. If `x1` and `x2` are multi-dimensional arrays (i.e., both have a rank greater than `1`), then the cross-product of each pair of corresponding 3-element vectors is independently computed.
@@ -43,6 +45,7 @@ Returns the cross product of 3-element vectors. If `x1` and `x2` are multi-dimen
 
     -   an array containing the cross products. The returned array must have a data type determined by {ref}`type-promotion` rules.
 
+(function-det)=
 ### det(x, /)
 
 Returns the determinant of a square matrix (or stack of square matrices) `x`.
@@ -59,6 +62,7 @@ Returns the determinant of a square matrix (or stack of square matrices) `x`.
 
     -   if `x` is a two-dimensional array, a zero-dimensional array containing the determinant; otherwise, a non-zero dimensional array containing the determinant for each square matrix. The returned array must have a data type determined by {ref}`type-promotion` rules.
 
+(function-diagonal)=
 ### diagonal(x, /, *, axis1=0, axis2=1, offset=0)
 
 Returns the specified diagonals. If `x` has more than two dimensions, then the axes (dimensions) specified by `axis1` and `axis2` are used to determine the two-dimensional sub-arrays from which to return diagonals.
@@ -93,22 +97,27 @@ Returns the specified diagonals. If `x` has more than two dimensions, then the a
 
     -   if `x` is a two-dimensional array, a one-dimensional array containing the diagonal; otherwise, a multi-dimensional array containing the diagonals and whose shape is determined by removing `axis1` and `axis2` and appending a dimension equal to the size of the resulting diagonals. The returned array must have the same data type as `x`.
 
+(function-dot)=
 ### dot()
 
 TODO
 
+(function-eig)=
 ### eig()
 
 TODO
 
+(function-eigvalsh)=
 ### eigvalsh()
 
 TODO
 
+(function-einsum)=
 ### einsum()
 
 TODO
 
+(function-inv)=
 ### inv(x, /)
 
 Computes the multiplicative inverse of a square matrix (or stack of square matrices) `x`.
@@ -125,22 +134,27 @@ Computes the multiplicative inverse of a square matrix (or stack of square matri
 
     -   an array containing the multiplicative inverses. The returned array must have the same data type and shape as `x`.
 
+(function-lstsq)=
 ### lstsq()
 
 TODO
 
+(function-matmul)=
 ### matmul()
 
 TODO
 
+(function-matrix_power)=
 ### matrix_power()
 
 TODO
 
+(function-matrix_rank)=
 ### matrix_rank()
 
 TODO
 
+(function-norm)=
 ### norm(x, /, *, axis=None, keepdims=False, ord=None)
 
 Computes the matrix or vector norm of `x`.
@@ -219,6 +233,7 @@ Computes the matrix or vector norm of `x`.
 
     -   an array containing the norms. If `axis` is `None`, the output array is a zero-dimensional array containing a vector norm. If `axis` is a scalar value (`int` or `float`), the output array has a rank which is one less than the rank of `x`. If `axis` is a 2-tuple, the output array has a rank which is two less than the rank of `x`. The returned array must have the same data type as `x`.
 
+(function-outer)=
 ### outer(x1, x2, /)
 
 Computes the outer product of two vectors `x1` and `x2`.
@@ -239,26 +254,32 @@ Computes the outer product of two vectors `x1` and `x2`.
 
     -   a two-dimensional array containing the outer product and whose shape is `NxM`. The returned array must have a data type determined by {ref}`type-promotion` rules.
 
+(function-pinv)=
 ### pinv()
 
 TODO
 
+(function-qr)=
 ### qr()
 
 TODO
 
+(function-slogdet)=
 ### slogdet()
 
 TODO
 
+(function-solve)=
 ### solve()
 
 TODO
 
+(function-svd)=
 ### svd()
 
 TODO
 
+(function-trace)=
 ### trace(x, /, *, axis1=0, axis2=1, offset=0)
 
 Returns the sum along the specified diagonals. If `x` has more than two dimensions, then the axes (dimensions) specified by `axis1` and `axis2` are used to determine the two-dimensional sub-arrays for which to compute the trace.
@@ -301,6 +322,7 @@ Returns the sum along the specified diagonals. If `x` has more than two dimensio
 
         The returned array must have the same data type as `x`.
 
+(function-transpose)=
 ### transpose(x, /, *, axes=None)
 
 Transposes (or permutes the axes (dimensions)) of an array `x`.

--- a/spec/API_specification/manipulation_functions.md
+++ b/spec/API_specification/manipulation_functions.md
@@ -12,6 +12,7 @@ A conforming implementation of the array API standard must provide and support t
 
 <!-- NOTE: please keep the functions in alphabetical order -->
 
+(function-concat)=
 ### concat(arrays, /, *, axis=0)
 
 Joins a sequence of arrays along an existing axis.
@@ -37,6 +38,7 @@ Joins a sequence of arrays along an existing axis.
         This specification leaves type promotion between data type families (i.e., `intxx` and `floatxx`) unspecified.
         ```
 
+(function-expand_dims)=
 ### expand_dims(x, axis, /)
 
 Expands the shape of an array by inserting a new axis (dimension) of size one at the position specified by `axis`.
@@ -57,6 +59,7 @@ Expands the shape of an array by inserting a new axis (dimension) of size one at
 
     -   an expanded output array having the same data type and shape as `x`.
 
+(function-flip)=
 ### flip(x, /, *, axis=None)
 
 Reverses the order of elements in an array along the given axis. The shape of the array must be preserved.
@@ -77,6 +80,7 @@ Reverses the order of elements in an array along the given axis. The shape of th
 
     -   an output array having the same data type and shape as `x` and whose elements, relative to `x`, are reordered.
 
+(function-reshape)=
 ### reshape(x, shape, /)
 
 Reshapes an array without changing its data.
@@ -97,6 +101,7 @@ Reshapes an array without changing its data.
 
     -   an output array having the same data type, elements, and underlying element order as `x`.
 
+(function-roll)=
 ### roll(x, shift, /, *, axis=None)
 
 Rolls array elements along a specified axis. Array elements that roll beyond the last position are re-introduced at the first position. Array elements that roll beyond the first position are re-introduced at the last position.
@@ -121,6 +126,7 @@ Rolls array elements along a specified axis. Array elements that roll beyond the
 
     -   an output array having the same data type as `x` and whose elements, relative to `x`, are shifted.
 
+(function-squeeze)=
 ### squeeze(x, /, *, axis=None)
 
 Removes singleton dimensions (axes) from `x`.
@@ -141,6 +147,7 @@ Removes singleton dimensions (axes) from `x`.
 
     -   an output array having the same data type and elements as `x`.
 
+(function-stack)=
 ### stack(arrays, /, *, axis=0)
 
 Joins a sequence of arrays along a new axis.

--- a/spec/API_specification/searching_functions.md
+++ b/spec/API_specification/searching_functions.md
@@ -16,6 +16,7 @@ A conforming implementation of the array API standard must provide and support t
 
 <!-- NOTE: please keep the functions in alphabetical order -->
 
+(function-argmax)=
 ### argmax(x, /, *, axis=None, keepdims=False)
 
 Returns the indices of the maximum values along a specified axis. When the maximum value occurs multiple times, only the indices corresponding to the first occurrence are returned.
@@ -40,6 +41,7 @@ Returns the indices of the maximum values along a specified axis. When the maxim
 
     -   if `axis` is `None`, a zero-dimensional array containing the index of the first occurrence of the maximum value; otherwise, a non-zero-dimensional array containing the indices of the maximum values. The returned array must have be the default array index data type.
 
+(function-argmin)=
 ### argmin(x, /, *, axis=None, keepdims=False)
 
 Returns the indices of the minimum values along a specified axis. When the minimum value occurs multiple times, only the indices corresponding to the first occurrence are returned.
@@ -64,6 +66,7 @@ Returns the indices of the minimum values along a specified axis. When the minim
 
     -   if `axis` is `None`, a zero-dimensional array containing the index of the first occurrence of the minimum value; otherwise, a non-zero-dimensional array containing the indices of the minimum values. The returned array must have the default array index data type.
 
+(function-nonzero)=
 ### nonzero(x, /)
 
 Returns the indices of the array elements which are non-zero.
@@ -80,6 +83,7 @@ Returns the indices of the array elements which are non-zero.
 
     -   a tuple of `k` arrays, one for each dimension of `x` and each of size `n` (where `n` is the total number of non-zero elements), containing the indices of the non-zero elements in that dimension. The indices must be returned in row-major, C-style order. The returned array must have the default array index data type.
 
+(function-where)=
 ### where(condition, x1, x2, /)
 
 Returns elements chosen from `x1` or `x2` depending on `condition`.

--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -12,6 +12,7 @@ A conforming implementation of the array API standard must provide and support t
 
 <!-- NOTE: please keep the functions in alphabetical order -->
 
+(function-unique)=
 ### unique(x, /, *, return_counts=False, return_index=False, return_inverse=False, sorted=True)
 
 Returns the unique elements of an input array `x`.

--- a/spec/API_specification/sorting_functions.md
+++ b/spec/API_specification/sorting_functions.md
@@ -12,6 +12,7 @@ A conforming implementation of the array API standard must provide and support t
 
 <!-- NOTE: please keep the functions in alphabetical order -->
 
+(function-argsort)=
 ### argsort(x, /, *, axis=-1, descending=False, stable=True)
 
 Returns the indices that sort an array `x` along a specified axis.
@@ -40,6 +41,7 @@ Returns the indices that sort an array `x` along a specified axis.
 
     -   an array of indices. The returned array must have the same shape as `x`. The returned array must have the default array index data type.
 
+(function-sort)=
 ### sort(x, /, *, axis=-1, descending=False, stable=True)
 
 Returns a sorted copy of an input array `x`.

--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -15,6 +15,7 @@ A conforming implementation of the array API standard must provide and support t
 
 <!-- NOTE: please keep the functions in alphabetical order -->
 
+(function-max)=
 ### max(x, /, *, axis=None, keepdims=False)
 
 Calculates the maximum value of the input array `x`.
@@ -39,6 +40,7 @@ Calculates the maximum value of the input array `x`.
 
     -   if the maximum value was computed over the entire array, a zero-dimensional array containing the maximum value; otherwise, a non-zero-dimensional array containing the maximum values. The returned array must have the same data type as `x`.
 
+(function-mean)=
 ### mean(x, /, *, axis=None, keepdims=False)
 
 Calculates the arithmetic mean of the input array `x`.
@@ -63,6 +65,7 @@ Calculates the arithmetic mean of the input array `x`.
 
     -   if the arithmetic mean was computed over the entire array, a zero-dimensional array containing the arithmetic mean; otherwise, a non-zero-dimensional array containing the arithmetic means. The returned array must have be the default floating-point data type.
 
+(function-min)=
 ### min(x, /, *, axis=None, keepdims=False)
 
 Calculates the minimum value of the input array `x`.
@@ -87,6 +90,7 @@ Calculates the minimum value of the input array `x`.
 
     -   if the minimum value was computed over the entire array, a zero-dimensional array containing the minimum value; otherwise, a non-zero-dimensional array containing the minimum values. The returned array must have the same data type as `x`.
 
+(function-prod)=
 ### prod(x, /, *, axis=None, keepdims=False)
 
 Calculates the product of input array `x` elements.
@@ -111,6 +115,7 @@ Calculates the product of input array `x` elements.
 
     -   if the product was computed over the entire array, a zero-dimensional array containing the product; otherwise, a non-zero-dimensional array containing the products. The returned array must have the same data type as `x`.
 
+(function-std)=
 ### std(x, /, *, axis=None, correction=0.0, keepdims=False)
 
 Calculates the standard deviation of the input array `x`.
@@ -139,6 +144,7 @@ Calculates the standard deviation of the input array `x`.
 
     -   if the standard deviation was computed over the entire array, a zero-dimensional array containing the standard deviation; otherwise, a non-zero-dimensional array containing the standard deviations. The returned array must have the default floating-point data type.
 
+(function-sum)=
 ### sum(x, /, *, axis=None, keepdims=False)
 
 Calculates the sum of the input array `x`.
@@ -163,6 +169,7 @@ Calculates the sum of the input array `x`.
 
     -   if the sum was computed over the entire array, a zero-dimensional array containing the sum; otherwise, an array containing the sums. The returned array must have the same data type as `x`.
 
+(function-var)=
 ### var(x, /, *, axis=None, correction=0.0, keepdims=False)
 
 Calculates the variance of the input array `x`.

--- a/spec/API_specification/utility_functions.md
+++ b/spec/API_specification/utility_functions.md
@@ -15,6 +15,7 @@ A conforming implementation of the array API standard must provide and support t
 
 <!-- NOTE: please keep the functions in alphabetical order -->
 
+(function-all)=
 ### all(x, /, *, axis=None, keepdims=False)
 
 Tests whether all input array elements evaluate to `True` along a specified axis.
@@ -39,6 +40,7 @@ Tests whether all input array elements evaluate to `True` along a specified axis
 
     -   if a logical AND reduction was performed over the entire array, a zero-dimensional array containing the test result; otherwise, a non-zero-dimensional array containing the test results. The returned array must have a data type of `bool` (i.e., must be a boolean array).
 
+(function-any)=
 ### any(x, /, *, axis=None, keepdims=False)
 
 Tests whether any input array element evaluates to `True` along a specified axis.


### PR DESCRIPTION
This will make them easier to parse for the test suite. See https://github.com/data-apis/array-api/pull/72/files#r520185462.

Also, it turns out I was wrong. Sphinx make the anchor name based on the header text, not the cross-reference name. So the anchor URLs are still the same after this change. Actually it would be better if they were based on the cross-reference name, but I don't know how to do that.