### PR TITLE
Add specification for performing a batched matrix transpose on an array instance via an `.mT` attribute

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -215,6 +215,19 @@ Hardware device the array data resides on.
 
     -   a `device` object (see {ref}`device-support`).
 
+(attribute-mT)=
+### mT
+
+Transpose of a matrix (or a stack of matrices).
+
+If an array instance has fewer than two dimensions, an error should be raised.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   array whose last two dimensions (axes) are permuted in reverse order relative to original array (i.e., for an array instance having shape `(..., M, N)`, the returned array must have shape `(..., N, M)`). The returned array must have the same data type as the original array.
+
 (attribute-ndim)=
 ### ndim
 


### PR DESCRIPTION
This PR:

-   adds a specification for the `.mT` attribute for performing a batched matrix transpose on an array instance.

## Background

Discussion regarding the need for an `.mT` attribute can be found in [gh-228](https://github.com/data-apis/array-api/issues/228).

Notably, we cannot use the existing `.T` attribute for applying a transpose operation to a stack of matrices, as this would introduce an undesirable incompatibility in the array library ecosystem, where existing practice (see NumPy et al) is to reverse all dimensions for arrays having more than two-dimensions. Accordingly, in order to support applying a batched matrix transpose on an array instance, a new attribute is necessary.