### PR TITLE
Fix the logaddexp special cases

### DIFF
--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -944,8 +944,9 @@ each element `x1_i` of the input array `x1` with the respective element `x2_i` o
 
 For floating-point operands,
 
-- If either `x1_i` or `x2_i` is `NaN`, the result is `NaN`.
-- If either `x1_i` or `x2_i` is `+infinity`, the result is `+infinity`.
+-   If either `x1_i` or `x2_i` is `NaN`, the result is `NaN`.
+-   If `x1_i` is `+infinity` and `x2_i` is not `NaN`, the result is `+infinity`.
+-   If `x1_i` is not `NaN` and `x2_i` is `+infinity`, the result is `+infinity`.
 
 #### Parameters
 


### PR DESCRIPTION
As previously written, they would fail in the test suite because of ambiguity
about the value of logaddexp(nan, inf).