### PR TITLE
Clarify the exact bounds of what is required for slices

### DIFF
--- a/spec/API_specification/indexing.md
+++ b/spec/API_specification/indexing.md
@@ -114,11 +114,8 @@ Using a slice to index a single array axis must adhere to the following rules. L
 
 ```{note}
 
-This specification does not require "clipping" out-of-bounds slice indices.
-
-```{note}
-
-This is in contrast to Python slice semantics where `0:100` and `0:10` are equivalent on a list of length `10`.
+This specification does not require "clipping" out-of-bounds slice indices. This is in contrast to Python slice semantics where `0:100` and `0:10` are equivalent on a list of length `10`.
+```
 
 The following ranges for the start and stop values of a slice must be supported. Let `n` be the axis (dimension) size being sliced. For a slice `i:j:k`, the behavior specified above should be implemented for the following:
 

--- a/spec/API_specification/indexing.md
+++ b/spec/API_specification/indexing.md
@@ -114,9 +114,13 @@ Using a slice to index a single array axis must adhere to the following rules. L
 
 ```{note}
 
-This specification does not require "clipping" out-of-bounds slice indices (for example, in Python slice semantics, `0:100` and `0:10` are equivalent on a list of length `10`).
+This specification does not require "clipping" out-of-bounds slice indices.
 
-As such, only the following ranges for the start and stop values of a slice are required. Let `n` be the axis (dimension) size being sliced. For a slice `i:j:k`, the behavior specified above should be implemented for the following:
+```{note}
+
+This is in contrast to Python slice semantics where `0:100` and `0:10` are equivalent on a list of length `10`.
+
+The following ranges for the start and stop values of a slice must be supported. Let `n` be the axis (dimension) size being sliced. For a slice `i:j:k`, the behavior specified above should be implemented for the following:
 
 - `i` or `j` omitted (`None`).
 - `-n <= i <= max(0, n - 1)`.

--- a/spec/API_specification/indexing.md
+++ b/spec/API_specification/indexing.md
@@ -114,16 +114,18 @@ Using a slice to index a single array axis must adhere to the following rules. L
 
 ```{note}
 
-This specification does not require "clipping" out-of-bounds indices (i.e., requiring the starting and stopping indices `i` and `j` be bound by `0` and `n`, respectively).
+This specification does not require "clipping" out-of-bounds slice indices (for example, in Python slice semantics, `0:100` and `0:10` are equivalent on a list of length `10`).
 
-_Rationale: this is consistent with bounds checking for integer indexing; the behavior of out-of-bounds indices is left unspecified. Implementations may choose to clip, raise an exception, return junk values, or some other behavior depending on device requirements and performance considerations._
-```
+As such, only the following ranges for the start and stop values of a slice are required. Let `n` be the axis (dimension) size being sliced. For a slice `i:j:k`, the behavior specified above should be implemented for the following:
 
-```{note}
+- `i` or `j` omitted (`None`).
+- `-n <= i <= max(0, n - 1)`.
+- For `k > 0` or `k` omitted (`None`), `-n <= j <= n`.
+- For `k < 0`, `-n - 1 <= j <= max(0, n - 1)`.
 
-This specification leaves unspecified the behavior of indexing a single array axis with an out-of-bounds slice (i.e., a slice which does not select any array axis elements).
+The behavior outside of these bounds is unspecified.
 
-_Rationale: this is consistent with bounds checking for integer indexing; the behavior of out-of-bounds indices is left unspecified. Implementations may choose to return an empty array (whose axis (dimension) size along the indexed axis is `0`), raise an exception, or some other behavior depending on device requirements and performance considerations._
+_Rationale: this is consistent with bounds checking for integer indexing; the behavior of out-of-bounds indices is left unspecified. Implementations may choose to clip (consistent with Python `list` slicing semantics), raise an exception, return junk values, or some other behavior depending on device requirements and performance considerations._
 ```
 
 ## Multi-axis Indexing


### PR DESCRIPTION
@alextp @apaszke you originally requested this at https://github.com/data-apis/array-api/pull/46#pullrequestreview-495753430. Can you clarify if this is inline with what you are looking for? @shoyer I seem to remember you also had opinions on this, but I could be misremembering. 

Personally, I'm a little confused by this. If you know the shape of the array, you can always statically determine the shape of a sliced axis, regardless of what the slice looks like. Conversely, if the shape is only known symbolically, the sliced axis in general is also indeterminate. This is not just the case for bounds clipping. The size of the first axis in something like `a[:-1]` is not a fixed number. It's always 1 less than the size of the first axis of `a` (slices like that are very common in practice). So I think I may be missing something from this discussion.

Even so, every valid array slice is representable as a slice with the given conditions listed here, so this shouldn't affect expressibility.

For context, the reason this matters is that NumPy array API implementation, we want to make something that only allows those things that are explicitly *required* by the spec, so that people can use it as a test to see if their code will work for every API compatible implementation. So in particular, we want to restrict the indexing in `numpy._array_api` so that it doesn't allow indices that may not be supported by other valid array API implementations. So it's important to be precise about exactly what is required by the spec. 