### PR TITLE
Use maxdepth=3 in the API index

### DIFF
--- a/spec/API_specification/index.rst
+++ b/spec/API_specification/index.rst
@@ -5,7 +5,7 @@ API specification
 
 .. toctree::
    :caption: API specification
-   :maxdepth: 1
+   :maxdepth: 3
 
    function_and_method_signatures
    array_object


### PR DESCRIPTION
This makes the API index page list every function in the spec. On the NumPy list, @mattip requested a page that lists every API function. This is an easy way to achieve this.