### PR TITLE
Add a `result_type` function to the API specification

### DIFF
--- a/spec/API_specification/utility_functions.md
+++ b/spec/API_specification/utility_functions.md
@@ -64,3 +64,27 @@ Tests whether any input array element evaluates to `True` along a specified axis
 -   **out**: _&lt;array&gt;_
 
     -   if a logical OR reduction was performed over the entire array, the returned array must be a zero-dimensional array containing the test result; otherwise, the returned array must be a non-zero-dimensional array containing the test results. The returned array must have a data type of `bool`.
+
+
+(function-result_type)=
+### result_type(*arrays_and_dtypes)
+
+Returns the dtype that results from applying the type promotion rules
+(see {ref}`type-promotion`) to the arguments.
+
+```{note}
+If mixed dtypes (e.g. integer and floating-point) are used, the output of
+`result_type` will be implementation-specific.
+```
+
+#### Parameters
+
+-   **arrays_and_dtypes**: _List\[Union\[&lt;array&gt, &lt;dtype\]\];_
+
+    -   input arrays and dtypes.
+
+#### Returns
+
+-   **out**: _&lt;dtype&gt;_
+
+    -   the dtype resulting from an operation involving the input arrays and dtypes.

--- a/spec/API_specification/utility_functions.md
+++ b/spec/API_specification/utility_functions.md
@@ -79,7 +79,7 @@ If mixed dtypes (e.g. integer and floating-point) are used, the output of
 
 #### Parameters
 
--   **arrays_and_dtypes**: _List\[Union\[&lt;array&gt;, &lt;dtype&gt;\]\];_
+-   **arrays_and_dtypes**: _Sequence\[Union\[&lt;array&gt;, &lt;dtype&gt;\]\];_
 
     -   input arrays and dtypes.
 

--- a/spec/API_specification/utility_functions.md
+++ b/spec/API_specification/utility_functions.md
@@ -79,7 +79,7 @@ If mixed dtypes (e.g. integer and floating-point) are used, the output of
 
 #### Parameters
 
--   **arrays_and_dtypes**: _List\[Union\[&lt;array&gt, &lt;dtype\]\];_
+-   **arrays_and_dtypes**: _List\[Union\[&lt;array&gt;, &lt;dtype&gt;\]\];_
 
     -   input arrays and dtypes.
 


### PR DESCRIPTION
This PR adds a specification for `result_type`, which is the function needed to be able to do explicit dtype casting for portable results in case of mixed integer - floating point operations. Identified as needed in gh-14, also came up in gh-43 and gh-91.

## Notes

-   Most libraries have a `result_type` function with the signature proposed here; MXNet is the exception.
-   The `array-api-comparison` tooling says TensorFlow doesn't have it, however in TF 2.4.0 the `experimental.numpy` namespace does have it.
