### PR TITLE
Add specifications for returning upper (`triu`) and lower (`tril`) triangular matrices

### DIFF
--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -396,7 +396,7 @@ The lower triangular part of the matrix is defined as the elements on and below 
 
 -   **out**: _&lt;array&gt;_
 
-    -   an array containing the lower triangular part(s). The returned array must have the same shape and data type as `x`. All elements above the specified diagonal `k` must be zeroed.
+    -   an array containing the lower triangular part(s). The returned array must have the same shape and data type as `x`. All elements above the specified diagonal `k` must be zeroed. The returned array should be allocated on the same device as `x`.
 
 (function-triu)=
 ### triu(x, /, *, k=0)
@@ -424,7 +424,7 @@ The upper triangular part of the matrix is defined as the elements on and above 
 
 -   **out**: _&lt;array&gt;_
 
-    -   an array containing the upper triangular part(s). The returned array must have the same shape and data type as `x`. All elements below the specified diagonal `k` must be zeroed.
+    -   an array containing the upper triangular part(s). The returned array must have the same shape and data type as `x`. All elements below the specified diagonal `k` must be zeroed. The returned array should be allocated on the same device as `x`.
 
 (function-zeros)=
 ### zeros(shape, *, dtype=None, device=None)

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -391,6 +391,7 @@ The lower triangular part of the matrix is defined as the elements on and below 
 
         ```{note}
         The main diagonal is defined as the set of indices `{(i, i)}` for `i` on the interval `[0, min(M, N) - 1]`.
+        ```
 
 #### Returns
 
@@ -419,6 +420,7 @@ The upper triangular part of the matrix is defined as the elements on and above 
 
         ```{note}
         The main diagonal is defined as the set of indices `{(i, i)}` for `i` on the interval `[0, min(M, N) - 1]`.
+        ```
 
 #### Returns
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -371,7 +371,7 @@ Returns a new array filled with ones and having the same `shape` as an input arr
     -   an array having the same shape as `x` and filled with ones.
 
 (function-tril)=
-### tril(x, /, *, k=0, device=None)
+### tril(x, /, *, k=0)
 
 Returns the lower triangular part of a matrix (or a stack of matrices) `x`.
 
@@ -391,11 +391,6 @@ The lower triangular part of the matrix is defined as the elements on and below 
 
         ```{note}
         The main diagonal is defined as the set of indices `{(i, i)}` for `i` on the interval `[0, min(M, N) - 1]`.
-        ```
-
--   **device**: _Optional\[ &lt;device&gt; ]_
-
-    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
 
 #### Returns
 
@@ -404,9 +399,9 @@ The lower triangular part of the matrix is defined as the elements on and below 
     -   an array containing the lower triangular part(s). The returned array must have the same shape and data type as `x`. All elements above the specified diagonal `k` must be zeroed.
 
 (function-triu)=
-### triu(x, /, *, k=0, device=None)
+### triu(x, /, *, k=0)
 
-Returns the uppder triangular part of a matrix (or a stack of matrices) `x`.
+Returns the upper triangular part of a matrix (or a stack of matrices) `x`.
 
 ```{note}
 The upper triangular part of the matrix is defined as the elements on and above the specified diagonal `k`.
@@ -424,11 +419,6 @@ The upper triangular part of the matrix is defined as the elements on and above 
 
         ```{note}
         The main diagonal is defined as the set of indices `{(i, i)}` for `i` on the interval `[0, min(M, N) - 1]`.
-        ```
-
--   **device**: _Optional\[ &lt;device&gt; ]_
-
-    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
 
 #### Returns
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -41,7 +41,7 @@ This function cannot guarantee that the interval does not include the `stop` val
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. Default: `None`.
+    -   device on which to place the created array. Default: `None`.
 
 #### Returns
 
@@ -72,7 +72,7 @@ Convert the input to an array.
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. Default: `None`.
+    -   device on which to place the created array. Default: `None`.
 
 -   **copy**: _Optional\[ bool ]_
 
@@ -102,7 +102,7 @@ Returns an uninitialized array having a specified `shape`.
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. Default: `None`.
+    -   device on which to place the created array. Default: `None`.
 
 #### Returns
 
@@ -127,7 +127,7 @@ Returns an uninitialized array with the same `shape` as an input array `x`.
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
+    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
 
 #### Returns
 
@@ -160,7 +160,7 @@ Returns a two-dimensional array with ones on the `k`th diagonal and zeros elsewh
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. Default: `None`.
+    -   device on which to place the created array. Default: `None`.
 
 #### Returns
 
@@ -210,7 +210,7 @@ Returns a new array having a specified `shape` and filled with `fill_value`.
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. Default: `None`.
+    -   device on which to place the created array. Default: `None`.
 
 #### Returns
 
@@ -239,7 +239,7 @@ Returns a new array filled with `fill_value` and having the same `shape` as an i
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
+    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
 
 #### Returns
 
@@ -277,7 +277,7 @@ Returns evenly spaced numbers over a specified interval.
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. Default: `None`.
+    -   device on which to place the created array. Default: `None`.
 
 -   **endpoint**: _bool_
 
@@ -337,7 +337,7 @@ Returns a new array having a specified `shape` and filled with ones.
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. Default: `None`.
+    -   device on which to place the created array. Default: `None`.
 
 #### Returns
 
@@ -362,13 +362,79 @@ Returns a new array filled with ones and having the same `shape` as an input arr
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
+    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
 
 #### Returns
 
 -   **out**: _&lt;array&gt;_
 
     -   an array having the same shape as `x` and filled with ones.
+
+(function-tril)=
+### tril(x, /, *, k=0, device=None)
+
+Returns the lower triangular part of a matrix (or a stack of matrices) `x`.
+
+```{note}
+The lower triangular part of the matrix is defined as the elements on and below the specified diagonal `k`.
+```
+
+#### Parameters
+
+-   **x**: _&lt;array&gt;_
+
+    -   input array having shape `(..., M, N)` and whose innermost two dimensions form `MxN` matrices.
+
+-   **k**: _int_
+
+    -   diagonal above which to zero elements. If `k = 0`, the diagonal is the main diagonal. If `k < 0`, the diagonal is below the main diagonal. If `k > 0`, the diagonal is above the main diagonal. Default: `0`.
+
+        ```{note}
+        The main diagonal is defined as the set of indices `{(i, i)}` for `i` on the interval `[0, min(M, N) - 1]`.
+        ```
+
+-   **device**: _Optional\[ &lt;device&gt; ]_
+
+    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the lower triangular part(s). The returned array must have the same shape and data type as `x`. All elements above the specified diagonal `k` must be zeroed.
+
+(function-triu)=
+### triu(x, /, *, k=0, device=None)
+
+Returns the uppder triangular part of a matrix (or a stack of matrices) `x`.
+
+```{note}
+The upper triangular part of the matrix is defined as the elements on and above the specified diagonal `k`.
+```
+
+#### Parameters
+
+-   **x**: _&lt;array&gt;_
+
+    -   input array having shape `(..., M, N)` and whose innermost two dimensions form `MxN` matrices.
+
+-   **k**: _int_
+
+    -   diagonal below which to zero elements. If `k = 0`, the diagonal is the main diagonal. If `k < 0`, the diagonal is below the main diagonal. If `k > 0`, the diagonal is above the main diagonal. Default: `0`.
+
+        ```{note}
+        The main diagonal is defined as the set of indices `{(i, i)}` for `i` on the interval `[0, min(M, N) - 1]`.
+        ```
+
+-   **device**: _Optional\[ &lt;device&gt; ]_
+
+    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the upper triangular part(s). The returned array must have the same shape and data type as `x`. All elements below the specified diagonal `k` must be zeroed.
 
 (function-zeros)=
 ### zeros(shape, *, dtype=None, device=None)
@@ -387,7 +453,7 @@ Returns a new array having a specified `shape` and filled with zeros.
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. Default: `None`.
+    -   device on which to place the created array. Default: `None`.
 
 #### Returns
 
@@ -412,7 +478,7 @@ Returns a new array filled with zeros and having the same `shape` as an input ar
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device to place the created array on, if given. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
+    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
 
 #### Returns
 


### PR DESCRIPTION
This PR

-   resolves [gh-237](https://github.com/data-apis/array-api/issues/237) by adding specifications for returning the lower (`tril`) and upper (`triu`) triangular matrix for one or more matrices.
-   includes a minor textual change to improve grammar.

## Notes

-   The function signatures were derived by comparing the signatures across array libraries ([`tril`](https://github.com/data-apis/array-api-comparison/blob/a2fdc6b7a7ac4728519785550c6cf25a7ca69973/signatures/creation/tril.md), [`triu`](https://github.com/data-apis/array-api-comparison/blob/a2fdc6b7a7ac4728519785550c6cf25a7ca69973/signatures/creation/triu.md)). The signatures across libraries are consistent, with the exception that PyTorch uses `diagonal` as the keyword argument, rather than `k` as used in NumPy et al. This PR chose `k` given its preponderance.
-   TF was the sole library without `tril` and `triu` APIs; however, these are included in the experimental `numpy` namespace.
-   The proposed APIs deviate from NumPy in allowing providing a batch of matrices (as discussed in [gh-237](https://github.com/data-apis/array-api/issues/237)). Supporting batches is part of a more general theme in this specification (see linear algebra) and follows prior art in the PyTorch API.
-   Both `tril` and `triu` were included in the list of potential APIs to standardize for v2 of the specification (see [gh-187](https://github.com/data-apis/array-api/issues/187)); however, these APIs were found to be needed in the current specification (see [gh-226](https://github.com/data-apis/array-api/pull/226) and discussion [gh-217](https://github.com/data-apis/array-api/issues/217)).
-   Once merged, this should allow merging of [gh-226](https://github.com/data-apis/array-api/pull/226).