### PR TITLE
Remove statement that bool dtype must be stored as a byte

### DIFF
--- a/spec/API_specification/data_types.md
+++ b/spec/API_specification/data_types.md
@@ -36,7 +36,7 @@ The default array index data type should be clearly defined in a conforming libr
 
 ## bool
 
-Boolean (`True` or `False`) stored as a byte.
+Boolean (`True` or `False`).
 
 ## int8
 


### PR DESCRIPTION
Closes gh-86