### PR TITLE
Fix output array dtype when computing the remainder

### DIFF
--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -1209,7 +1209,7 @@ Returns the remainder of division for each element `x1_i` of the input array `x1
 
 -   **out**: _&lt;array&gt;_
 
-    -   an array containing the element-wise results. Each element-wise result must have the same sign as the respective element `x2_i`. The returned array must have a floating-point data type determined by {ref}`type-promotion`.
+    -   an array containing the element-wise results. Each element-wise result must have the same sign as the respective element `x2_i`. The returned array must have a data type determined by {ref}`type-promotion`.
 
 (function-round)=
 ### round(x, /)


### PR DESCRIPTION
It stated that the return type should be floating-point, but it accepts
integer inputs (and the remainder of two integers is always an integer).

Somewhat related, I noticed that `remainder` doesn't specify any special cases, but it perhaps should specify the behavior for remainder by 0, and infinites. Also should integer remainder by 0 be unspecified? 