### PR TITLE
Remove `linalg.lstsq`

### DIFF
--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -267,36 +267,6 @@ Computes the multiplicative inverse of a square matrix (or a stack of square mat
 
     -   an array containing the multiplicative inverses. The returned array must have a floating-point data type determined by {ref}`type-promotion` and must have the same shape as `x`.
 
-(function-linalg-lstsq)=
-### linalg.lstsq(x1, x2, /, *, rtol=None)
-
-Returns the least-squares solution to a linear matrix equation `Ax = b`.
-
-#### Parameters
-
--   **x1**: _&lt;array&gt;_
-
-    -   coefficient array `A` having shape `(..., M, N)` and whose innermost two dimensions form `MxN` matrices. Should have a floating-point data type.
-
--   **x2**: _&lt;array&gt;_
-
-    -   ordinate (or "dependent variable") array `b`. If `x2` has shape `(..., M)`, `x2` is equivalent to an array having shape `(..., M, 1)`, and `shape(x2)` must be compatible with `shape(x1)[:-1]` (see {ref}`broadcasting`). If `x2` has shape `(..., M, K)`, each column `k` defines a set of ordinate values for which to compute a solution, and `shape(x2)[:-1]` must be compatible with `shape(x1)[:-1]` (see {ref}`broadcasting`). Should have a floating-point data type.
-
--   **rtol**: _Optional\[ Union\[ float, &lt;array&gt; ] ]_
-
-    -   relative tolerance for small singular values. Singular values less than or equal to `rtol * largest_singular_value` are set to zero. If a `float`, the value is equivalent to a zero-dimensional array having a data type determined by {ref}`type-promotion` (as applied to `x1` and `x2`) and must be broadcast against each matrix. If an `array`, must have a floating-point data type and must be compatible with `shape(x1)[:-2]` (see {ref}`broadcasting`). If `None`, the default value is `max(M, N) * eps`, where `eps` must be the machine epsilon associated with the floating-point data type determined by {ref}`type-promotion` (as applied to `x1` and `x2`). Default: `None`.
-
-#### Returns
-
--   **out**: _Tuple\[ &lt;array&gt;, &lt;array&gt;, &lt;array&gt;, &lt;array&gt; ]_
-
-    -   a namedtuple `(x, residuals, rank, s)` whose
-
-        -   first element must have the field name `x` and must be an array containing the least-squares solution for each `MxN` matrix in `x1`. The array containing the solutions must have shape `(N, K)` and must have a floating-point data type determined by {ref}`type-promotion`.
-        -   second element must have the field name `residuals` and must be an array containing the sum of squares residuals (i.e., the squared Euclidean 2-norm for each column in `b - Ax`). The array containing the residuals must have shape `(K,)` and must have a floating-point data type determined by {ref}`type-promotion`.
-        -   third element must have the field name `rank` and must be an array containing the effective rank of each `MxN` matrix. The array containing the ranks must have shape `shape(x1)[:-2]` and must have an integer data type.
-        -   fourth element must have the field name `s` and must be an array containing the singular values for each `MxN` matrix in `x1`. The array containing the singular values must have shape `(..., min(M, N))` and must have a floating-point data type determined by {ref}`type-promotion`.
-
 (function-linalg-matmul)=
 ### linalg.matmul(x1, x2, /)
 


### PR DESCRIPTION
This PR

-   removes `linalg.lstsq` (per consensus vote held during the consortium meeting held 2021-07-29). This PR supersedes [gh-235](https://github.com/data-apis/array-api/pull/235), which attempted to replace `lstsq` with a simpler API.
-   closes [gh-227](https://github.com/data-apis/array-api/issues/227) and [gh-235](https://github.com/data-apis/array-api/pull/235).

## Background

Initial discussion on `linalg.lstsq` API design can be found in [gh-227](https://github.com/data-apis/array-api/issues/227). There, it was held that the current API design posed undue burden on specification implementers due to API complexity (returning solutions, ranks, residuals, and singular values) and violated various linear algebra API design principles (particularly orthogonality).

Based on ensuing discussion in consortium meetings, consensus was found in simply removing the `linalg.lstsq` API altogether. This API finds low usage among downstream libraries (see [data](https://github.com/data-apis/array-api-comparison/blob/bb9922d42d2cc9d040bb0b60612f345356442fc2/data/common_apis_ranks.csv#L191)) and has several variants due to specialized use cases (see SciPy).

Should this or similar functionality be found to be desirable in the future, specification can happen in a future revision of the standard.