### PR TITLE
Some improvements to type hints

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -780,7 +780,7 @@ The `matmul` function must implement the same semantics as the built-in `@` oper
 
 -   **self**: _&lt;array&gt;_
 
-    -   array instance. Should have a numeric data type. Must have at least one dimension. If `self` is one-dimensional having shape `(M)` and `other` has more than one dimension, `self` must be promoted to a two-dimensional array by prepending `1` to its dimensions (i.e., must have shape `(1, M)`). After matrix multiplication, the prepended dimensions in the returned array must be removed. If `self` has more than one dimension (including after vector-to-matrix promotion), `self` must be compatible with `other` (see {ref}`broadcasting`). If `self` has shape `(..., M, K)`, the innermost two dimensions form matrices on which to perform matrix multiplication. 
+    -   array instance. Should have a numeric data type. Must have at least one dimension. If `self` is one-dimensional having shape `(M)` and `other` has more than one dimension, `self` must be promoted to a two-dimensional array by prepending `1` to its dimensions (i.e., must have shape `(1, M)`). After matrix multiplication, the prepended dimensions in the returned array must be removed. If `self` has more than one dimension (including after vector-to-matrix promotion), `self` must be compatible with `other` (see {ref}`broadcasting`). If `self` has shape `(..., M, K)`, the innermost two dimensions form matrices on which to perform matrix multiplication.
 
 -   **other**: _&lt;array&gt;_
 
@@ -809,7 +809,7 @@ The `matmul` function must implement the same semantics as the built-in `@` oper
 
 -   if either `self` or `other` is a zero-dimensional array.
 -   if `self` is a one-dimensional array having shape `(N)`, `other` is a one-dimensional array having shape `(M)`, and `N != M`.
--   if `self` is an array having shape `(..., M, K)`, `other` is an array having shape `(..., L, N)`, and `K != L`. 
+-   if `self` is an array having shape `(..., M, K)`, `other` is an array having shape `(..., L, N)`, and `K != L`.
 
 (method-__mod__)=
 ### \_\_mod\_\_(self, other, /)
@@ -1066,7 +1066,7 @@ Sets `self[key]` to `value`.
 
 #### Parameters
 
--   **self**: _&lt;array;&gt;_
+-   **self**: _&lt;array&gt;_
 
     -   array instance.
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -57,7 +57,7 @@ Convert the input to an array.
 
 #### Parameters
 
--   **obj**: _Union\[ float, NestedSequence\[ bool | int | float ], SupportsDLPack, SupportsBufferProtocol ]_
+-   **obj**: _Union\[ &lt;array&gt;, float, NestedSequence\[ bool | int | float ], SupportsDLPack, SupportsBufferProtocol ]_
 
     -   Object to be converted to an array. Can be a Python scalar, a (possibly nested) sequence of Python scalars, or an object supporting DLPack or the Python buffer protocol.
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -57,7 +57,7 @@ Convert the input to an array.
 
 #### Parameters
 
--   **obj**: _Union\[ &lt;array&gt;, float, NestedSequence\[ bool | int | float ], SupportsDLPack, SupportsBufferProtocol ]_
+-   **obj**: _Union\[ &lt;array&gt;, bool, int, float, NestedSequence\[ bool | int | float ], SupportsDLPack, SupportsBufferProtocol ]_
 
     -   Object to be converted to an array. Can be a Python scalar, a (possibly nested) sequence of Python scalars, or an object supporting DLPack or the Python buffer protocol.
 

--- a/spec/API_specification/manipulation_functions.md
+++ b/spec/API_specification/manipulation_functions.md
@@ -19,7 +19,7 @@ Joins a sequence of arrays along an existing axis.
 
 #### Parameters
 
--   **arrays**: _Tuple\[ &lt;array&gt;, ... ]_
+-   **arrays**: _Union\[Tuple\[ &lt;array&gt;, ... ], List\[ &lt;array&gt; ] ]_
 
     -   input arrays to join. The arrays must have the same shape, except in the dimension specified by `axis`.
 
@@ -154,7 +154,7 @@ Joins a sequence of arrays along a new axis.
 
 #### Parameters
 
--   **arrays**: _Tuple\[ &lt;array&gt;, ... ]_
+-   **arrays**: _Union\[Tuple\[ &lt;array&gt;, ... ], List\[ &lt;array&gt; ] ]_
 
     -   input arrays to join. Each array must have the same shape.
 

--- a/spec/API_specification/searching_functions.md
+++ b/spec/API_specification/searching_functions.md
@@ -27,7 +27,7 @@ Returns the indices of the maximum values along a specified axis. When the maxim
 
     -   input array.
 
--   **axis**: _int_
+-   **axis**: _Optional\[ int ]_
 
     -   axis along which to search. If `None`, the function must return the index of the maximum value of the flattened array. Default: `None`.
 
@@ -52,7 +52,7 @@ Returns the indices of the minimum values along a specified axis. When the minim
 
     -   input array.
 
--   **axis**: _int_
+-   **axis**: _Optional\[ int ]_
 
     -   axis along which to search. If `None`, the function must return the index of the minimum value of the flattened array. Default: `None`.
 

--- a/spec/API_specification/searching_functions.md
+++ b/spec/API_specification/searching_functions.md
@@ -106,4 +106,4 @@ Returns elements chosen from `x1` or `x2` depending on `condition`.
 
 -   **out**: _&lt;array&gt;_
 
-    -   an array with elements from `x1` where `condition` is `True`, and elements from `x2` elsewhere. The returned array must have a data type determined by {ref}`type-promotion` rules.
+    -   an array with elements from `x1` where `condition` is `True`, and elements from `x2` elsewhere. The returned array must have a data type determined by {ref}`type-promotion` rules with the arrays `x1` and `x2`.

--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -201,7 +201,7 @@ Returns the eigenvalues and eigenvectors of a symmetric matrix (or a stack of sy
 -   **out**: _Tuple\[ &lt;array&gt; ]_
 
     -   a namedtuple (`e`, `v`) whose
-    
+
         -   first element must have shape `(..., M)` and consist of computed eigenvalues.
         -   second element must have shape `(..., M, M)`and have the columns of the inner most matrices contain the computed eigenvectors.
 
@@ -291,7 +291,7 @@ Returns the least-squares solution to a linear matrix equation `Ax = b`.
 -   **out**: _Tuple\[ &lt;array&gt;, &lt;array&gt;, &lt;array&gt;, &lt;array&gt; ]_
 
     -   a namedtuple `(x, residuals, rank, s)` whose
-    
+
         -   first element must have the field name `x` and must be an array containing the least-squares solution for each `MxN` matrix in `x1`. The array containing the solutions must have shape `(N, K)` and must have a floating-point data type determined by {ref}`type-promotion`.
         -   second element must have the field name `residuals` and must be an array containing the sum of squares residuals (i.e., the squared Euclidean 2-norm for each column in `b - Ax`). The array containing the residuals must have shape `(K,)` and must have a floating-point data type determined by {ref}`type-promotion`.
         -   third element must have the field name `rank` and must be an array containing the effective rank of each `MxN` matrix. The array containing the ranks must have shape `shape(x1)[:-2]` and must have an integer data type.
@@ -300,7 +300,7 @@ Returns the least-squares solution to a linear matrix equation `Ax = b`.
 (function-linalg-matmul)=
 ### linalg.matmul(x1, x2, /)
 
-Alias for {ref}`function-matmul`. 
+Alias for {ref}`function-matmul`.
 
 (function-linalg-matrix_power)=
 ### linalg.matrix_power(x, n, /)
@@ -458,7 +458,7 @@ Computes the (Moore-Penrose) pseudo-inverse of a matrix (or a stack of square ma
     -   input array having shape `(..., M, N)` and whose innermost two dimensions form `MxN` matrices. Should have a floating-point data type.
 
 -   **rtol**: _Optional\[ Union\[ float, &lt;array&gt; ] ]_
-    
+
     -   relative tolerance for small singular values. Singular values less than or equal to `rtol * largest_singular_value` are set to zero. If a `float`, the value is equivalent to a zero-dimensional array having a floating-point data type determined by {ref}`type-promotion` (as applied to `x`) and must be broadcast against each matrix. If an `array`, must have a floating-point data type and must be compatible with `shape(x)[:-2]` (see {ref}`broadcasting`). If `None`, the default value is `max(M, N) * eps`, where `eps` must be the machine epsilon associated with the floating-point data type determined by {ref}`type-promotion` (as applied to `x`). Default: `None`.
 
 #### Returns
@@ -519,10 +519,10 @@ The purpose of this function is to calculate the determinant more accurately whe
 -   **out**: _Tuple\[ &lt;array&gt;, &lt;array&gt; ]_
 
     -   a namedtuple (`sign`, `logabsdet`) whose
-    
+
         -   first element must be an array containing a number representing the sign of the determinant for each square matrix.
         -   second element must be an array containing the determinant for each square matrix.
-    
+
         For a real matrix, the sign of the determinant must be either `1`, `0`, or `-1`. If a determinant is zero, then the corresponding `sign` must be `0` and `logabsdet` must be `-infinity`. In all cases, the determinant must be equal to `sign * exp(logsabsdet)`.
 
         Each returned array must have shape `shape(x)[:-2]` and a floating-point data type determined by {ref}`type-promotion`.

--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -478,7 +478,7 @@ Computes the qr factorization of a matrix (or a stack of matrices), where `q` is
 
     -   input array having shape `(..., M, N)` and whose innermost two dimensions form `MxN` matrices. Should have a floating-point data type.
 
--   **mode**: _str_
+-   **mode**: _Literal\[ 'reduced', 'complete' ]_
 
     -   factorization mode. Should be one of the following modes:
 

--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -565,20 +565,15 @@ Computes the singular value decomposition `A = USV` of a matrix (or a stack of m
 
 #### Returns
 
--   **out**: _Union\[ &lt;array&gt;, Tuple\[ &lt;array&gt;, ... ] ]_
+-   **out**: _Tuple\[ &lt;array&gt;, &lt;array&gt;, &lt;array&gt; ]_
 
     -   a namedtuple `(u, s, v)` whose
-    
+
         -   first element must be an array whose shape depends on the value of `full_matrices` and contain unitary array(s) (i.e., the left singular vectors). The left singular vectors must be stored as columns. If `full_matrices` is `True`, the array must have shape `(..., M, M)`. If `full_matrices` is `False`, the array must have shape `(..., M, K)`, where `K = min(M, N)`. The first `x.ndim-2` dimensions must have the same shape as those of the input `x`.
         -   second element must be an array with shape `(..., K)` that contains the vector(s) of singular values of length `K`. For each vector, the singular values must be sorted in descending order by magnitude, such that `s[..., 0]` is the largest value, `s[..., 1]` is the second largest value, et cetera. The first `x.ndim-2` dimensions must have the same shape as those of the input `x`.
         -   third element must be an array whose shape depends on the value of `full_matrices` and contain unitary array(s) (i.e., the right singular vectors). The right singular vectors must be stored as rows (i.e., the array is the adjoint). If `full_matrices` is `True`, the array must have shape `(..., N, N)`. If `full_matrices` is `False`, the array must have shape `(..., K, N)` where `K = min(M, N)`. The first `x.ndim-2` dimensions must have the same shape as those of the input `x`.
 
         Each returned array must have the same floating-point data type as `x`.
-
-(function-linalg-tensordot)=
-### linalg.tensordot(x1, x2, /, *, axes=2)
-
-Alias for {ref}`function-tensordot`.
 
 (function-linalg-svdvals)=
 ### linalg.svdvals(x, /)
@@ -596,6 +591,11 @@ Computes the singular values of a matrix (or a stack of matrices) `x`.
 -   **out**: _Union\[ &lt;array&gt;, Tuple\[ &lt;array&gt;, ... ] ]_
 
     -   an array with shape `(..., K)` that contains the vector(s) of singular values of length `K`. For each vector, the singular values must be sorted in descending order by magnitude, such that `s[..., 0]` is the largest value, `s[..., 1]` is the second largest value, et cetera. The first `x.ndim-2` dimensions must have the same shape as those of the input `x`. The returned array must have the same floating-point data type as `x`.
+
+(function-linalg-tensordot)=
+### linalg.tensordot(x1, x2, /, *, axes=2)
+
+Alias for {ref}`function-tensordot`.
 
 (function-linalg-trace)=
 ### linalg.trace(x, /, *, axis1=0, axis2=1, offset=0)


### PR DESCRIPTION
And other small fixes. The type hint fixes come from https://github.com/numpy/numpy/pull/18585, except for the `Literal` change in qr which comes from me. 

One thing that I didn't address here is the type for the `stream` argument in `__dlpack__`. See this discussion https://github.com/numpy/numpy/pull/18585#discussion_r659026425.