### PR TITLE
Add specification for computing the dot product (linalg: vecdot)

### DIFF
--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -98,9 +98,29 @@ Returns the specified diagonals. If `x` has more than two dimensions, then the a
     -   if `x` is a two-dimensional array, a one-dimensional array containing the diagonal; otherwise, a multi-dimensional array containing the diagonals and whose shape is determined by removing `axis1` and `axis2` and appending a dimension equal to the size of the resulting diagonals. The returned array must have the same data type as `x`.
 
 (function-dot)=
-### dot()
+### dot(x1, x2, /, *, axis=0)
 
-TODO
+Computes the dot product of two arrays (or stacks of arrays).
+
+#### Parameters
+
+-   **x1**: _&lt;array&gt;_
+
+    -   first input array. Must have a data type of either `float32` or `float64`.
+
+-   **x2**: _&lt;array&gt;_
+
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Must have a data type of either `float32` or `float64`.
+
+-   **axis**: _int_
+
+    -   axis over which to compute the dot product. If `axis` is `0`, the dot product must be computed over the last axis (dimension). If `axis` is `1`, the dot product must be computed over the second-to-last axis (dimension). Default: `0`.
+
+#### Returns
+
+-   **out**: _&lt;array;&gt;_
+
+    -   an array containing the dot product(s). Must have shape `shape(x1)[:-1]`. The returned array must have a data type determined by {ref}`type-promotion`.
 
 (function-eig)=
 ### eig()

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -125,7 +125,7 @@ Computes the dot product of two arrays.
 #### Raises
 
 -   if provided an invalid `axis`.
--   if the size of the axis over which to compute the inner product is not equal for both `x1` and `x2`.
+-   if the size of the axis over which to compute the inner product is not the same for both `x1` and `x2`.
 
 (function-eig)=
 ### eig()

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -100,7 +100,7 @@ Returns the specified diagonals. If `x` has more than two dimensions, then the a
 (function-dot)=
 ### dot(x1, x2, /, *, axis=None)
 
-Computes the dot product of two arrays (or stacks of arrays).
+Computes the dot product of two arrays.
 
 #### Parameters
 

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -98,7 +98,7 @@ Returns the specified diagonals. If `x` has more than two dimensions, then the a
     -   if `x` is a two-dimensional array, a one-dimensional array containing the diagonal; otherwise, a multi-dimensional array containing the diagonals and whose shape is determined by removing `axis1` and `axis2` and appending a dimension equal to the size of the resulting diagonals. The returned array must have the same data type as `x`.
 
 (function-dot)=
-### dot(x1, x2, /, *, axis=0)
+### dot(x1, x2, /, *, axis=None)
 
 Computes the dot product of two arrays (or stacks of arrays).
 
@@ -106,21 +106,21 @@ Computes the dot product of two arrays (or stacks of arrays).
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array. Must have a data type of either `float32` or `float64`.
+    -   first input array. Must have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Must have a data type of either `float32` or `float64`.
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Must have a numeric data type.
 
--   **axis**: _int_
+-   **axis**: _Optional\[ int ]_
 
-    -   axis over which to compute the dot product. If `axis` is `0`, the dot product must be computed over the last axis (dimension). If `axis` is `1`, the dot product must be computed over the second-to-last axis (dimension). Default: `0`.
+    -   axis over which to compute the dot product. Must be an integer on the interval `[-N, N)`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. If specified as a negative integer, the function must determine the axis along which to perform a reduction by counting backward from the last dimension (where `-1` refers to the last dimension). If `None`, the function must compute the dot product over the last axis. If provided an invalid `axis`, the function must raise an exception. Default: `None`.
 
 #### Returns
 
 -   **out**: _&lt;array;&gt;_
 
-    -   an array containing the dot product(s). Must have shape `shape(x1)[:-1]`. The returned array must have a data type determined by {ref}`type-promotion`.
+    -   an array containing the dot product(s). Must have a shape determined according to {ref}`broadcasting`. Must have a data type determined by {ref}`type-promotion`.
 
 (function-eig)=
 ### eig()

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -114,7 +114,7 @@ Computes the dot product of two arrays.
 
 -   **axis**: _Optional\[ int ]_
 
-    -   axis over which to compute the dot product. Must be an integer on the interval `[-N, N)`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. If specified as a negative integer, the function must determine the axis along which to perform a reduction by counting backward from the last dimension (where `-1` refers to the last dimension). If `None`, the function must compute the dot product over the last axis. Default: `None`.
+    -   axis over which to compute the dot product. Must be an integer on the interval `[-N, N)`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. If specified as a negative integer, the function must determine the axis along which to compute the dot product by counting backward from the last dimension (where `-1` refers to the last dimension). If `None`, the function must compute the dot product over the last axis. Default: `None`.
 
 #### Returns
 

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -114,13 +114,18 @@ Computes the dot product of two arrays (or stacks of arrays).
 
 -   **axis**: _Optional\[ int ]_
 
-    -   axis over which to compute the dot product. Must be an integer on the interval `[-N, N)`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. If specified as a negative integer, the function must determine the axis along which to perform a reduction by counting backward from the last dimension (where `-1` refers to the last dimension). If `None`, the function must compute the dot product over the last axis. If provided an invalid `axis`, the function must raise an exception. Default: `None`.
+    -   axis over which to compute the dot product. Must be an integer on the interval `[-N, N)`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. If specified as a negative integer, the function must determine the axis along which to perform a reduction by counting backward from the last dimension (where `-1` refers to the last dimension). If `None`, the function must compute the dot product over the last axis. Default: `None`.
 
 #### Returns
 
 -   **out**: _&lt;array;&gt;_
 
-    -   an array containing the dot product(s). Must have a shape determined according to {ref}`broadcasting`. Must have a data type determined by {ref}`type-promotion`.
+    -   if `x1` and `x2` are both one-dimensional arrays, a zero-dimensional containing the dot product; otherwise, a non-zero-dimensional array containing the dot products and having rank `N-1`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. Must have a data type determined by {ref}`type-promotion`.
+
+#### Raises
+
+-   if provided an invalid `axis`.
+-   if the size of the axis over which to compute the inner product is not equal for both `x1` and `x2`.
 
 (function-eig)=
 ### eig()

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -121,11 +121,11 @@ Computes the dot product of two arrays.
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array. Must have a numeric data type.
+    -   first input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Must have a numeric data type.
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 -   **axis**: _Optional\[ int ]_
 
@@ -135,7 +135,7 @@ Computes the dot product of two arrays.
 
 -   **out**: _&lt;array;&gt;_
 
-    -   if `x1` and `x2` are both one-dimensional arrays, a zero-dimensional containing the dot product; otherwise, a non-zero-dimensional array containing the dot products and having rank `N-1`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. Must have a data type determined by {ref}`type-promotion`.
+    -   if `x1` and `x2` are both one-dimensional arrays, a zero-dimensional containing the dot product; otherwise, a non-zero-dimensional array containing the dot products and having rank `N-1`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. The returned array must have a data type determined by {ref}`type-promotion`.
 
 #### Raises
 

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -112,36 +112,6 @@ TODO
 
 TODO
 
-(function-inner_dot)=
-### inner_dot(x1, x2, /, *, axis=None)
-
-Computes the dot product of two arrays.
-
-#### Parameters
-
--   **x1**: _&lt;array&gt;_
-
-    -   first input array. Should have a numeric data type.
-
--   **x2**: _&lt;array&gt;_
-
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
-
--   **axis**: _Optional\[ int ]_
-
-    -   axis over which to compute the dot product. Must be an integer on the interval `[-N, N)`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. If specified as a negative integer, the function must determine the axis along which to compute the dot product by counting backward from the last dimension (where `-1` refers to the last dimension). If `None`, the function must compute the dot product over the last axis. Default: `None`.
-
-#### Returns
-
--   **out**: _&lt;array;&gt;_
-
-    -   if `x1` and `x2` are both one-dimensional arrays, a zero-dimensional containing the dot product; otherwise, a non-zero-dimensional array containing the dot products and having rank `N-1`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. The returned array must have a data type determined by {ref}`type-promotion`.
-
-#### Raises
-
--   if provided an invalid `axis`.
--   if the size of the axis over which to compute the inner product is not the same for both `x1` and `x2`.
-
 (function-inv)=
 ### inv(x, /)
 
@@ -367,3 +337,33 @@ Transposes (or permutes the axes (dimensions)) of an array `x`.
 -   **out**: _&lt;array&gt;_
 
     -   an array containing the transpose. The returned array must have the same data type as `x`.
+
+(function-vecdot)=
+### vecdot(x1, x2, /, *, axis=None)
+
+Computes the (vector) dot product of two arrays.
+
+#### Parameters
+
+-   **x1**: _&lt;array&gt;_
+
+    -   first input array. Should have a numeric data type.
+
+-   **x2**: _&lt;array&gt;_
+
+    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
+
+-   **axis**: _Optional\[ int ]_
+
+    -   axis over which to compute the dot product. Must be an integer on the interval `[-N, N)`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. If specified as a negative integer, the function must determine the axis along which to compute the dot product by counting backward from the last dimension (where `-1` refers to the last dimension). If `None`, the function must compute the dot product over the last axis. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;array;&gt;_
+
+    -   if `x1` and `x2` are both one-dimensional arrays, a zero-dimensional containing the dot product; otherwise, a non-zero-dimensional array containing the dot products and having rank `N-1`, where `N` is the rank (number of dimensions) of the shape determined according to {ref}`broadcasting`. The returned array must have a data type determined by {ref}`type-promotion`.
+
+#### Raises
+
+-   if provided an invalid `axis`.
+-   if the size of the axis over which to compute the dot product is not the same for both `x1` and `x2`.

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -97,8 +97,23 @@ Returns the specified diagonals. If `x` has more than two dimensions, then the a
 
     -   if `x` is a two-dimensional array, a one-dimensional array containing the diagonal; otherwise, a multi-dimensional array containing the diagonals and whose shape is determined by removing `axis1` and `axis2` and appending a dimension equal to the size of the resulting diagonals. The returned array must have the same data type as `x`.
 
-(function-dot)=
-### dot(x1, x2, /, *, axis=None)
+(function-eig)=
+### eig()
+
+TODO
+
+(function-eigvalsh)=
+### eigvalsh()
+
+TODO
+
+(function-einsum)=
+### einsum()
+
+TODO
+
+(function-inner_dot)=
+### inner_dot(x1, x2, /, *, axis=None)
 
 Computes the dot product of two arrays.
 
@@ -126,21 +141,6 @@ Computes the dot product of two arrays.
 
 -   if provided an invalid `axis`.
 -   if the size of the axis over which to compute the inner product is not the same for both `x1` and `x2`.
-
-(function-eig)=
-### eig()
-
-TODO
-
-(function-eigvalsh)=
-### eigvalsh()
-
-TODO
-
-(function-einsum)=
-### einsum()
-
-TODO
 
 (function-inv)=
 ### inv(x, /)


### PR DESCRIPTION
This PR

-   adds the specification for computing the dot product.

-   currently deviates from current behavior across array libraries. Follows more closely to NumPy's `inner`.

-   comparisons for API signatures can be found [here](https://github.com/data-apis/array-api-comparison/blob/75bbbeaa22121a437fc78d01d23570b4dbcc23af/signatures/linalg/dot.md).

-   attempts to eliminate overloaded behavior found in the NumPy API. Namely, when

    -   `x1` and `x2` are 1D: NumPy computes the dot product.
    -   `x1` and `x2` are mixed 1D and ND: NumPy operates on the stack, computing the dot product over the last axis.
    -   `x1` and `x2` are 2D: NumPy performs matrix multiplication.
    -   `x1` and `x2` are ND: NumPy performs a tensor contraction using the second-to-last and the last axes, respectively.

    This proposal seeks to limit computation to strictly the dot product and limit to a single axis for >1D.

-   adds `axis` keyword to specify dimension over which to compute the dot product. (Note: this is similar to MATLAB's [dot](https://www.mathworks.com/help/matlab/ref/dot.html)).

-   renames the API as `vecdot` to avoid user confusion regarding expected behavior when transitioning from, e.g., `np.dot` to using `vecdot`.

## Background

Overview of the various NumPy APIs for computing the dot product:

|     | dot | inner | vdot | multi_dot | tensordot | matmul | einsum |
| --- | --- | ----- | ---- | -------- | --------- | ------ | ------ |
| 1D | dot product | dot product | dot product | dot product | dot product<sup>1</sup> | dot product | dot product<sup>2</sup> |
| 2D | matrix multiplication | dot product | (flattens) | dot product | dot product<sup>1</sup> | matrix multiplication | dot product<sup>2</sup> |
| ND | tensor contraction | dot product (cols vs cols) | (flattens) | -- | dot product<sup>1</sup> | matrix multiplication | dot product <sup>2</sup> |
| stacks | N | Y | N | N | Y | Y | Y |
| axes | N | N | N | N | Y | N | Y |
| complex conjugation | N | N | Y | N | -- | N | -- |

<sup>1</sup> can specify arbitrary axes for tensor contraction as a tuple of sequences.
<sup>2</sup> can specify an arbitrary axis for computing a sum.

## Notes

-   NumPy et al perform different quantities (dot product vs matrix multiplication) depending on the input argument shapes. This stems, at least in part, from legacy concerns dating prior to the introduction of `matmul`.

-   Pytorch limits computation to 1D vectors. From their docs (latest `master`):

    > Unlike NumPy’s `dot`, `torch.dot` intentionally only supports computing the dot product of two 1D tensors with the same number of elements.

-   For reference, Julia limits computing the [dot product](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.dot) over vectors. Extension to multi-dimensional arrays is supported so long as the dot product operation is defined on the elements. BLAS routines for computing the dot product are limited to strided vectors, with complex conjugation for complex dtypes.

## Other Considerations

-   An alternative specification could limit computing the dot product to one of the last two dimensions and treat >2D arrays as stacks.
-   Once complex dtypes are added to the standard, I'd advocate for complex conjugation, rather than having a separate API (e.g., `vdot`).
-   If an `axis` keyword argument is supported, then, similar to statistical reduction APIs (`mean`, `max`, `min`), we could consider supporting a `keepdims` keyword argument to retain the reduced dimension.