### PR TITLE
Clarify guidance on operations having data-dependent output shapes

### DIFF
--- a/spec/API_specification/indexing.md
+++ b/spec/API_specification/indexing.md
@@ -163,7 +163,7 @@ _Rationale: this is consistent with bounds-checking for single-axis indexing. An
 :::{admonition} Data-dependent output shape
 :class: important
 
-For common boolean array use cases (e.g., using a dynamically-sized boolean array mask to filter the values of another array), the shape of the output array is data-dependent; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find boolean array indexing difficult to implement. Accordingly, such libraries may choose to omit boolean array indexing. See {ref}`data-dependent-output-shapes` section for more details.
+For common boolean array use cases (e.g., using a dynamically-sized boolean array mask to filter the values of another array), the shape of the output array is data-dependent; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find boolean array indexing difficult to implement. Accordingly, such libraries may choose to omit boolean array indexing. See {ref}`data-dependent-output-shapes` section for more details.
 :::
 
 An array must support indexing where the **sole index** is an `M`-dimensional boolean array `B` with shape `S1 = (s1, ..., sM)` according to the following rules. Let `A` be an `N`-dimensional array with shape `S2 = (s1, ..., sM, ..., sN)`.

--- a/spec/API_specification/indexing.md
+++ b/spec/API_specification/indexing.md
@@ -160,6 +160,12 @@ _Rationale: this is consistent with bounds-checking for single-axis indexing. An
 
 ## Boolean Array Indexing
 
+:::{admonition} Data-dependent output shape
+:class: important
+
+For common boolean array use cases (e.g., using a dynamically-sized boolean array mask to filter the values of another array), the shape of the output array is data-dependent; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find boolean array indexing difficult to implement. Accordingly, such libraries may choose to omit boolean array indexing. See {ref}`data-dependent-output-shapes` section for more details.
+:::
+
 An array must support indexing where the **sole index** is an `M`-dimensional boolean array `B` with shape `S1 = (s1, ..., sM)` according to the following rules. Let `A` be an `N`-dimensional array with shape `S2 = (s1, ..., sM, ..., sN)`.
 
 -   If `N >= M`, then `A[B]` must replace the first `M` dimensions of `A` with a single dimension having a size equal to the number of `True` elements in `B`. The values in the resulting array must be in row-major (C-style order); this is equivalent to `A[nonzero(B)]`.

--- a/spec/API_specification/searching_functions.md
+++ b/spec/API_specification/searching_functions.md
@@ -72,7 +72,7 @@ Returns the indices of the minimum values along a specified axis. When the minim
 :::{admonition} Data-dependent output shape
 :class: important
 
-The shape of the output array for this function depends on the data values in the input array; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
+The shape of the output array for this function depends on the data values in the input array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
 :::
 
 Returns the indices of the array elements which are non-zero.

--- a/spec/API_specification/searching_functions.md
+++ b/spec/API_specification/searching_functions.md
@@ -72,7 +72,7 @@ Returns the indices of the minimum values along a specified axis. When the minim
 :::{admonition} Data-dependent output shape
 :class: important
 
-The shape of the output array for this function depends on the data values in the input array, hence it can be difficult to implement for libraries that build computation graphs for arrays without knowing their values. See {ref}`indexing` section for more details.
+The shape of the output array for this function depends on the data values in the input array; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`indexing` section for more details.
 :::
 
 Returns the indices of the array elements which are non-zero.

--- a/spec/API_specification/searching_functions.md
+++ b/spec/API_specification/searching_functions.md
@@ -72,7 +72,7 @@ Returns the indices of the minimum values along a specified axis. When the minim
 :::{admonition} Data-dependent output shape
 :class: important
 
-The shape of the output array for this function depends on the data values in the input array; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`indexing` section for more details.
+The shape of the output array for this function depends on the data values in the input array; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
 :::
 
 Returns the indices of the array elements which are non-zero.

--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -18,7 +18,7 @@ A conforming implementation of the array API standard must provide and support t
 :::{admonition} Data-dependent output shape
 :class: important
 
-The shape of the output array for this function depends on the data values in the input array, hence it can be difficult to implement for libraries that build computation graphs for arrays without knowing their values. See {ref}`indexing` section for more details.
+The shapes of one or more of output arrays for this function depend on the data values in the input array; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`indexing` section for more details.
 :::
 
 Returns the unique elements of an input array `x`.

--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -18,7 +18,7 @@ A conforming implementation of the array API standard must provide and support t
 :::{admonition} Data-dependent output shape
 :class: important
 
-The shapes of one or more of output arrays for this function depend on the data values in the input array; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
+The shapes of one or more of output arrays for this function depend on the data values in the input array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
 :::
 
 Returns the unique elements of an input array `x`.

--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -18,7 +18,7 @@ A conforming implementation of the array API standard must provide and support t
 :::{admonition} Data-dependent output shape
 :class: important
 
-The shapes of one or more of output arrays for this function depend on the data values in the input array; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`indexing` section for more details.
+The shapes of one or more of output arrays for this function depend on the data values in the input array; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
 :::
 
 Returns the unique elements of an input array `x`.

--- a/spec/design_topics/data_dependent_output_shapes.md
+++ b/spec/design_topics/data_dependent_output_shapes.md
@@ -2,3 +2,14 @@
 
 # Data-dependent output shapes
 
+Array libraries which build array computation graphs commonly employ static memory allocation techniques for performance optimization. In order to efficiently perform static memory allocation, such libraries must be able to infer array sizes during ahead-of-time (AOT) compilation. Functions and operations which are value-dependent present difficulties for such libraries, as array sizes cannot be inferred AOT without also knowing the contents of the respective arrays.
+
+While value-dependent functions and operations are not impossible for array computation graph libraries to implement, this specification does not want to impose and undue burden on such libraries and permits omission of value-dependent operations. All other array libraries are expected, however, to implement the value-dependent operations included in this specification in order to be array specification compliant.
+
+Value-dependent operations are demarcated in this specification using an admonition similar to the following:
+
+:::{admonition} Data-dependent output shape
+:class: important
+
+The shape of the output array for this function/operation depends on the data values in the input array; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find this function/operation difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
+:::

--- a/spec/design_topics/data_dependent_output_shapes.md
+++ b/spec/design_topics/data_dependent_output_shapes.md
@@ -2,7 +2,7 @@
 
 # Data-dependent output shapes
 
-Array libraries which build array computation graphs commonly employ static analysis that relies upon known shapes. For example, JAX requires known array sizes when compiling code, in order to perform static memory allocation. Functions and operations which are value-dependent present difficulties for such libraries, as array sizes cannot be inferred AOT without also knowing the contents of the respective arrays.
+Array libraries which build array computation graphs commonly employ static analysis that relies upon known shapes. For example, JAX requires known array sizes when compiling code, in order to perform static memory allocation. Functions and operations which are value-dependent present difficulties for such libraries, as array sizes cannot be inferred ahead of time without also knowing the contents of the respective arrays.
 
 While value-dependent functions and operations are not impossible for array computation graph libraries to implement, this specification does not want to impose an undue burden on such libraries and permits omission of value-dependent operations. All other array libraries are expected, however, to implement the value-dependent operations included in this specification in order to be array specification compliant.
 

--- a/spec/design_topics/data_dependent_output_shapes.md
+++ b/spec/design_topics/data_dependent_output_shapes.md
@@ -2,7 +2,7 @@
 
 # Data-dependent output shapes
 
-Array libraries which build array computation graphs commonly employ static memory allocation techniques for performance optimization. In order to efficiently perform static memory allocation, such libraries must be able to infer array sizes during ahead-of-time (AOT) compilation. Functions and operations which are value-dependent present difficulties for such libraries, as array sizes cannot be inferred AOT without also knowing the contents of the respective arrays.
+Array libraries which build array computation graphs commonly employ static analysis that relies upon known shapes. For example, JAX requires known array sizes when compiling code, in order to perform static memory allocation. Functions and operations which are value-dependent present difficulties for such libraries, as array sizes cannot be inferred AOT without also knowing the contents of the respective arrays.
 
 While value-dependent functions and operations are not impossible for array computation graph libraries to implement, this specification does not want to impose an undue burden on such libraries and permits omission of value-dependent operations. All other array libraries are expected, however, to implement the value-dependent operations included in this specification in order to be array specification compliant.
 

--- a/spec/design_topics/data_dependent_output_shapes.md
+++ b/spec/design_topics/data_dependent_output_shapes.md
@@ -4,7 +4,7 @@
 
 Array libraries which build array computation graphs commonly employ static memory allocation techniques for performance optimization. In order to efficiently perform static memory allocation, such libraries must be able to infer array sizes during ahead-of-time (AOT) compilation. Functions and operations which are value-dependent present difficulties for such libraries, as array sizes cannot be inferred AOT without also knowing the contents of the respective arrays.
 
-While value-dependent functions and operations are not impossible for array computation graph libraries to implement, this specification does not want to impose and undue burden on such libraries and permits omission of value-dependent operations. All other array libraries are expected, however, to implement the value-dependent operations included in this specification in order to be array specification compliant.
+While value-dependent functions and operations are not impossible for array computation graph libraries to implement, this specification does not want to impose an undue burden on such libraries and permits omission of value-dependent operations. All other array libraries are expected, however, to implement the value-dependent operations included in this specification in order to be array specification compliant.
 
 Value-dependent operations are demarcated in this specification using an admonition similar to the following:
 

--- a/spec/design_topics/data_dependent_output_shapes.md
+++ b/spec/design_topics/data_dependent_output_shapes.md
@@ -1,0 +1,4 @@
+(data-dependent-output-shapes)=
+
+# Data-dependent output shapes
+

--- a/spec/design_topics/data_dependent_output_shapes.md
+++ b/spec/design_topics/data_dependent_output_shapes.md
@@ -2,14 +2,14 @@
 
 # Data-dependent output shapes
 
-Array libraries which build array computation graphs commonly employ static analysis that relies upon known shapes. For example, JAX requires known array sizes when compiling code, in order to perform static memory allocation. Functions and operations which are value-dependent present difficulties for such libraries, as array sizes cannot be inferred ahead of time without also knowing the contents of the respective arrays.
+Array libraries which build computation graphs commonly employ static analysis that relies upon known shapes. For example, JAX requires known array sizes when compiling code, in order to perform static memory allocation. Functions and operations which are value-dependent present difficulties for such libraries, as array sizes cannot be inferred ahead of time without also knowing the contents of the respective arrays.
 
-While value-dependent functions and operations are not impossible for array computation graph libraries to implement, this specification does not want to impose an undue burden on such libraries and permits omission of value-dependent operations. All other array libraries are expected, however, to implement the value-dependent operations included in this specification in order to be array specification compliant.
+While value-dependent functions and operations are not impossible to implement for array libraries which build computation graphs, this specification does not want to impose an undue burden on such libraries and permits omission of value-dependent operations. All other array libraries are expected, however, to implement the value-dependent operations included in this specification in order to be array specification compliant.
 
 Value-dependent operations are demarcated in this specification using an admonition similar to the following:
 
 :::{admonition} Data-dependent output shape
 :class: important
 
-The shape of the output array for this function/operation depends on the data values in the input array; hence, libraries that build array computation graphs (e.g., JAX, Dask, etc.) may find this function/operation difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
+The shape of the output array for this function/operation depends on the data values in the input array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function/operation difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
 :::

--- a/spec/design_topics/index.rst
+++ b/spec/design_topics/index.rst
@@ -6,6 +6,7 @@ Design topics & constraints
    :maxdepth: 1
 
    copies_views_and_mutation
+   data_dependent_output_shapes
    data_interchange
    device_support
    static_typing


### PR DESCRIPTION
This PR supersedes [gh-168](https://github.com/data-apis/array-api/pull/168) by @steff456.

In summary, this PR

-   clarifies guidance on functions/operations having data-dependent output shapes.
-   grants permission to array libraries which build array computation graphs to omit such operations.

## Notes

-  I messed up the Git history of [gh-168](https://github.com/data-apis/array-api/pull/168) when attempting to make updates. 😓

