### PR TITLE
Add specification for computing the matrix transpose (`matrix_transpose`)

### DIFF
--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -60,6 +60,23 @@ The `matmul` function must implement the same semantics as the built-in `@` oper
 -   if `x1` is a one-dimensional array having shape `(N)`, `x2` is a one-dimensional array having shape `(M)`, and `N != M`.
 -   if `x1` is an array having shape `(..., M, K)`, `x2` is an array having shape `(..., L, N)`, and `K != L`.
 
+(function-matrix-transpose)=
+### matrix_transpose(x, /)
+
+Transposes a matrix (or a stack of matrices) `x`.
+
+#### Parameters
+
+-   **x**: _&lt;array&gt;_
+
+    -   input array having shape `(..., M, N)` and whose innermost two dimensions form `MxN` matrices.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the transpose for each matrix and having shape `(..., N, M)`. The returned array must have the same data type as `x`.
+
 (function-tensordot)=
 ### tensordot(x1, x2, /, *, axes=2)
 
@@ -92,27 +109,6 @@ Returns a tensor contraction of `x1` and `x2` over specific axes.
 -   **out**: _&lt;array&gt;_
 
     -   an array containing the tensor contraction whose shape consists of the non-contracted axes (dimensions) of the first array `x1`, followed by the non-contracted axes (dimensions) of the second array `x2`. The returned array must have a data type determined by {ref}`type-promotion`.
-
-(function-transpose)=
-### transpose(x, /, *, axes=None)
-
-Transposes (or permutes the axes (dimensions)) of an array `x`.
-
-#### Parameters
-
--   **x**: _&lt;array&gt;_
-
-    -   input array.
-
--   **axes**: _Optional\[ Tuple\[ int, ... ] ]_
-
-    -   tuple containing a permutation of `(0, 1, ..., N-1)` where `N` is the number of axes (dimensions) of `x`. If `None`, the axes (dimensions) must be permuted in reverse order (i.e., equivalent to setting `axes=(N-1, ..., 1, 0)`). Default: `None`.
-
-#### Returns
-
--   **out**: _&lt;array&gt;_
-
-    -   an array containing the transpose. The returned array must have the same data type as `x`.
 
 (function-vecdot)=
 ### vecdot(x1, x2, /, *, axis=None)

--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -357,6 +357,11 @@ Computes the rank (i.e., number of non-zero singular values) of a matrix (or a s
 
     -   an array containing the ranks. The returned array must have a floating-point data type determined by {ref}`type-promotion` and must have shape `(...)` (i.e., must have a shape equal to `shape(x)[:-2]`).
 
+(function-linalg-matrix-transpose)=
+### linalg.matrix_transpose(x, /)
+
+Alias for {ref}`function-matrix-transpose`.
+
 (function-linalg-outer)=
 ### linalg.outer(x1, x2, /)
 
@@ -561,11 +566,6 @@ Returns the sum along the specified diagonals of a matrix (or a stack of matrice
         ```
 
         The returned array must have the same data type as `x`.
-
-(function-linalg-transpose)=
-### linalg.transpose(x, /, *, axes=None)
-
-Alias for {ref}`function-transpose`.
 
 (function-linalg-vecdot)=
 ### linalg.vecdot(x1, x2, /, *, axis=None)


### PR DESCRIPTION
This PR:

-   adds a specification for computing the transpose of a matrix (or a stack of matrices).

## Background

The addition of a `matrix_transpose` API is meant to replace the use of the `transpose` API. The `transpose` API was found to be problematic due to its API supporting more general axes permutation (see [gh-228](https://github.com/data-apis/array-api/issues/228)).

Similar to other linear algebra APIs, the proposed `matrix_transpose` API operates on stack of matrices and thus more succinctly and explicitly allows expressing matrix operations in accordance with mathematical intuition and obviates the need for doing `transpose(x, axes=[-2,-1])` whenever wanting to perform a batched matrix transpose. Batching is the default behavior.

The `matrix_transpose` API serves as a functional complement to the proposed [`.mT`](https://github.com/data-apis/array-api/pull/246) attribute (see [gh-246](https://github.com/data-apis/array-api/pull/246)).