### PR TITLE
Replace lstsq with lstsq_solve

### DIFF
--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -267,8 +267,8 @@ Computes the multiplicative inverse of a square matrix (or a stack of square mat
 
     -   an array containing the multiplicative inverses. The returned array must have a floating-point data type determined by {ref}`type-promotion` and must have the same shape as `x`.
 
-(function-linalg-lstsq)=
-### linalg.lstsq(x1, x2, /, *, rtol=None)
+(function-linalg-lstsq-solve)=
+### linalg.lstsq_solve(x1, x2, /, *, rtol=None)
 
 Returns the least-squares solution to a linear matrix equation `Ax = b`.
 
@@ -288,14 +288,9 @@ Returns the least-squares solution to a linear matrix equation `Ax = b`.
 
 #### Returns
 
--   **out**: _Tuple\[ &lt;array&gt;, &lt;array&gt;, &lt;array&gt;, &lt;array&gt; ]_
+-   **out**: _&lt;array&gt;_
 
-    -   a namedtuple `(x, residuals, rank, s)` whose
-
-        -   first element must have the field name `x` and must be an array containing the least-squares solution for each `MxN` matrix in `x1`. The array containing the solutions must have shape `(N, K)` and must have a floating-point data type determined by {ref}`type-promotion`.
-        -   second element must have the field name `residuals` and must be an array containing the sum of squares residuals (i.e., the squared Euclidean 2-norm for each column in `b - Ax`). The array containing the residuals must have shape `(K,)` and must have a floating-point data type determined by {ref}`type-promotion`.
-        -   third element must have the field name `rank` and must be an array containing the effective rank of each `MxN` matrix. The array containing the ranks must have shape `shape(x1)[:-2]` and must have an integer data type.
-        -   fourth element must have the field name `s` and must be an array containing the singular values for each `MxN` matrix in `x1`. The array containing the singular values must have shape `(..., min(M, N))` and must have a floating-point data type determined by {ref}`type-promotion`.
+    -  an array containing the least-squares solution for each `MxN` matrix in `x1`. The array containing the solutions must have shape `(N, K)` and must have a floating-point data type determined by {ref}`type-promotion`.
 
 (function-linalg-matmul)=
 ### linalg.matmul(x1, x2, /)


### PR DESCRIPTION
This PR

-   resolves [gh-227](https://github.com/data-apis/array-api/issues/227) by removing `linalg.lstsq` and replacing with `linalg.lstsq_solve`.
-   in contrast to `linalg.lstsq`, `linalg.lstsq_solve` **only** returns the least-squares solution. For singular values, rank, and residuals, users would be required to use other APIs already present in the specification (e.g., `linalg.svdvals`, `linalg.matrix_rank`, etc). This is consistent with linear algebra design principles in which functionality should be orthogonal and not duplicated across APIs.

## Notes

-   the name `lstsq_solve` was suggested by @Lezcano as an alternative name for `lstsq` only returning the solutions which does not conflict with existing API names in NumPy and SciPy (e.g., `least_squares`, `lsqr`, etc).