### PR TITLE
PR: Add meshgrid 

### DIFF
--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -289,6 +289,33 @@ Returns evenly spaced numbers over a specified interval.
 
     -   a one-dimensional array containing evenly spaced values.
 
+(function-meshgrid)=
+### meshgrid(x, /, *, indexing='xy')
+
+Returns coordinate matrices from coordinate vectors.
+
+### Special cases
+
+-    For `n` one dimensional arrays `x1, x2, ..., xn` with lengths `Ni = len(xi)`, this function returns `(N1, N2, N3, ..., Nn)` shaped arrays if the indexing is 'ij' or `(N2, N1, N3, ..., Nn)` shaped arrays if indexing 'xy'.
+
+-    The 0-D and 1-D case, the indexing keyword has no effect.
+
+### Parameters
+
+-    **x**: _&lt;array&gt;_
+
+     -   One dimensional array representing the coordinates of the grid.
+
+-    **indexing**: _Optional\[str]_
+
+     -   Cartesian 'xy' by default or 'ij' for matrix indexing of the output.
+
+### Returns
+
+-    **out**: _\[&lt;array&gt;\]_
+
+      -    List of N arrays with rank N.
+
 (function-ones)=
 ### ones(shape, /, *, dtype=None, device=None)
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -290,7 +290,7 @@ Returns evenly spaced numbers over a specified interval.
     -   a one-dimensional array containing evenly spaced values.
 
 (function-meshgrid)=
-### meshgrid(*arrays, /, indexing='xy')
+### meshgrid(*arrays, /, *, indexing='xy')
 
 Returns coordinate matrices from coordinate vectors.
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -290,7 +290,7 @@ Returns evenly spaced numbers over a specified interval.
     -   a one-dimensional array containing evenly spaced values.
 
 (function-meshgrid)=
-### meshgrid(*arrays, /, *, indexing='xy')
+### meshgrid(*arrays, /, indexing='xy')
 
 Returns coordinate matrices from coordinate vectors.
 
@@ -302,7 +302,7 @@ Returns coordinate matrices from coordinate vectors.
 
 ### Parameters
 
--    ***arrays**: _&lt;array&gt;_
+-    **\*arrays**: _&lt;array&gt;_
 
      -   One dimensional arrays representing the coordinates of the grid.
 
@@ -315,6 +315,22 @@ Returns coordinate matrices from coordinate vectors.
 -    **out**: _Tuple\[ &lt;array&gt;, ... ]_
 
       -    List of N arrays with rank `max(2, N)`.
+
+### Notes
+
+This function supports indexing conventions using the `indexing` keyword. In the case of `xy` the function will return a meshgrid with cartesian indexing, while `ij` will use matrix indexing. The difference is illustrated by the following code snippet:
+
+```
+xv, yv = meshgrid(x, y, indexing='xy')
+for i in range(nx):
+    for j in range(ny):
+        # treat xv[j, i], yv[j, i]
+
+xv, yv = meshgrid(x, y, indexing='ij')
+for i in range(nx):
+    for j in range(ny):
+        # treat xv[i, j], yv[i, j]
+```
 
 (function-ones)=
 ### ones(shape, /, *, dtype=None, device=None)

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -308,7 +308,7 @@ Returns coordinate matrices from coordinate vectors.
 
 -    **out**: _List\[ &lt;array&gt;, ... ]_
 
-    -   List of N arrays, where `N` is the number of provided one-dimensional input arrays. Each returned array must have rank `N`. For `N` one-dimensional arrays having lengths `Ni = len(xi)`,
+    -   list of N arrays, where `N` is the number of provided one-dimensional input arrays. Each returned array must have rank `N`. For `N` one-dimensional arrays having lengths `Ni = len(xi)`,
 
         -   if matrix indexing `ij`, then each returned array must have the shape `(N1, N2, N3, ..., Nn)`.
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -294,31 +294,17 @@ Returns evenly spaced numbers over a specified interval.
 
 Returns coordinate matrices from coordinate vectors.
 
-### Special cases
+#### Parameters
 
--    For `n` one dimensional arrays `x1, x2, ..., xn` with lengths `Ni = len(xi)`, this function returns `(N1, N2, N3, ..., Nn)` shaped arrays if the indexing is 'ij' or `(N2, N1, N3, ..., Nn)` shaped arrays if indexing 'xy'.
+-    **arrays**: _Sequence\[ &lt;array&gt; ]_
 
--    The 0-D and 1-D case, the indexing keyword has no effect.
+     -   one-dimensional arrays representing grid coordinates. Must have a numeric data type.
 
-### Parameters
+-    **indexing**: _str_
 
--    **\*arrays**: _&lt;array&gt;_
+     -   Cartesian 'xy' or matrix 'ij' indexing of output. If provided zero or one one-dimensional vector(s) (i.e., the zero- and one-dimensional cases, respectively), the `indexing` keyword has no effect and should be ignored. Default: `'xy'`.
 
-     -   One dimensional arrays representing the coordinates of the grid.
-
--    **indexing**: _Optional\[ str ]_
-
-     -   Cartesian 'xy' by default or 'ij' for matrix indexing of the output.
-
-### Returns
-
--    **out**: _Tuple\[ &lt;array&gt;, ... ]_
-
-      -    List of N arrays with rank `max(2, N)`.
-
-### Notes
-
-This function supports indexing conventions using the `indexing` keyword. In the case of `xy` the function will return a meshgrid with cartesian indexing, while `ij` will use matrix indexing. The difference is illustrated by the following code snippet:
+     -   In the case of `xy` the function will return a meshgrid with cartesian indexing, while `ij` will use matrix indexing. The difference is illustrated by the following code snippet:
 
 ```
 xv, yv = meshgrid(x, y, indexing='xy')
@@ -331,6 +317,22 @@ for i in range(nx):
     for j in range(ny):
         # treat xv[i, j], yv[i, j]
 ```
+
+#### Returns
+
+-    **out**: _List \[ &lt;array&gt;, ... ]_
+
+      -    List of N arrays, where `N` is the number of provided one-dimensional input arrays. Each returned array must have rank `N`. For `N` one-dimensional arrays having lengths `Ni = len(xi)`,
+
+          -    if matrix indexing `ij` then each return array must have the shape `(N1, N2, N3, ..., Nn)`.
+
+          -    if Cartesian indexing `xy`, then each returned array must have shape `(N2, N1, N3, ..., Nn)`.
+
+     - Accordingly, for the two-dimensional case with input one-dimensional arrays of length `M` and `N`, if matrix indexing `ij`, then each returned array must have shape `(M, N)`, and, if Cartesian indexing `xy`, then each returned array must have shape `(N, M)`.
+
+     - Similarly, for the three-dimensional case with input one-dimensional arrays of length `M`, `N`, and `P`, if matrix indexing `ij`, then each returned array must have shape `(M, N, P)`, and, if Cartesian indexing `xy`, then each returned array must have shape `(N, M, P)`.
+
+     - The returned arrays must have a numeric data type determined by {ref}`type-promotion`.
 
 (function-ones)=
 ### ones(shape, /, *, dtype=None, device=None)

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -320,19 +320,19 @@ for i in range(nx):
 
 #### Returns
 
--    **out**: _List \[ &lt;array&gt;, ... ]_
+-    **out**: _List\[ &lt;array&gt;, ... ]_
 
-      -    List of N arrays, where `N` is the number of provided one-dimensional input arrays. Each returned array must have rank `N`. For `N` one-dimensional arrays having lengths `Ni = len(xi)`,
+    -   List of N arrays, where `N` is the number of provided one-dimensional input arrays. Each returned array must have rank `N`. For `N` one-dimensional arrays having lengths `Ni = len(xi)`,
 
-          -    if matrix indexing `ij` then each return array must have the shape `(N1, N2, N3, ..., Nn)`.
+        -   if matrix indexing `ij` then each return array must have the shape `(N1, N2, N3, ..., Nn)`.
 
-          -    if Cartesian indexing `xy`, then each returned array must have shape `(N2, N1, N3, ..., Nn)`.
+        -   if Cartesian indexing `xy`, then each returned array must have shape `(N2, N1, N3, ..., Nn)`.
 
-     - Accordingly, for the two-dimensional case with input one-dimensional arrays of length `M` and `N`, if matrix indexing `ij`, then each returned array must have shape `(M, N)`, and, if Cartesian indexing `xy`, then each returned array must have shape `(N, M)`.
+        Accordingly, for the two-dimensional case with input one-dimensional arrays of length `M` and `N`, if matrix indexing `ij`, then each returned array must have shape `(M, N)`, and, if Cartesian indexing `xy`, then each returned array must have shape `(N, M)`.
 
-     - Similarly, for the three-dimensional case with input one-dimensional arrays of length `M`, `N`, and `P`, if matrix indexing `ij`, then each returned array must have shape `(M, N, P)`, and, if Cartesian indexing `xy`, then each returned array must have shape `(N, M, P)`.
+        Similarly, for the three-dimensional case with input one-dimensional arrays of length `M`, `N`, and `P`, if matrix indexing `ij`, then each returned array must have shape `(M, N, P)`, and, if Cartesian indexing `xy`, then each returned array must have shape `(N, M, P)`.
 
-     - The returned arrays must have a numeric data type determined by {ref}`type-promotion`.
+        The returned arrays must have a numeric data type determined by {ref}`type-promotion`.
 
 (function-ones)=
 ### ones(shape, /, *, dtype=None, device=None)

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -310,7 +310,7 @@ Returns coordinate matrices from coordinate vectors.
 
     -   List of N arrays, where `N` is the number of provided one-dimensional input arrays. Each returned array must have rank `N`. For `N` one-dimensional arrays having lengths `Ni = len(xi)`,
 
-        -   if matrix indexing `ij` then each return array must have the shape `(N1, N2, N3, ..., Nn)`.
+        -   if matrix indexing `ij`, then each return array must have the shape `(N1, N2, N3, ..., Nn)`.
 
         -   if Cartesian indexing `xy`, then each returned array must have shape `(N2, N1, N3, ..., Nn)`.
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -302,21 +302,7 @@ Returns coordinate matrices from coordinate vectors.
 
 -    **indexing**: _str_
 
-     -   Cartesian 'xy' or matrix 'ij' indexing of output. If provided zero or one one-dimensional vector(s) (i.e., the zero- and one-dimensional cases, respectively), the `indexing` keyword has no effect and should be ignored. Default: `'xy'`.
-
-     -   In the case of `xy` the function will return a meshgrid with cartesian indexing, while `ij` will use matrix indexing. The difference is illustrated by the following code snippet:
-
-```
-xv, yv = meshgrid(x, y, indexing='xy')
-for i in range(nx):
-    for j in range(ny):
-        # treat xv[j, i], yv[j, i]
-
-xv, yv = meshgrid(x, y, indexing='ij')
-for i in range(nx):
-    for j in range(ny):
-        # treat xv[i, j], yv[i, j]
-```
+    -   Cartesian 'xy' or matrix 'ij' indexing of output. If provided zero or one one-dimensional vector(s) (i.e., the zero- and one-dimensional cases, respectively), the `indexing` keyword has no effect and should be ignored. Default: `'xy'`.
 
 #### Returns
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -290,7 +290,7 @@ Returns evenly spaced numbers over a specified interval.
     -   a one-dimensional array containing evenly spaced values.
 
 (function-meshgrid)=
-### meshgrid(x, /, *, indexing='xy')
+### meshgrid(*arrays, /, *, indexing='xy')
 
 Returns coordinate matrices from coordinate vectors.
 
@@ -302,19 +302,19 @@ Returns coordinate matrices from coordinate vectors.
 
 ### Parameters
 
--    **x**: _&lt;array&gt;_
+-    ***arrays**: _&lt;array&gt;_
 
-     -   One dimensional array representing the coordinates of the grid.
+     -   One dimensional arrays representing the coordinates of the grid.
 
--    **indexing**: _Optional\[str]_
+-    **indexing**: _Optional\[ str ]_
 
      -   Cartesian 'xy' by default or 'ij' for matrix indexing of the output.
 
 ### Returns
 
--    **out**: _\[&lt;array&gt;\]_
+-    **out**: _Tuple\[ &lt;array&gt;, ... ]_
 
-      -    List of N arrays with rank N.
+      -    List of N arrays with rank `max(2, N)`.
 
 (function-ones)=
 ### ones(shape, /, *, dtype=None, device=None)

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -310,7 +310,7 @@ Returns coordinate matrices from coordinate vectors.
 
     -   List of N arrays, where `N` is the number of provided one-dimensional input arrays. Each returned array must have rank `N`. For `N` one-dimensional arrays having lengths `Ni = len(xi)`,
 
-        -   if matrix indexing `ij`, then each return array must have the shape `(N1, N2, N3, ..., Nn)`.
+        -   if matrix indexing `ij`, then each returned array must have the shape `(N1, N2, N3, ..., Nn)`.
 
         -   if Cartesian indexing `xy`, then each returned array must have shape `(N2, N1, N3, ..., Nn)`.
 


### PR DESCRIPTION
This PR

- Adds specification for `meshgrid`, which returns coordinate matrices from coordinate vectors.

Notes
----
- For this function the arguments `copy` and `sparse` currently supported in NumPy, CuPy and JAX were dropped (https://github.com/data-apis/array-api-comparison/blob/main/signatures/creation/meshgrid.md)
- The optional argument `indexing` is based in the current implementation of NumPy including it's special cases for 0-D and 1-D arrays.
