### PR TITLE
Clarify `eig` and `eigvals` todos

### DIFF
--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -177,7 +177,7 @@ Returns the specified diagonals. If `x` has more than two dimensions, then the a
 (function-linalg-eig)=
 ### linalg.eig()
 
-TODO
+_TODO: this requires complex number support to be added to the specification._
 
 (function-linalg-eigh)=
 ### linalg.eigh(x, /, *, upper=False)
@@ -215,7 +215,7 @@ Eigenvalue sort order is left unspecified.
 (function-linalg-eigvals)=
 ### linalg.eigvals()
 
-TODO
+_TODO: this requires complex number support to be added to the specification._
 
 (function-linalg-eigvalsh)=
 ### linalg.eigvalsh(x, /, *, upper=False)


### PR DESCRIPTION
This PR

-   updates the TODOs to indicate that the function `eig` and `eigvals` are dependent on complex number support being added to the specification.