### PR TITLE
Make axis keyword to squeeze() positional

### DIFF
--- a/spec/API_specification/manipulation_functions.md
+++ b/spec/API_specification/manipulation_functions.md
@@ -127,7 +127,7 @@ Rolls array elements along a specified axis. Array elements that roll beyond the
     -   an output array having the same data type as `x` and whose elements, relative to `x`, are shifted.
 
 (function-squeeze)=
-### squeeze(x, /, *, axis=None)
+### squeeze(x, /, axis)
 
 Removes singleton dimensions (axes) from `x`.
 
@@ -137,9 +137,9 @@ Removes singleton dimensions (axes) from `x`.
 
     -   input array.
 
--   **axis**: _Optional\[ Union\[ int, Tuple\[ int, ... ] ] ]_
+-   **axis**: _Union\[ int, Tuple\[ int, ... ] ]_
 
-    -   axis (or axes) to squeeze. If provided, only the specified axes must be squeezed. If `axis` is `None`, all singleton dimensions (axes) must be removed. If a specified axis has a size greater than one, the specified axis must be left unchanged. Default: `None`.
+    -   axis (or axes) to squeeze. If a specified axis has a size greater than one, a `ValueError` must be raised.
 
 #### Returns
 


### PR DESCRIPTION
As suggested by @shoyer in https://github.com/data-apis/array-api/issues/97#issuecomment-747116655. This makes it possible to predict resulting rank of output array, which is otherwise undetermined (see discussion in gh-97).

Using squeeze without specifying the axis in library code often results in unintuitive behaviour. For the common use case of turning a size-1 2-D array into a 0-D, this gets a little more verbose (e.g. `np.squeeze(np.array([[1]]), axis=(0, 1))`), but that's probably a price worth paying for the extra clarity.

Also changes specified behaviour for a given axis not having size 1 to raising a `ValueError`, which is what NumPy does. This wasn't considered before, and the current description seems simply incorrect.

Finally, this makes `squeeze` the exact inverse of `expand_dims`, which is probably a good thing.

The caveats:
- This deviates from what libraries currently do
- Most existing uses of `squeeze` (e.g. in SciPy) do not use the `axis` keyword. The counter-argument for that is that many of those instances are hard to understand and have no comment for why squeeze is used. 