### PR TITLE
Explicitly specify which categories of dtypes the elementwise functions are defined for

### DIFF
--- a/spec/API_specification/data_types.md
+++ b/spec/API_specification/data_types.md
@@ -82,10 +82,10 @@ A conforming implementation of the array API standard may provide and support ad
 (data-type-categories)=
 ## Data Type Categories
 
-For the purposes of this spec, the following data type categories are defined.
+For the purposes of this specification, the following data type categories are defined.
 Libraries do not need to organize dtypes according to these categories. These
-are only for organizing the functions in this spec itself. Future versions of
-the spec will include additional categories for complex data types.
+are only for organizing the functions in this specification itself. Future versions of
+the specification will include additional categories for complex data types.
 
 ### Numeric Data Types
 

--- a/spec/API_specification/data_types.md
+++ b/spec/API_specification/data_types.md
@@ -78,3 +78,29 @@ Implementations may provide other ways to specify data types (e.g.,
 
 A conforming implementation of the array API standard may provide and support additional data types beyond those described in this specification.
 ```
+
+(data-type-categories)=
+## Data Type Categories
+
+For the purposes of this spec, the following data type categories are defined.
+Libraries do not need to organize dtypes according to these categories. These
+are only for organizing the functions in this spec itself. Future versions of
+the spec will include additional categories for complex data types.
+
+### Numeric Data Types
+
+``int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`,
+`uint64`, `float32`, and `float64` (i.e., all dtypes except for `bool`).
+
+### Integer Data Types
+
+``int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, and
+`uint64`.
+
+### Floating-point Data Types
+
+`float32` and `float64`.
+
+### Boolean Data Types
+
+`bool`.

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -10,6 +10,7 @@ A conforming implementation of the array API standard must provide and support t
 -   Optional parameters must be [keyword-only](https://www.python.org/dev/peps/pep-3102/) arguments.
 -   Broadcasting semantics must follow the semantics defined in {ref}`broadcasting`.
 -   Unless stated otherwise, functions must support the data types defined in {ref}`data-types`.
+-   Functions may only be required for a subset of input data type. Libraries may chose to implement functions for additional data types, but that behavior is not required by the spec. See {ref}`data-type-categories`.
 -   Unless stated otherwise, functions must adhere to the type promotion rules defined in {ref}`type-promotion`.
 -   Unless stated otherwise, floating-point operations must adhere to IEEE 754-2019.
 -   Unless stated otherwise, element-wise mathematical functions must satisfy the minimum accuracy requirements defined in {ref}`accuracy`.
@@ -35,7 +36,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -61,7 +62,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 #### Returns
 
@@ -87,7 +88,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array whose elements each represent the area of a hyperbolic sector.
+    -   input array whose elements each represent the area of a hyperbolic sector. Should have a floating-point data type.
 
 #### Returns
 
@@ -131,11 +132,11 @@ Floating-point addition is a commutative operation, but not always associative.
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -162,7 +163,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 #### Returns
 
@@ -189,7 +190,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array whose elements each represent the area of a hyperbolic sector.
+    -   input array whose elements each represent the area of a hyperbolic sector. Should have a floating-point data type.
 
 #### Returns
 
@@ -216,7 +217,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 #### Returns
 
@@ -270,11 +271,11 @@ For floating-point operands,
 
 -   **x1**: _&lt;array&gt;_
 
-    -   input array corresponding to the y-coordinates.
+    -   input array corresponding to the y-coordinates. Should have a floating-point data type
 
 -   **x2**: _&lt;array&gt;_
 
-    -   input array corresponding to the x-coordinates. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   input array corresponding to the x-coordinates. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a floating-point data type.
 
 #### Returns
 
@@ -303,7 +304,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array whose elements each represent the area of a hyperbolic sector.
+    -   input array whose elements each represent the area of a hyperbolic sector. Should have a floating-point data type.
 
 #### Returns
 
@@ -320,11 +321,11 @@ Computes the bitwise AND of the underlying binary representation of each element
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array. Must have an integer or boolean data type.
+    -   first input array. Should have an integer or boolean data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Must have an integer or boolean data type.
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have an integer or boolean data type.
 
 #### Returns
 
@@ -341,11 +342,11 @@ Shifts the bits of each element `x1_i` of the input array `x1` to the left by ap
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array. Must have an integer data type.
+    -   first input array. Should have an integer data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Must have an integer data type. Each element must be greater than or equal to `0`.
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have an integer data type. Each element must be greater than or equal to `0`.
 
 #### Returns
 
@@ -362,7 +363,7 @@ Inverts (flips) each bit for each element `x_i` of the input array `x`.
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array. Must have an integer or boolean data type.
+    -   input array. Should have an integer or boolean data type.
 
 #### Returns
 
@@ -379,11 +380,11 @@ Computes the bitwise OR of the underlying binary representation of each element 
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array. Must have an integer or boolean data type.
+    -   first input array. Should have an integer or boolean data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Must have an integer or boolean data type.
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have an integer or boolean data type.
 
 #### Returns
 
@@ -400,11 +401,11 @@ Shifts the bits of each element `x1_i` of the input array `x1` to the right acco
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array. Must have an integer data type.
+    -   first input array. Should have an integer data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Must have an integer data type. Each element must be greater than or equal to `0`.
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have an integer data type. Each element must be greater than or equal to `0`.
 
 #### Returns
 
@@ -421,11 +422,11 @@ Computes the bitwise XOR of the underlying binary representation of each element
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array. Must have an integer or boolean data type.
+    -   first input array. Should have an integer or boolean data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Must have an integer or boolean data type.
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have an integer or boolean data type.
 
 #### Returns
 
@@ -446,7 +447,7 @@ Rounds each element `x_i` of the input array `x` to the smallest (i.e., closest 
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -473,7 +474,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array whose elements are each expressed in radians.
+    -   input array whose elements are each expressed in radians. Should have a floating-point data type.
 
 #### Returns
 
@@ -500,7 +501,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array whose elements each represent a hyperbolic angle.
+    -   input array whose elements each represent a hyperbolic angle. Should have a floating-point data type.
 
 #### Returns
 
@@ -544,11 +545,11 @@ For floating-point operands,
 
 -   **x1**: _&lt;array&gt;_
 
-    -   dividend input array.
+    -   dividend input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   divisor input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   divisor input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -565,7 +566,7 @@ Computes the truth value of `x1_i == x2_i` for each element `x1_i` of the input 
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. May have any data type.
 
 -   **x2**: _&lt;array&gt;_
 
@@ -596,7 +597,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 #### Returns
 
@@ -628,7 +629,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -649,7 +650,7 @@ Rounds each element `x_i` of the input array `x` to the greatest (i.e., closest 
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -666,11 +667,11 @@ Rounds the result of dividing each element `x1_i` of the input array `x1` by the
 
 -   **x1**: _&lt;array&gt;_
 
-    -   dividend input array.
+    -   dividend input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   divisor input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   divisor input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -687,11 +688,11 @@ Computes the truth value of `x1_i > x2_i` for each element `x1_i` of the input a
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -708,11 +709,11 @@ Computes the truth value of `x1_i >= x2_i` for each element `x1_i` of the input 
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -729,7 +730,7 @@ Tests each element `x_i` of the input array `x` to determine if finite (i.e., no
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -746,7 +747,7 @@ Tests each element `x_i` of the input array `x` to determine if equal to positiv
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -763,13 +764,13 @@ Tests each element `x_i` of the input array `x` to determine whether the element
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
 -   **out**: _&lt;array&gt;_
 
-    -   an array containing test results. An element `out_i` is `True` if `x_i` is `NaN` and `False` otherwise. The returned array must have a data type of `bool`.
+    -   an array containing test results. An element `out_i` is `True` if `x_i` is `NaN` and `False` otherwise. The returned array Should have a data type of `bool`.
 
 (function-less)=
 ### less(x1, x2, /)
@@ -780,11 +781,11 @@ Computes the truth value of `x1_i < x2_i` for each element `x1_i` of the input a
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -801,11 +802,11 @@ Computes the truth value of `x1_i <= x2_i` for each element `x1_i` of the input 
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -832,7 +833,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 #### Returns
 
@@ -865,7 +866,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 #### Returns
 
@@ -892,7 +893,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 #### Returns
 
@@ -919,7 +920,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 #### Returns
 
@@ -936,11 +937,11 @@ Computes the logical AND for each element `x1_i` of the input array `x1` with th
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. Should have a boolean data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a boolean data type.
 
 #### Returns
 
@@ -957,7 +958,7 @@ Computes the logical NOT for each element `x_i` of the input array `x`. Zeros ar
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a boolean data type.
 
 #### Returns
 
@@ -974,11 +975,11 @@ Computes the logical OR for each element `x1_i` of the input array `x1` with the
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. Should have a boolean data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a boolean data type.
 
 #### Returns
 
@@ -995,11 +996,11 @@ Computes the logical XOR for each element `x1_i` of the input array `x1` with th
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. Should have a boolean data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a boolean data type.
 
 #### Returns
 
@@ -1035,11 +1036,11 @@ Floating-point multiplication is not always associative due to finite precision.
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeri
 
 #### Returns
 
@@ -1056,7 +1057,7 @@ Computes the numerical negative of each element `x_i` (i.e., `y_i = -x_i`) of th
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -1073,7 +1074,7 @@ Computes the truth value of `x1_i != x2_i` for each element `x1_i` of the input 
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. May have any data type.
 
 -   **x2**: _&lt;array&gt;_
 
@@ -1094,7 +1095,7 @@ Computes the numerical positive of each element `x_i` (i.e., `y_i = +x_i`) of th
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -1140,11 +1141,11 @@ For floating-point operands,
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array whose elements correspond to the exponentiation base.
+    -   first input array whose elements correspond to the exponentiation base. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array whose elements correspond to the exponentiation exponent. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array whose elements correspond to the exponentiation exponent. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -1161,11 +1162,11 @@ Returns the remainder of division for each element `x1_i` of the input array `x1
 
 -   **x1**: _&lt;array&gt;_
 
-    -   dividend input array.
+    -   dividend input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   divisor input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   divisor input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -1187,7 +1188,7 @@ Rounds each element `x_i` of the input array `x` to the nearest integer-valued n
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -1210,7 +1211,7 @@ Returns an indication of the sign of a number for each element `x_i` of the inpu
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -1236,7 +1237,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array whose elements are each expressed in radians.
+    -   input array whose elements are each expressed in radians. Should have a floating-point data type.
 
 #### Returns
 
@@ -1263,7 +1264,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array whose elements each represent a hyperbolic angle.
+    -   input array whose elements each represent a hyperbolic angle. Should have a floating-point data type.
 
 #### Returns
 
@@ -1280,7 +1281,7 @@ Squares (`x_i * x_i`) each element `x_i` of the input array `x`.
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 
@@ -1307,7 +1308,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 #### Returns
 
@@ -1324,11 +1325,11 @@ Calculates the difference for each element `x1_i` of the input array `x1` with t
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array.
+    -   first input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`).
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -1354,7 +1355,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array whose elements are expressed in radians.
+    -   input array whose elements are expressed in radians. Should have a floating-point data type.
 
 #### Returns
 
@@ -1381,7 +1382,7 @@ For floating-point operands,
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array whose elements each represent a hyperbolic angle.
+    -   input array whose elements each represent a hyperbolic angle. Should have a floating-point data type.
 
 #### Returns
 
@@ -1402,7 +1403,7 @@ Rounds each element `x_i` of the input array `x` to the integer-valued number th
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 #### Returns
 

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -545,11 +545,11 @@ For floating-point operands,
 
 -   **x1**: _&lt;array&gt;_
 
-    -   dividend input array. Should have a numeric data type.
+    -   dividend input array. Should have a floating-point data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   divisor input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
+    -   divisor input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a floating-point data type.
 
 #### Returns
 
@@ -1141,11 +1141,11 @@ For floating-point operands,
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array whose elements correspond to the exponentiation base. Should have a numeric data type.
+    -   first input array whose elements correspond to the exponentiation base. Should have a floating-point data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array whose elements correspond to the exponentiation exponent. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
+    -   second input array whose elements correspond to the exponentiation exponent. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a floating-point data type.
 
 #### Returns
 

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -10,7 +10,7 @@ A conforming implementation of the array API standard must provide and support t
 -   Optional parameters must be [keyword-only](https://www.python.org/dev/peps/pep-3102/) arguments.
 -   Broadcasting semantics must follow the semantics defined in {ref}`broadcasting`.
 -   Unless stated otherwise, functions must support the data types defined in {ref}`data-types`.
--   Functions may only be required for a subset of input data type. Libraries may chose to implement functions for additional data types, but that behavior is not required by the spec. See {ref}`data-type-categories`.
+-   Functions may only be required for a subset of input data type. Libraries may choose to implement functions for additional data types, but that behavior is not required by the specification. See {ref}`data-type-categories`.
 -   Unless stated otherwise, functions must adhere to the type promotion rules defined in {ref}`type-promotion`.
 -   Unless stated otherwise, floating-point operations must adhere to IEEE 754-2019.
 -   Unless stated otherwise, element-wise mathematical functions must satisfy the minimum accuracy requirements defined in {ref}`accuracy`.
@@ -271,7 +271,7 @@ For floating-point operands,
 
 -   **x1**: _&lt;array&gt;_
 
-    -   input array corresponding to the y-coordinates. Should have a floating-point data type
+    -   input array corresponding to the y-coordinates. Should have a floating-point data type.
 
 -   **x2**: _&lt;array&gt;_
 
@@ -770,7 +770,7 @@ Tests each element `x_i` of the input array `x` to determine whether the element
 
 -   **out**: _&lt;array&gt;_
 
-    -   an array containing test results. An element `out_i` is `True` if `x_i` is `NaN` and `False` otherwise. The returned array Should have a data type of `bool`.
+    -   an array containing test results. An element `out_i` is `True` if `x_i` is `NaN` and `False` otherwise. The returned array should have a data type of `bool`.
 
 (function-less)=
 ### less(x1, x2, /)

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -1040,7 +1040,7 @@ Floating-point multiplication is not always associative due to finite precision.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeri
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 


### PR DESCRIPTION
Please double check that I didn't make any mistakes.

Some comments:

- I made all transcendental functions require floating-point inputs (i.e., no integers). This is because they say the output must use type promotion, but integer dtypes do not type promote to floating-point dtypes according to the type promotion rules. 
- For `pow`, `pow(a, b)` does not make sense if `a` and `b` are integers and `b` is negative. Should we restrict it to only being defined for nonnegative `b`? I think I might have brought this up before somewhere, but I don't remember what was decided.
  - (as an aside, shouldn't `pow(0, 0) == 1` be listed as a special case for `pow`?)
- The same question for `divide`. Should it be defined for integer inputs, and if so, does that preclude the definition when the second argument is 0?

I will also update the array methods as per https://github.com/data-apis/array-api/issues/98#issuecomment-739088199 in another PR once this is merged. 