### PR TITLE
Fix a typo in a type annotation

### DIFF
--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -143,7 +143,7 @@ Returns a new array having a specified `shape` and filled with `fill_value`.
 
     -   output array shape.
 
--   **fill_value**: _Union\[ int, float ] ]_
+-   **fill_value**: _Union\[ int, float ]_
 
     -   fill value.
 
@@ -172,7 +172,7 @@ Returns a new array filled with `fill_value` and having the same `shape` as an i
 
     -   input array from which to derive the output array shape.
 
--   **fill_value**: _Union\[ int, float ] ]_
+-   **fill_value**: _Union\[ int, float ]_
 
     -   fill value.
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -222,7 +222,7 @@ Returns evenly spaced numbers over a specified interval.
 
     -   device to place the created array on, if given. Default: `None`.
 
--   **endpoint**: _Optional\[ bool ]_
+-   **endpoint**: _bool_
 
     -   boolean indicating whether to include `stop` in the interval. Default: `True`.
 

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -183,7 +183,7 @@ Computes the matrix or vector norm of `x`.
 
     -   If `True`, the axes (dimensions) specified by `axis` must be included in the result as singleton dimensions, and, accordingly, the result must be compatible with the input array (see {ref}`broadcasting`). Otherwise, if `False`, the axes (dimensions) specified by `axis` must not be included in the result. Default: `False`.
 
--   **ord**: _Optional\[ int, float, Literal\[ inf, -inf, 'fro', 'nuc' ] ]_
+-   **ord**: _Optional\[ Union\[  int, float, Literal\[ inf, -inf, 'fro', 'nuc' ] ] ]_
 
     -   order of the norm. The following mathematical norms must be supported:
 

--- a/spec/API_specification/manipulation_functions.md
+++ b/spec/API_specification/manipulation_functions.md
@@ -158,7 +158,7 @@ Joins a sequence of arrays along a new axis.
 
     -   input arrays to join. Each array must have the same shape.
 
--   **axis**: _Optional\[ int ]_
+-   **axis**: _int_
 
     -   axis along which the arrays will be joined. Providing an `axis` specifies the index of the new axis in the dimensions of the result. For example, if `axis` is `0`, the new axis will be the first dimension and the output array will have shape `(N, A, B, C)`; if `axis` is `1`, the new axis will be the second dimension and the output array will have shape `(A, N, B, C)`; and, if `axis` is `-1`, the new axis will be the last dimension and the output array will have shape `(A, B, C, N)`. A valid `axis` must be on the interval `[-N, N)`, where `N` is the rank (number of dimensions) of `x`. If provided an `axis` outside of the required interval, the function must raise an exception. Default: `0`.
 

--- a/spec/API_specification/searching_functions.md
+++ b/spec/API_specification/searching_functions.md
@@ -90,7 +90,7 @@ Returns elements chosen from `x1` or `x2` depending on `condition`.
 
 #### Parameters
 
--   **condition**: _&lt;array&lt;bool&gt;&gt;_
+-   **condition**: _&lt;array&gt;_
 
     -   when `True`, yield `x1_i`; otherwise, yield `x2_i`. Must be compatible with `x1` and `x2` (see {ref}`broadcasting`).
 


### PR DESCRIPTION
This also removes the dtype from the `where()` type annotation. We should document input and output dtypes (https://github.com/data-apis/array-api/issues/98), but type annotations aren't the right place to do this. 