### PR TITLE
Add specification for `asarray`

### DIFF
--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -49,6 +49,42 @@ This function cannot guarantee that the interval does not include the `stop` val
 
     -   a one-dimensional array containing evenly spaced values. The length of the output array must be `ceil((stop-start)/step)`.
 
+
+(function-asarray)=
+### asarray(obj, /, *, dtype=None, device=None, copy=False)
+
+Convert the input to an array.
+
+#### Parameters
+
+-   **obj**: _Union\[ float, NestedSequence\[ bool | int | float ], SupportsDLPack, SupportsBufferProtocol, memoryview ]_
+
+    -   Object to be converted to an array. Can be a Python scalar, a (possibly nested) sequence of Python scalars, or an object supporting DLPack or the Python buffer protocol.
+
+    :::{tip}
+    An object supporting DLPack has `__dlpack__` and `__dlpack_device__` methods.
+    An object supporting the buffer protocol can be turned into a memoryview through `memoryview(obj)`.
+    :::
+
+-   **dtype**: _Optional\[ &lt;dtype&gt; ]_
+
+    -   output array data type. If `dtype` is `None`, the output array data type must be inferred from the data type(s) in `obj`. Default: `None`.
+
+-   **device**: _Optional\[ &lt;device&gt; ]_
+
+    -   device to place the created array on, if given. Default: `None`.
+
+-   **copy**: _bool_
+
+    -   Whether or not to make a copy of the input. If `True`, always copies. If `False`, reuses existing memory buffer if possible. Default: `False`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   An array containing the data from `obj`.
+
+
 (function-empty)=
 ### empty(shape, /, *, dtype=None, device=None)
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -51,7 +51,7 @@ This function cannot guarantee that the interval does not include the `stop` val
 
 
 (function-asarray)=
-### asarray(obj, /, *, dtype=None, device=None, copy=False)
+### asarray(obj, /, *, dtype=None, device=None, copy=None)
 
 Convert the input to an array.
 
@@ -76,7 +76,7 @@ Convert the input to an array.
 
 -   **copy**: _bool_
 
-    -   Whether or not to make a copy of the input. If `True`, always copies. If `False`, reuses existing memory buffer if possible. Default: `False`.
+    -   Whether or not to make a copy of the input. If `True`, always copies. If `False`, never copies. If `None`, reuses existing memory buffer if possible. Default: `None`.
 
 #### Returns
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -57,7 +57,7 @@ Convert the input to an array.
 
 #### Parameters
 
--   **obj**: _Union\[ float, NestedSequence\[ bool | int | float ], SupportsDLPack, SupportsBufferProtocol, memoryview ]_
+-   **obj**: _Union\[ float, NestedSequence\[ bool | int | float ], SupportsDLPack, SupportsBufferProtocol ]_
 
     -   Object to be converted to an array. Can be a Python scalar, a (possibly nested) sequence of Python scalars, or an object supporting DLPack or the Python buffer protocol.
 
@@ -74,9 +74,9 @@ Convert the input to an array.
 
     -   device to place the created array on, if given. Default: `None`.
 
--   **copy**: _bool_
+-   **copy**: _Optional\[ bool ]_
 
-    -   Whether or not to make a copy of the input. If `True`, always copies. If `False`, never copies. If `None`, reuses existing memory buffer if possible. Default: `None`.
+    -   Whether or not to make a copy of the input. If `True`, always copies. If `False`, never copies for input which supports DLPack or the buffer protocol, and raises `ValueError` in case that would be necessary. If `None`, reuses existing memory buffer if possible, copies otherwise. Default: `None`.
 
 #### Returns
 


### PR DESCRIPTION
Closes gh-122

See gh-122 for a discussion on the `order=` keyword. The majority opinion there is not to add it, but it's not 100% clear cut.

Also, I did add `memoryview` as a supported input type, which wasn't considered in the discussion in gh-122. (EDIT: removed again, captured by `SupportsBufferProtocol`).