### PR TITLE
PR: Add smallest normal to finfo class

### DIFF
--- a/spec/API_specification/data_type_functions.md
+++ b/spec/API_specification/data_type_functions.md
@@ -96,7 +96,7 @@ Machine limits for floating-point data types.
         -   **min**: _float_
             -   smallest representable number.
         -   **smallest_normal**: _float_
-            -   smallest positive floating point number with full precision.
+            -   smallest positive floating-point number with full precision.
 
 (function-iinfo)=
 ### iinfo(type, /)

--- a/spec/API_specification/data_type_functions.md
+++ b/spec/API_specification/data_type_functions.md
@@ -95,6 +95,8 @@ Machine limits for floating-point data types.
             -   largest representable number.
         -   **min**: _float_
             -   smallest representable number.
+        -   **smallest_normal**: _float_
+            -   smallest positive floating point number with full precision.
 
 (function-iinfo)=
 ### iinfo(type, /)


### PR DESCRIPTION
This PR adds the `smallest_normal` attribute to the finfo class taking into account the discussion in issue #131. 