### PR TITLE
Add contributor acknowledgements via all-contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,314 @@
+{
+  "projectName": "array-api",
+  "projectOwner": "data-apis",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "saulshanabrook",
+      "name": "Saul Shanabrook",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1186124?v=4",
+      "profile": "http://saulshanabrook.github.io/",
+      "contributions": [
+        "tool",
+        "ideas",
+        "research"
+      ]
+    },
+    {
+      "login": "kgryte",
+      "name": "Athan",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2643044?v=4",
+      "profile": "https://github.com/stdlib-js/stdlib",
+      "contributions": [
+        "content",
+        "data",
+        "tool",
+        "research"
+      ]
+    },
+    {
+      "login": "steff456",
+      "name": "Stephannie Jimenez Gacha",
+      "avatar_url": "https://avatars.githubusercontent.com/u/20992645?v=4",
+      "profile": "https://github.com/steff456",
+      "contributions": [
+        "data",
+        "content",
+        "research"
+      ]
+    },
+    {
+      "login": "asmeurer",
+      "name": "Aaron Meurer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/71486?v=4",
+      "profile": "https://github.com/asmeurer",
+      "contributions": [
+        "content",
+        "test",
+        "tool"
+      ]
+    },
+    {
+      "login": "tonyfast",
+      "name": "Tony Fast",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4236275?v=4",
+      "profile": "http://deathbeds.github.io/",
+      "contributions": [
+        "maintenance"
+      ]
+    },
+    {
+      "login": "rgommers",
+      "name": "Ralf Gommers",
+      "avatar_url": "https://avatars.githubusercontent.com/u/98330?v=4",
+      "profile": "https://github.com/rgommers",
+      "contributions": [
+        "blog",
+        "business",
+        "code",
+        "content",
+        "doc",
+        "fundingFinding",
+        "maintenance",
+        "ideas",
+        "projectManagement",
+        "talk"
+      ]
+    },
+    {
+      "login": "teoliphant",
+      "name": "Travis E. Oliphant",
+      "avatar_url": "https://avatars.githubusercontent.com/u/254880?v=4",
+      "profile": "https://github.com/teoliphant",
+      "contributions": [
+        "business",
+        "fundingFinding",
+        "ideas"
+      ]
+    },
+    {
+      "login": "leofang",
+      "name": "Leo Fang",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5534781?v=4",
+      "profile": "https://leofang.github.io/",
+      "contributions": [
+        "review",
+        "ideas",
+        "content"
+      ]
+    },
+    {
+      "login": "tqchen",
+      "name": "Tianqi Chen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2577440?v=4",
+      "profile": "https://tqchen.com/",
+      "contributions": [
+        "ideas",
+        "review"
+      ]
+    },
+    {
+      "login": "shoyer",
+      "name": "Stephan Hoyer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1217238?v=4",
+      "profile": "http://stephanhoyer.com/",
+      "contributions": [
+        "ideas",
+        "review",
+        "question"
+      ]
+    },
+    {
+      "login": "alextp",
+      "name": "Alexandre Passos",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5061?v=4",
+      "profile": "http://www.ic.unicamp.br/~tachard/",
+      "contributions": [
+        "ideas",
+        "review"
+      ]
+    },
+    {
+      "login": "dynamicwebpaige",
+      "name": "Paige Bailey",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3712347?v=4",
+      "profile": "http://paigevie.ws/",
+      "contributions": [
+        "fundingFinding"
+      ]
+    },
+    {
+      "login": "apaszke",
+      "name": "Adam Paszke",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4583066?v=4",
+      "profile": "https://github.com/apaszke",
+      "contributions": [
+        "ideas",
+        "review",
+        "talk"
+      ]
+    },
+    {
+      "login": "amueller",
+      "name": "Andreas Mueller",
+      "avatar_url": "https://avatars.githubusercontent.com/u/449558?v=4",
+      "profile": "http://amueller.github.io/",
+      "contributions": [
+        "ideas",
+        "review"
+      ]
+    },
+    {
+      "login": "szha",
+      "name": "Sheng Zha",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2626883?v=4",
+      "profile": "https://www.linkedin.com/in/shengzha/",
+      "contributions": [
+        "ideas",
+        "review",
+        "talk"
+      ]
+    },
+    {
+      "login": "kkraus",
+      "name": "kkraus",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1324560?v=4",
+      "profile": "https://github.com/kkraus",
+      "contributions": [
+        "ideas",
+        "review",
+        "talk"
+      ]
+    },
+    {
+      "login": "TomAugspurger",
+      "name": "Tom Augspurger",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1312546?v=4",
+      "profile": "https://tomaugspurger.github.io/",
+      "contributions": [
+        "review",
+        "question"
+      ]
+    },
+    {
+      "login": "edloper",
+      "name": "edloper",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5790348?v=4",
+      "profile": "https://github.com/edloper",
+      "contributions": [
+        "review",
+        "question"
+      ]
+    },
+    {
+      "login": "aregm",
+      "name": "Areg Melik-Adamyan",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1798344?v=4",
+      "profile": "https://github.com/aregm",
+      "contributions": [
+        "review",
+        "fundingFinding"
+      ]
+    },
+    {
+      "login": "oleksandr-pavlyk",
+      "name": "Oleksandr Pavlyk",
+      "avatar_url": "https://avatars.githubusercontent.com/u/21087696?v=4",
+      "profile": "http://math.stackexchange.com/users/11069/sasha",
+      "contributions": [
+        "review",
+        "question"
+      ]
+    },
+    {
+      "login": "tdimitri",
+      "name": "tdimitri",
+      "avatar_url": "https://avatars.githubusercontent.com/u/62962217?v=4",
+      "profile": "https://github.com/tdimitri",
+      "contributions": [
+        "ideas"
+      ]
+    },
+    {
+      "login": "jack-pappas",
+      "name": "Jack Pappas",
+      "avatar_url": "https://avatars.githubusercontent.com/u/477287?v=4",
+      "profile": "https://github.com/jack-pappas",
+      "contributions": [
+        "ideas"
+      ]
+    },
+    {
+      "login": "agarwalashish",
+      "name": "Ashish Agarwal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3207727?v=4",
+      "profile": "https://github.com/agarwalashish",
+      "contributions": [
+        "review",
+        "question"
+      ]
+    },
+    {
+      "login": "ezyang",
+      "name": "Edward Z. Yang",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13564?v=4",
+      "profile": "http://ezyang.com/",
+      "contributions": [
+        "ideas"
+      ]
+    },
+    {
+      "login": "mruberry",
+      "name": "Mike Ruberry",
+      "avatar_url": "https://avatars.githubusercontent.com/u/38511765?v=4",
+      "profile": "https://github.com/mruberry",
+      "contributions": [
+        "ideas"
+      ]
+    },
+    {
+      "login": "eric-wieser",
+      "name": "Eric Wieser",
+      "avatar_url": "https://avatars.githubusercontent.com/u/425260?v=4",
+      "profile": "http://ericwieser.me/",
+      "contributions": [
+        "ideas"
+      ]
+    },
+    {
+      "login": "willingc",
+      "name": "Carol Willing",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2680980?v=4",
+      "profile": "https://www.willingconsulting.com/",
+      "contributions": [
+        "ideas"
+      ]
+    },
+    {
+      "login": "arogozhnikov",
+      "name": "Alex Rogozhnikov",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6318811?v=4",
+      "profile": "https://arogozhnikov.github.io/",
+      "contributions": [
+        "ideas"
+      ]
+    },
+    {
+      "login": "honnibal",
+      "name": "Matthew Honnibal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8059750?v=4",
+      "profile": "https://explosion.ai/",
+      "contributions": [
+        "ideas"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 spec/_build/
+build/
+.vscode/
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for your interest in contributing!
 
 
-## Contributing 
+## Contributing
 
 If you would like to contribute textual clarifications or other "maintenance
 type" changes, please open a pull request on the
@@ -17,10 +17,21 @@ before opening a pull request. If your proposed addition seems in scope,
 opening an issue for discussion may be more appropriate as a first step.
 
 
+## Acknowledgements
+
+We recognize all types of contributions. This project follows the
+[all-contributors](https://github.com/all-contributors/all-contributors)
+specification. Please add yourself to the list of contributors when you make
+a contribution. You can do this by posting a comment with the text:
+`@all-contributors please add @YOUR-USERNAME for THING(S)` (`THING` is one of
+[these keys](https://allcontributors.org/docs/en/emoji-key)) and our nice bot
+will add you.
+
+
 ## Reporting issues
 
 Please use the [issue tracker](https://github.com/data-apis/array-api/issues)
-for reporting issues with the published Array API Standard. 
+for reporting issues with the published Array API Standard.
 
 Please note that *implementation* issues should be reported to the project
 implementing the standard.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Array API standard
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-29-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This repository contains documents, tooling and other content related to the
 API standard for arrays (or tensors).
@@ -11,3 +14,59 @@ These are relevant documents related to the content in this repository:
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for how to go about contributing to
 this array API standard.
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="http://saulshanabrook.github.io/"><img src="https://avatars.githubusercontent.com/u/1186124?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Saul Shanabrook</b></sub></a><br /><a href="#tool-saulshanabrook" title="Tools">🔧</a> <a href="#ideas-saulshanabrook" title="Ideas, Planning, & Feedback">🤔</a> <a href="#research-saulshanabrook" title="Research">🔬</a></td>
+    <td align="center"><a href="https://github.com/stdlib-js/stdlib"><img src="https://avatars.githubusercontent.com/u/2643044?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Athan</b></sub></a><br /><a href="#content-kgryte" title="Content">🖋</a> <a href="#data-kgryte" title="Data">🔣</a> <a href="#tool-kgryte" title="Tools">🔧</a> <a href="#research-kgryte" title="Research">🔬</a></td>
+    <td align="center"><a href="https://github.com/steff456"><img src="https://avatars.githubusercontent.com/u/20992645?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephannie Jimenez Gacha</b></sub></a><br /><a href="#data-steff456" title="Data">🔣</a> <a href="#content-steff456" title="Content">🖋</a> <a href="#research-steff456" title="Research">🔬</a></td>
+    <td align="center"><a href="https://github.com/asmeurer"><img src="https://avatars.githubusercontent.com/u/71486?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Aaron Meurer</b></sub></a><br /><a href="#content-asmeurer" title="Content">🖋</a> <a href="https://github.com/data-apis/array-api/commits?author=asmeurer" title="Tests">⚠️</a> <a href="#tool-asmeurer" title="Tools">🔧</a></td>
+    <td align="center"><a href="http://deathbeds.github.io/"><img src="https://avatars.githubusercontent.com/u/4236275?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tony Fast</b></sub></a><br /><a href="#maintenance-tonyfast" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/rgommers"><img src="https://avatars.githubusercontent.com/u/98330?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ralf Gommers</b></sub></a><br /><a href="#blog-rgommers" title="Blogposts">📝</a> <a href="#business-rgommers" title="Business development">💼</a> <a href="https://github.com/data-apis/array-api/commits?author=rgommers" title="Code">💻</a> <a href="#content-rgommers" title="Content">🖋</a> <a href="https://github.com/data-apis/array-api/commits?author=rgommers" title="Documentation">📖</a> <a href="#fundingFinding-rgommers" title="Funding Finding">🔍</a> <a href="#maintenance-rgommers" title="Maintenance">🚧</a> <a href="#ideas-rgommers" title="Ideas, Planning, & Feedback">🤔</a> <a href="#projectManagement-rgommers" title="Project Management">📆</a> <a href="#talk-rgommers" title="Talks">📢</a></td>
+    <td align="center"><a href="https://github.com/teoliphant"><img src="https://avatars.githubusercontent.com/u/254880?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Travis E. Oliphant</b></sub></a><br /><a href="#business-teoliphant" title="Business development">💼</a> <a href="#fundingFinding-teoliphant" title="Funding Finding">🔍</a> <a href="#ideas-teoliphant" title="Ideas, Planning, & Feedback">🤔</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://leofang.github.io/"><img src="https://avatars.githubusercontent.com/u/5534781?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Leo Fang</b></sub></a><br /><a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Aleofang" title="Reviewed Pull Requests">👀</a> <a href="#ideas-leofang" title="Ideas, Planning, & Feedback">🤔</a> <a href="#content-leofang" title="Content">🖋</a></td>
+    <td align="center"><a href="https://tqchen.com/"><img src="https://avatars.githubusercontent.com/u/2577440?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tianqi Chen</b></sub></a><br /><a href="#ideas-tqchen" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Atqchen" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="http://stephanhoyer.com/"><img src="https://avatars.githubusercontent.com/u/1217238?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stephan Hoyer</b></sub></a><br /><a href="#ideas-shoyer" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Ashoyer" title="Reviewed Pull Requests">👀</a> <a href="#question-shoyer" title="Answering Questions">💬</a></td>
+    <td align="center"><a href="http://www.ic.unicamp.br/~tachard/"><img src="https://avatars.githubusercontent.com/u/5061?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alexandre Passos</b></sub></a><br /><a href="#ideas-alextp" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Aalextp" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="http://paigevie.ws/"><img src="https://avatars.githubusercontent.com/u/3712347?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Paige Bailey</b></sub></a><br /><a href="#fundingFinding-dynamicwebpaige" title="Funding Finding">🔍</a></td>
+    <td align="center"><a href="https://github.com/apaszke"><img src="https://avatars.githubusercontent.com/u/4583066?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Adam Paszke</b></sub></a><br /><a href="#ideas-apaszke" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Aapaszke" title="Reviewed Pull Requests">👀</a> <a href="#talk-apaszke" title="Talks">📢</a></td>
+    <td align="center"><a href="http://amueller.github.io/"><img src="https://avatars.githubusercontent.com/u/449558?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Andreas Mueller</b></sub></a><br /><a href="#ideas-amueller" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Aamueller" title="Reviewed Pull Requests">👀</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://www.linkedin.com/in/shengzha/"><img src="https://avatars.githubusercontent.com/u/2626883?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sheng Zha</b></sub></a><br /><a href="#ideas-szha" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Aszha" title="Reviewed Pull Requests">👀</a> <a href="#talk-szha" title="Talks">📢</a></td>
+    <td align="center"><a href="https://github.com/kkraus"><img src="https://avatars.githubusercontent.com/u/1324560?v=4?s=100" width="100px;" alt=""/><br /><sub><b>kkraus</b></sub></a><br /><a href="#ideas-kkraus" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Akkraus" title="Reviewed Pull Requests">👀</a> <a href="#talk-kkraus" title="Talks">📢</a></td>
+    <td align="center"><a href="https://tomaugspurger.github.io/"><img src="https://avatars.githubusercontent.com/u/1312546?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tom Augspurger</b></sub></a><br /><a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3ATomAugspurger" title="Reviewed Pull Requests">👀</a> <a href="#question-TomAugspurger" title="Answering Questions">💬</a></td>
+    <td align="center"><a href="https://github.com/edloper"><img src="https://avatars.githubusercontent.com/u/5790348?v=4?s=100" width="100px;" alt=""/><br /><sub><b>edloper</b></sub></a><br /><a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Aedloper" title="Reviewed Pull Requests">👀</a> <a href="#question-edloper" title="Answering Questions">💬</a></td>
+    <td align="center"><a href="https://github.com/aregm"><img src="https://avatars.githubusercontent.com/u/1798344?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Areg Melik-Adamyan</b></sub></a><br /><a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Aaregm" title="Reviewed Pull Requests">👀</a> <a href="#fundingFinding-aregm" title="Funding Finding">🔍</a></td>
+    <td align="center"><a href="http://math.stackexchange.com/users/11069/sasha"><img src="https://avatars.githubusercontent.com/u/21087696?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Oleksandr Pavlyk</b></sub></a><br /><a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Aoleksandr-pavlyk" title="Reviewed Pull Requests">👀</a> <a href="#question-oleksandr-pavlyk" title="Answering Questions">💬</a></td>
+    <td align="center"><a href="https://github.com/tdimitri"><img src="https://avatars.githubusercontent.com/u/62962217?v=4?s=100" width="100px;" alt=""/><br /><sub><b>tdimitri</b></sub></a><br /><a href="#ideas-tdimitri" title="Ideas, Planning, & Feedback">🤔</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/jack-pappas"><img src="https://avatars.githubusercontent.com/u/477287?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jack Pappas</b></sub></a><br /><a href="#ideas-jack-pappas" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/agarwalashish"><img src="https://avatars.githubusercontent.com/u/3207727?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ashish Agarwal</b></sub></a><br /><a href="https://github.com/data-apis/array-api/pulls?q=is%3Apr+reviewed-by%3Aagarwalashish" title="Reviewed Pull Requests">👀</a> <a href="#question-agarwalashish" title="Answering Questions">💬</a></td>
+    <td align="center"><a href="http://ezyang.com/"><img src="https://avatars.githubusercontent.com/u/13564?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Edward Z. Yang</b></sub></a><br /><a href="#ideas-ezyang" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/mruberry"><img src="https://avatars.githubusercontent.com/u/38511765?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mike Ruberry</b></sub></a><br /><a href="#ideas-mruberry" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="http://ericwieser.me/"><img src="https://avatars.githubusercontent.com/u/425260?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Eric Wieser</b></sub></a><br /><a href="#ideas-eric-wieser" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://www.willingconsulting.com/"><img src="https://avatars.githubusercontent.com/u/2680980?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Carol Willing</b></sub></a><br /><a href="#ideas-willingc" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://arogozhnikov.github.io/"><img src="https://avatars.githubusercontent.com/u/6318811?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alex Rogozhnikov</b></sub></a><br /><a href="#ideas-arogozhnikov" title="Ideas, Planning, & Feedback">🤔</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://explosion.ai/"><img src="https://avatars.githubusercontent.com/u/8059750?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Matthew Honnibal</b></sub></a><br /><a href="#ideas-honnibal" title="Ideas, Planning, & Feedback">🤔</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
The idea here is to add this on the main repos for arrays and for dataframes. The initial set of contributors was added via the all-contributors CLI, later it can be done via the bot. See https://allcontributors.org/ for details.
   
It looks like it is not possible at this time to add people who do not have a GitHub username - I opened an issue on the all-contributors repo about that.

There are many repos in this org; my intent is to use all-contributors only on the `array-api` and the main dataframe repo.

This is what it will look like:

<img width="674" alt="image" src="https://user-images.githubusercontent.com/98330/111880523-59dd7d00-89ac-11eb-83fc-491194ca0d12.png">
