### PR TITLE
Specify input dtypes for the statistical functions

### DIFF
--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -24,7 +24,7 @@ Calculates the maximum value of the input array `x`.
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 -   **axis**: _Optional\[ Union\[ int, Tuple\[ int, ... ] ] ]_
 
@@ -49,7 +49,7 @@ Calculates the arithmetic mean of the input array `x`.
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 -   **axis**: _Optional\[ Union\[ int, Tuple\[ int, ... ] ] ]_
 
@@ -74,7 +74,7 @@ Calculates the minimum value of the input array `x`.
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 -   **axis**: _Optional\[ Union\[ int, Tuple\[ int, ... ] ] ]_
 
@@ -99,7 +99,7 @@ Calculates the product of input array `x` elements.
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 -   **axis**: _Optional\[ Union\[ int, Tuple\[ int, ... ] ] ]_
 
@@ -124,7 +124,7 @@ Calculates the standard deviation of the input array `x`.
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 -   **axis**: _Optional\[ Union\[ int, Tuple\[ int, ... ] ] ]_
 
@@ -153,7 +153,7 @@ Calculates the sum of the input array `x`.
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 -   **axis**: _Optional\[ Union\[ int, Tuple\[ int, ... ] ] ]_
 
@@ -178,7 +178,7 @@ Calculates the variance of the input array `x`.
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a floating-point data type.
 
 -   **axis**: _Optional\[ Union\[ int, Tuple\[ int, ... ] ] ]_
 


### PR DESCRIPTION
Functions like mean() that perform divisions require floating-point inputs.
All other functions require numeric inputs.

This was mentioned in #232 but does not fix the main question of that issue
(the behavior of the statistical functions on empty arrays). I can implement
that as well if we come to an agreement about what it should say.