### PR TITLE
Clarify that constants are Python scalars

### DIFF
--- a/spec/API_specification/constants.md
+++ b/spec/API_specification/constants.md
@@ -2,7 +2,9 @@
 
 > Array API specification for constants.
 
-A conforming implementation of the array API standard must provide and support the following constants.
+A conforming implementation of the array API standard must provide and support the following constants adhering to the following conventions.
+
+-   Each constant must have a Python numeric data type (i.e., `int`, `float`, or `complex`) and be provided as a Python scalar value.
 
 <!-- NOTE: please keep the constants in alphabetical order -->
 
@@ -11,7 +13,7 @@ A conforming implementation of the array API standard must provide and support t
 (constant-e)=
 ### e
 
-Euler's constant.
+IEEE 754 floating-point representation of Euler's constant.
 
 ```text
 e = 2.71828182845904523536028747135266249775724709369995...
@@ -30,7 +32,7 @@ IEEE 754 floating-point representation of Not a Number (`NaN`).
 (constant-pi)=
 ### pi
 
-The mathematical constant `π`.
+IEEE 754 floating-point representation of the mathematical constant `π`.
 
 ```text
 pi = 3.1415926535897932384626433...

--- a/spec/API_specification/constants.md
+++ b/spec/API_specification/constants.md
@@ -4,7 +4,7 @@
 
 A conforming implementation of the array API standard must provide and support the following constants adhering to the following conventions.
 
--   Each constant must have a Python numeric data type (i.e., `int`, `float`, or `complex`) and be provided as a Python scalar value.
+-   Each constant must have a Python floating-data type (i.e., `float`) and be provided as a Python scalar value.
 
 <!-- NOTE: please keep the constants in alphabetical order -->
 

--- a/spec/API_specification/constants.md
+++ b/spec/API_specification/constants.md
@@ -4,7 +4,7 @@
 
 A conforming implementation of the array API standard must provide and support the following constants adhering to the following conventions.
 
--   Each constant must have a Python floating-data type (i.e., `float`) and be provided as a Python scalar value.
+-   Each constant must have a Python floating-point data type (i.e., `float`) and be provided as a Python scalar value.
 
 <!-- NOTE: please keep the constants in alphabetical order -->
 


### PR DESCRIPTION
This PR

-   clarifies that constants are Python scalars.

Currently, the spec does not indicate how the constants should be exposed (e.g., Python scalars, zero-dimensional arrays, etc). This PR aims to remedy this.

The choice of Python scalar, rather than as a zero-dimensional array with a dtype described in the specification, stems from greater flexibility in how these constants participate in operations.

For example, according to the current specification, `pi` would be truncated when participating in an operation with an array having an integer dtype, which may not be the case if `pi` was a zero-dimensional `float64` array and participating in mixed-type promotion.

Further, as a Python scalar, `pi` would be converted to a `float32` array when participating in an operation with an array having a `float32` dtype, which would not be the case if `pi` was a zero-dimensional `float64` array.