### PR TITLE
Add specification for computing the eigenvalues of a symmetric matrix (linalg: eigvalsh)

### DIFF
--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -112,8 +112,8 @@ TODO
 
 TODO
 
-(function-eigvalsh)=
-### eigvalsh(x, /, *, upper=False)
+(function-linalg-eigvalsh)=
+### linalg.eigvalsh(x, /, *, upper=False)
 
 Computes the eigenvalues of a symmetric matrix (or a stack of symmetric matrices) `x`.
 

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -107,8 +107,8 @@ TODO
 
 TODO
 
-(function-eigvalsh)=
-### eigvalsh()
+(function-eigvals)=
+### eigvals()
 
 TODO
 

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -112,6 +112,34 @@ TODO
 
 TODO
 
+(function-eigvalsh)=
+### eigvalsh(x, /, *, upper=False)
+
+Computes the eigenvalues of a symmetric matrix (or a stack of symmetric matrices) `x`.
+
+<!-- NOTE: once complex number support, each matrix must be Hermitian -->
+
+#### Parameters
+
+-   **x**: _&lt;array&gt;_
+
+    -   input array having shape `(..., M, M)` and whose innermost two dimensions form square matrices. Must have a floating-point data type.
+
+-   **upper**: _bool_
+
+    -   If `True`, use the upper-triangular part to compute the eigenvalues. If `False`, use the lower-triangular part to compute the eigenvalues. Default: `False`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the computed eigenvalues. The returned array must have shape `(..., M)` and have the same data type as `x`.
+
+```{note}
+
+Eigenvalue sort order is left unspecified.
+```
+
 (function-einsum)=
 ### einsum()
 


### PR DESCRIPTION
This PR

-   adds a specification for computing the eigenvalues of a real symmetric matrix.

## Notes

-   In contrast to NumPy's `UPLO` keyword pattern (following LAPACK), this PR follows [Torch v1.7.1 symeig](https://pytorch.org/docs/1.7.1/generated/torch.symeig.html) and uses an `upper` keyword to have better consistency with other linalg spec'd functions.