### PR TITLE
Require unique counts array to be default integer dtype

### DIFF
--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -59,6 +59,4 @@ Returns the unique elements of an input array `x`.
 
         -   **counts**: _&lt;array&gt;_
 
-            -   an array containing the number of times each unique element occurs in `x`.
-
-                _TODO: should this be `int64`? This probably makes sense for most hardware; however, may be undesirable for older hardware and/or embedded systems._
+            -   an array containing the number of times each unique element occurs in `x`. The returned array must have the default integer data type.


### PR DESCRIPTION
This PR

-   requires that the array containing unique counts be the default integer dtype. This change is consistent with guidance included elsewhere in the specification, such as for index arrays.