### PR TITLE
Address a few device related issues

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -461,6 +461,7 @@ Exports the array for consumption by {ref}`function-from_dlpack` as a DLPack cap
         ```{note}
         Support for a `stream` value other than `None` is optional and implementation-dependent.
         ```
+
         Device-specific notes:
 
         :::{admonition} CUDA

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1191,3 +1191,33 @@ Evaluates `self_i ^ other_i` for each element of an array instance with the resp
 
 Element-wise results must equal the results returned by the equivalent element-wise function [`bitwise_xor(x1, x2)`](elementwise_functions.md#bitwise_xorx1-x2-).
 ```
+
+(method-to_device)=
+### to_device(self, device, /, *, stream=None)
+
+Copy the array from the device it currently resides to the specified `device`.
+
+#### Parameters
+
+-   **self**: _&lt;array&gt;_
+
+    -   array instance.
+
+-   **device**: _&lt;device&gt;_
+
+    -   device to place the copied array on.
+
+-   **stream**: _Optional\[ Union\[ int, Any ]]_
+
+    -   stream object to use during copy. See {ref}`method-__dlpack__`.
+
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an identical copy of the source array placed on the target `device`.
+
+```{note}
+
+Whether the copy is performed synchronously or asynchronously is up to the array library. As a result, if any synchronization (which is out of scope of this standard) is required to guarantee data safety, the library should explain to its users.
+```

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1217,7 +1217,7 @@ Element-wise results must equal the results returned by the equivalent element-w
 (method-to_device)=
 ### to\_device(self, device, /, *, stream=None)
 
-Copy the array from the device it currently resides to the specified `device`.
+Copy the array from the device on which it currently resides to the specified `device`.
 
 #### Parameters
 
@@ -1227,7 +1227,7 @@ Copy the array from the device it currently resides to the specified `device`.
 
 -   **device**: _&lt;device&gt;_
 
-    -   a `device` object (see {ref}`device-support`)
+    -   a `device` object (see {ref}`device-support`).
 
 -   **stream**: _Optional\[ Union\[ int, Any ]]_
 
@@ -1237,8 +1237,8 @@ Copy the array from the device it currently resides to the specified `device`.
 
 -   **out**: _&lt;array&gt;_
 
-    -   an array with the same data and dtype, located on the specified `device`.
+    -   an array with the same data and data type as `self` and located on the specified `device`.
 
 ```{note}
-If `stream` is given, the copy operation will be enqueued on it; otherwise, it is enqueued on the default stream/queue. Whether the copy is performed synchronously or asynchronously is up to the array library. As a result, if any synchronization is required to guarantee data safety, the library should explain to its users.
+If `stream` is given, the copy operation should be enqueued on the provided `stream`; otherwise, the copy operation should be enqueued on the default stream/queue. Whether the copy is performed synchronously or asynchronously is library dependent. As a result, if synchronization is required to guarantee data safety, this should be clearly explained in a conforming library's documentation.
 ```

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1229,7 +1229,7 @@ Copy the array from the device it currently resides to the specified `device`.
 
 -   **stream**: _Optional\[ Union\[ int, Any ]]_
 
-    -   stream object to use during copy. See {ref}`method-__dlpack__`.
+    -   stream object to use during copy. In addition to the supported types as discussed in {ref}`method-__dlpack__`, any library-specific stream object is also allowed to be used here.
 
 #### Returns
 
@@ -1239,6 +1239,5 @@ Copy the array from the device it currently resides to the specified `device`.
 
 ```{note}
 
-Whether the copy is performed synchronously or asynchronously is up to the array library. As a result, if any synchronization (which is out of scope of this standard) is required to guarantee data safety, the library should explain to its users.
+If `stream` is given, the copy operation will be enqueued on it; otherwise, it is enqueued on the default stream/queue (the concept of which is out of scope of this standard). Whether the copy is performed synchronously or asynchronously is up to the array library. As a result, if any synchronization (which is also out of scope of this standard) is required to guarantee data safety, the library should explain to its users.
 ```
-

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -458,6 +458,8 @@ Exports the array for consumption by {ref}`function-from_dlpack` as a DLPack cap
 
         For other device types which do have a stream, queue or similar synchronization mechanism, the most appropriate type to use for `stream` is not yet determined. E.g., for SYCL one may want to use an object containing an in-order `cl::sycl::queue`. This is allowed when libraries agree on such a convention, and may be standardized in a future version of this API standard.
 
+        Support for any `stream` value other than `None` is optional and up to each library in question.
+
         Device-specific notes:
 
         :::{admonition} CUDA
@@ -1229,7 +1231,7 @@ Copy the array from the device it currently resides to the specified `device`.
 
 -   **stream**: _Optional\[ Union\[ int, Any ]]_
 
-    -   stream object to use during copy. In addition to the supported types as discussed in {ref}`method-__dlpack__`, any library-specific stream object is also allowed to be used here.
+    -   stream object to use during copy. In addition to the supported types as discussed in {ref}`method-__dlpack__`, any library-specific stream object is also allowed to be used here, with the caveat that using such an object would make the code non-portable.
 
 #### Returns
 
@@ -1238,6 +1240,5 @@ Copy the array from the device it currently resides to the specified `device`.
     -   an array with the same data and dtype, located on the specified `device`.
 
 ```{note}
-
-If `stream` is given, the copy operation will be enqueued on it; otherwise, it is enqueued on the default stream/queue (the concept of which is out of scope of this standard). Whether the copy is performed synchronously or asynchronously is up to the array library. As a result, if any synchronization (which is also out of scope of this standard) is required to guarantee data safety, the library should explain to its users.
+If `stream` is given, the copy operation will be enqueued on it; otherwise, it is enqueued on the default stream/queue. Whether the copy is performed synchronously or asynchronously is up to the array library. As a result, if any synchronization is required to guarantee data safety, the library should explain to its users.
 ```

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -458,8 +458,9 @@ Exports the array for consumption by {ref}`function-from_dlpack` as a DLPack cap
 
         For other device types which do have a stream, queue or similar synchronization mechanism, the most appropriate type to use for `stream` is not yet determined. E.g., for SYCL one may want to use an object containing an in-order `cl::sycl::queue`. This is allowed when libraries agree on such a convention, and may be standardized in a future version of this API standard.
 
-        Support for any `stream` value other than `None` is optional and up to each library in question.
-
+        ```{note}
+        Support for a `stream` value other than `None` is optional and implementation-dependent.
+        ```
         Device-specific notes:
 
         :::{admonition} CUDA
@@ -1231,7 +1232,7 @@ Copy the array from the device on which it currently resides to the specified `d
 
 -   **stream**: _Optional\[ Union\[ int, Any ]]_
 
-    -   stream object to use during copy. In addition to the supported types as discussed in {ref}`method-__dlpack__`, any library-specific stream object is also allowed to be used here, with the caveat that using such an object would make the code non-portable.
+    -   stream object to use during copy. In addition to the types supported in {ref}`method-__dlpack__`, implementations may choose to support any library-specific stream object with the caveat that any code using such an object would not be portable.
 
 #### Returns
 
@@ -1240,5 +1241,5 @@ Copy the array from the device on which it currently resides to the specified `d
     -   an array with the same data and data type as `self` and located on the specified `device`.
 
 ```{note}
-If `stream` is given, the copy operation should be enqueued on the provided `stream`; otherwise, the copy operation should be enqueued on the default stream/queue. Whether the copy is performed synchronously or asynchronously is library dependent. As a result, if synchronization is required to guarantee data safety, this should be clearly explained in a conforming library's documentation.
+If `stream` is given, the copy operation should be enqueued on the provided `stream`; otherwise, the copy operation should be enqueued on the default stream/queue. Whether the copy is performed synchronously or asynchronously is implementation-dependent. Accordingly, if synchronization is required to guarantee data safety, this must be clearly explained in a conforming library's documentation.
 ```

--- a/spec/design_topics/device_support.md
+++ b/spec/design_topics/device_support.md
@@ -58,10 +58,10 @@ array API itself that can be instantiated to point to a specific physical or
 logical device. In other words, the standard does *not* include a universal
 `Device` object recognized by all compliant libraries.
 
-For array libraries that concern with multi-device support, including CPU and GPU,
-it is free to expose a library-specific device object for use (ex: creating an
-array on a particular device). For the purpose of this standard, it is considered
-an (important) implementation detail.
+For array libraries which concern themselves with multi-device support, including CPU and GPU,
+they are free to expose a library-specific device object for use (e.g., for creating an
+array on a particular device). It can be used as an input to `to_device`; the caveat
+is that it would make the code specific to that library.
 ```
 
 

--- a/spec/design_topics/device_support.md
+++ b/spec/design_topics/device_support.md
@@ -48,20 +48,20 @@ cross-device data transfer:
   libraries is out of scope).
 2. A `device=None` keyword for array creation functions, which takes an
    instance of a `Device` object.
-3. A `.to_device` method on the array object, with `device` again being
-   a `Device` object, to copy an array to a different device.
+3. A `.to_device` method on the array object to copy an array to a different device.
 
 ```{note}
 In the current API standard, the only way to obtain a `Device` object is from the
-`.device` property on the array object, hence there is no `Device` object in the
-array API itself that can be instantiated to point to a specific physical or
-logical device. In other words, the standard does *not* include a universal
-`Device` object recognized by all compliant libraries.
+`.device` property on the array object. The standard does **not** include a universal
+`Device` object recognized by all compliant libraries. Accordingly, the standard does
+not provide a means of instantiating a `Device` object to point to a specific physical or
+logical device.
 
 For array libraries which concern themselves with multi-device support, including CPU and GPU,
-they are free to expose a library-specific device object for use (e.g., for creating an
-array on a particular device). It can be used as an input to `to_device`; the caveat
-is that it would make the code specific to that library.
+they are free to expose a library-specific device object (e.g., for creating an
+array on a particular device). While a library-specific device object can be used as input to
+`to_device`, beware that this will mean non-portability as code will be specific to
+that library.
 ```
 
 

--- a/spec/design_topics/device_support.md
+++ b/spec/design_topics/device_support.md
@@ -49,9 +49,16 @@ cross-device data transfer:
    a `Device` object, to move an array to a different device.
 
 ```{note}
-The only way to obtain a `Device` object is from the `.device` property on
-the array object, hence there is no `Device` object in the array API itself
-that can be instantiated to point to a specific physical or logical device.
+In the current API standard, the only way to obtain a `Device` object is from the
+`.device` property on the array object, hence there is no `Device` object in the
+array API itself that can be instantiated to point to a specific physical or
+logical device. In other words, the standard does *not* include a universal
+`Device` object recognized by all compliant libraries.
+
+For array libraries that concern with multi-device support, including CPU and GPU,
+it is free to expose a library-specific device object for use (ex: creating an
+array on a particular device). For the purpose of this standard, it is considered
+an (important) implementation detail.
 ```
 
 

--- a/spec/design_topics/device_support.md
+++ b/spec/design_topics/device_support.md
@@ -57,6 +57,8 @@ In the current API standard, the only way to obtain a `Device` object is from th
 not provide a means of instantiating a `Device` object to point to a specific physical or
 logical device.
 
+The choice to not include a standardized `Device` object may be revisited in a future revision of this standard.
+
 For array libraries which concern themselves with multi-device support, including CPU and GPU,
 they are free to expose a library-specific device object (e.g., for creating an
 array on a particular device). While a library-specific device object can be used as input to

--- a/spec/design_topics/device_support.md
+++ b/spec/design_topics/device_support.md
@@ -48,8 +48,8 @@ cross-device data transfer:
   libraries is out of scope).
 2. A `device=None` keyword for array creation functions, which takes an
    instance of a `Device` object.
-3. A `.to_device(device)` method on the array object, with `device` again being
-   a `Device` object, to move an array to a different device.
+3. A `.to_device` method on the array object, with `device` again being
+   a `Device` object, to copy an array to a different device.
 
 ```{note}
 In the current API standard, the only way to obtain a `Device` object is from the


### PR DESCRIPTION
Close #256. Close #156.

This PR addresses a few things:
- Add `stream` to `.to_device()` and allow any library-specific stream object to be used
- Clarify that `.to_device()` is to *copy* (not move) data across devices 
- Clarify that the standard is not concerned with (a)synchronous transfer
- Clarify that any library-specific device management is permitted