### PR TITLE
Reorder design topics sections for relevance

### DIFF
--- a/spec/design_topics/index.rst
+++ b/spec/design_topics/index.rst
@@ -6,9 +6,9 @@ Design topics & constraints
    :maxdepth: 1
 
    copies_views_and_mutation
-   parallelism
-   static_typing
    data_interchange
-   accuracy
    device_support
+   static_typing
+   accuracy
    C_API
+   parallelism


### PR DESCRIPTION
- The most fundamental topics first
- Topics that are more context and don't impact the design towards
  the end