### PR TITLE
Remove upper keyword from `eigh` and `eigvalsh`.

### DIFF
--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -180,7 +180,7 @@ Returns the specified diagonals. If `x` has more than two dimensions, then the a
 _TODO: this requires complex number support to be added to the specification._
 
 (function-linalg-eigh)=
-### linalg.eigh(x)
+### linalg.eigh(x, /)
 
 Returns the eigenvalues and eigenvectors of a symmetric matrix (or a stack of symmetric matrices) `x`.
 
@@ -214,7 +214,7 @@ Eigenvalue sort order is left unspecified.
 _TODO: this requires complex number support to be added to the specification._
 
 (function-linalg-eigvalsh)=
-### linalg.eigvalsh(x)
+### linalg.eigvalsh(x, /)
 
 Computes the eigenvalues of a symmetric matrix (or a stack of symmetric matrices) `x`.
 

--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -180,7 +180,7 @@ Returns the specified diagonals. If `x` has more than two dimensions, then the a
 _TODO: this requires complex number support to be added to the specification._
 
 (function-linalg-eigh)=
-### linalg.eigh(x, /, *, upper=False)
+### linalg.eigh(x)
 
 Returns the eigenvalues and eigenvectors of a symmetric matrix (or a stack of symmetric matrices) `x`.
 
@@ -191,10 +191,6 @@ Returns the eigenvalues and eigenvectors of a symmetric matrix (or a stack of sy
 -   **x**: _&lt;array&gt;_
 
     -   input array having shape `(..., M, M)` and whose innermost two dimensions form square matrices. Must have a floating-point data type.
-
--   **upper**: _bool_
-
-    -   If `True`, use the upper-triangular part to compute the eigenvalues and eigenvectors. If `False`, use the lower-triangular part to compute the eigenvalues and eigenvectors. Default: `False`.
 
 #### Returns
 
@@ -218,7 +214,7 @@ Eigenvalue sort order is left unspecified.
 _TODO: this requires complex number support to be added to the specification._
 
 (function-linalg-eigvalsh)=
-### linalg.eigvalsh(x, /, *, upper=False)
+### linalg.eigvalsh(x)
 
 Computes the eigenvalues of a symmetric matrix (or a stack of symmetric matrices) `x`.
 
@@ -229,10 +225,6 @@ Computes the eigenvalues of a symmetric matrix (or a stack of symmetric matrices
 -   **x**: _&lt;array&gt;_
 
     -   input array having shape `(..., M, M)` and whose innermost two dimensions form square matrices. Must have a floating-point data type.
-
--   **upper**: _bool_
-
-    -   If `True`, use the upper-triangular part to compute the eigenvalues. If `False`, use the lower-triangular part to compute the eigenvalues. Default: `False`.
 
 #### Returns
 


### PR DESCRIPTION
As per the title

Fixes #217 

cc @rgommers @asmeurer @kgryte 