### PR TITLE
Add specification for computing singular values using singular value decomposition (linalg: svdvals)

### DIFF
--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -279,6 +279,23 @@ TODO
 
 TODO
 
+(function-svdvals)=
+### svdvals(x, /)
+
+Computes the singular values of a matrix (or stack of matrices) `x`.
+
+#### Parameters
+
+-   **x**: _&lt;array&gt;_
+
+    -   input array having shape `(..., M, N)` and whose innermost two dimensions form matrices on which to perform singular value decomposition. Should have a floating-point data type.
+
+#### Returns
+
+-   **out**: _Union\[ &lt;array&gt;, Tuple\[ &lt;array&gt;, ... ] ]_
+
+    -   an array with shape `(..., K)` that contains the vector(s) of singular values of length `K`. For each vector, the singular values must be sorted in descending order by magnitude, such that `s[..., 0]` is the largest value, `s[..., 1]` is the second largest value, et cetera. The first `x.ndim-2` dimensions must have the same shape as those of the input `x`. The returned array must have the same floating-point data type as `x`.
+
 (function-trace)=
 ### trace(x, /, *, axis1=0, axis2=1, offset=0)
 

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -279,8 +279,8 @@ TODO
 
 TODO
 
-(function-svdvals)=
-### svdvals(x, /)
+(function-linalg-svdvals)=
+### linalg.svdvals(x, /)
 
 Computes the singular values of a matrix (or a stack of matrices) `x`.
 

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -282,7 +282,7 @@ TODO
 (function-svdvals)=
 ### svdvals(x, /)
 
-Computes the singular values of a matrix (or stack of matrices) `x`.
+Computes the singular values of a matrix (or a stack of matrices) `x`.
 
 #### Parameters
 


### PR DESCRIPTION
This PR

-   adds a specification for computing singular values using singular value decomposition.

## Notes

-   This API deviates from current array libraries which overload the `svd` function modeled after NumPy via a `compute_uv` keyword. In that API, when `compute_uv` is `False`, only the singular values are returned. As discussed in a thread on [gh-114](https://github.com/data-apis/array-api/pull/114#issuecomment-801680942) and in a prior weekly meeting, in order to ensure API consistency with `eig` and `eigvals` and to limit polymorphism, splitting `svd` into `svd` and `svdvals` was deemed desirable. The former API is equivalent to `compute_uv=True`, while the latter is equivalent to `compute_uv=False`.