### PR TITLE
Clarify that boolean array indexing requirements

### DIFF
--- a/spec/API_specification/indexing.md
+++ b/spec/API_specification/indexing.md
@@ -160,7 +160,7 @@ _Rationale: this is consistent with bounds-checking for single-axis indexing. An
 
 ## Boolean Array Indexing
 
-An array must support indexing via a **single** `M`-dimensional boolean array `B` with shape `S1 = (s1, ..., sM)` according to the following rules. Let `A` be an `N`-dimensional array with shape `S2 = (s1, ..., sM, ..., sN)`.
+An array must support indexing where the **sole index** is an `M`-dimensional boolean array `B` with shape `S1 = (s1, ..., sM)` according to the following rules. Let `A` be an `N`-dimensional array with shape `S2 = (s1, ..., sM, ..., sN)`.
 
 -   If `N >= M`, then `A[B]` must replace the first `M` dimensions of `A` with a single dimension having a size equal to the number of `True` elements in `B`. The values in the resulting array must be in row-major (C-style order); this is equivalent to `A[nonzero(B)]`.
 


### PR DESCRIPTION
We only require that boolean array indexing be supported when the array is the
sole index. The previous text was ambiguous, and could be read as supporting
boolean arrays plus other non-array indices as part of a larger
multidimensional index. However, this is complicated in general, as it can
lead to some corner cases. See the discussion in #84.

With that being said, it is still an open discussion whether we should allow
some subset of boolean array indices along with other non-array indices in the
same index. I believe regardless, what we do not want to allow is:

- multiple boolean arrays (this requires broadcasting semantics, which are
  confusing for boolean arrays)
- boolean arrays and integers separated by a non-integer index (for example
  a[b, :, 0] where b is a boolean array). This is the corner case currently
  implemented by NumPy which we want to avoid for the standard.