### PR TITLE
Note that in-place operators should not change the dtype of the array

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -153,6 +153,9 @@ an array object supporting the following in-place Python operators:
 - `<<=`. May be implemented via `__ilshift__`.
 - `>>=`. May be implemented via `__irshift__`.
 
+An in-place operation must not change the dtype or shape of the in-place array
+as a result of {ref}`type-promotion` or {ref}`broadcasting`.
+
 ```{note}
 
 In-place operators must be supported as discussed in {ref}`copyview-mutability`.

--- a/spec/API_specification/type_promotion.md
+++ b/spec/API_specification/type_promotion.md
@@ -102,9 +102,9 @@ arrays must be supported for:
 - `array <op> scalar`
 - `scalar <op> array`
 
-where `<op>` is a built-in operator (see {ref}`operators` for operators
-supported by the array object) and `scalar` has a compatible type and value
-to the array dtype:
+where `<op>` is a built-in operator, including in-place operators (see
+{ref}`operators` for operators supported by the array object) and `scalar` has
+a compatible type and value to the array dtype:
 - Python `bool` for a `bool` array dtype,
 - a Python `int` within the [bounds](data-types) of the given dtype for integer array dtypes,
 - a Python `int` or `float` for floating-point array dtypes


### PR DESCRIPTION
Also note that the Python scalar rules do apply to in-place operators in
addition to normal operators.

The broadcasting rule here is duplicated in the broadcasting section. I'm
unsure if we should leave it duplicated or remove it so it is only mentioned
once.