### PR TITLE
Add i8 to the mixed-type promotion table

### DIFF
--- a/spec/API_specification/type_promotion.md
+++ b/spec/API_specification/type_promotion.md
@@ -70,6 +70,7 @@ where
 | **i1** | i2 | i4 | i8 |
 | **i2** | i2 | i4 | i8 |
 | **i4** | i4 | i4 | i8 |
+| **i8** | i8 | i8 | i8 |
 
 ### Floating-point type promotion table
 


### PR DESCRIPTION
It was already implied by the graph at the top of the page. 