### PR TITLE
Clarify output dtype guidance for `mean`, `var`, and `std`

### DIFF
--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -63,7 +63,9 @@ Calculates the arithmetic mean of the input array `x`.
 
 -   **out**: _&lt;array&gt;_
 
-    -   if the arithmetic mean was computed over the entire array, a zero-dimensional array containing the arithmetic mean; otherwise, a non-zero-dimensional array containing the arithmetic means. The returned array must have be the default floating-point data type.
+    -   if the arithmetic mean was computed over the entire array, a zero-dimensional array containing the arithmetic mean; otherwise, a non-zero-dimensional array containing the arithmetic means.
+
+        If the input array `x` has an integer data type, the returned array must have the default floating-point data type. Otherwise, if the input array `x` has a floating-point data type, the returned array must have the same data type as `x`.
 
 (function-min)=
 ### min(x, /, *, axis=None, keepdims=False)
@@ -142,7 +144,9 @@ Calculates the standard deviation of the input array `x`.
 
 -   **out**: _&lt;array&gt;_
 
-    -   if the standard deviation was computed over the entire array, a zero-dimensional array containing the standard deviation; otherwise, a non-zero-dimensional array containing the standard deviations. The returned array must have the default floating-point data type.
+    -   if the standard deviation was computed over the entire array, a zero-dimensional array containing the standard deviation; otherwise, a non-zero-dimensional array containing the standard deviations.
+
+        If the input array `x` has an integer data type, the returned array must have the default floating-point data type. Otherwise, if the input array `x` has a floating-point data type, the returned array must have the same data type as `x`.
 
 (function-sum)=
 ### sum(x, /, *, axis=None, keepdims=False)
@@ -196,4 +200,6 @@ Calculates the variance of the input array `x`.
 
 -   **out**: _&lt;array&gt;_
 
-    -   if the variance was computed over the entire array, a zero-dimensional array containing the variance; otherwise, a non-zero-dimensional array containing the variances. The returned array must have the default floating-point data type.
+    -   if the variance was computed over the entire array, a zero-dimensional array containing the variance; otherwise, a non-zero-dimensional array containing the variances.
+
+        If the input array `x` has an integer data type, the returned array must have the default floating-point data type. Otherwise, if the input array `x` has a floating-point data type, the returned array must have the same data type as `x`.

--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -63,9 +63,11 @@ Calculates the arithmetic mean of the input array `x`.
 
 -   **out**: _&lt;array&gt;_
 
-    -   if the arithmetic mean was computed over the entire array, a zero-dimensional array containing the arithmetic mean; otherwise, a non-zero-dimensional array containing the arithmetic means.
+    -   if the arithmetic mean was computed over the entire array, a zero-dimensional array containing the arithmetic mean; otherwise, a non-zero-dimensional array containing the arithmetic means. The returned array must have the same data type as `x`.
 
-        If the input array `x` has an integer data type, the returned array must have the default floating-point data type. Otherwise, if the input array `x` has a floating-point data type, the returned array must have the same data type as `x`.
+        ```{note}
+        While this specification recommends that this function only accept input arrays having a floating-point data type, specification-compliant array libraries may choose to accept input arrays having an integer data type. While mixed data type promotion is implementation-defined, if the input array `x` has an integer data type, the returned array must have the default floating-point data type.
+        ```
 
 (function-min)=
 ### min(x, /, *, axis=None, keepdims=False)
@@ -144,9 +146,11 @@ Calculates the standard deviation of the input array `x`.
 
 -   **out**: _&lt;array&gt;_
 
-    -   if the standard deviation was computed over the entire array, a zero-dimensional array containing the standard deviation; otherwise, a non-zero-dimensional array containing the standard deviations.
+    -   if the standard deviation was computed over the entire array, a zero-dimensional array containing the standard deviation; otherwise, a non-zero-dimensional array containing the standard deviations. The returned array must have the same data type as `x`.
 
-        If the input array `x` has an integer data type, the returned array must have the default floating-point data type. Otherwise, if the input array `x` has a floating-point data type, the returned array must have the same data type as `x`.
+        ```{note}
+        While this specification recommends that this function only accept input arrays having a floating-point data type, specification-compliant array libraries may choose to accept input arrays having an integer data type. While mixed data type promotion is implementation-defined, if the input array `x` has an integer data type, the returned array must have the default floating-point data type.
+        ```
 
 (function-sum)=
 ### sum(x, /, *, axis=None, keepdims=False)
@@ -200,6 +204,8 @@ Calculates the variance of the input array `x`.
 
 -   **out**: _&lt;array&gt;_
 
-    -   if the variance was computed over the entire array, a zero-dimensional array containing the variance; otherwise, a non-zero-dimensional array containing the variances.
+    -   if the variance was computed over the entire array, a zero-dimensional array containing the variance; otherwise, a non-zero-dimensional array containing the variances. The returned array must have the same data type as `x`.
 
-        If the input array `x` has an integer data type, the returned array must have the default floating-point data type. Otherwise, if the input array `x` has a floating-point data type, the returned array must have the same data type as `x`.
+        ```{note}
+        While this specification recommends that this function only accept input arrays having a floating-point data type, specification-compliant array libraries may choose to accept input arrays having an integer data type. While mixed data type promotion is implementation-defined, if the input array `x` has an integer data type, the returned array must have the default floating-point data type.
+        ```


### PR DESCRIPTION
This PR

-   clarifies output dtype guidance for `mean`, `var`, and `std`, as discussed in [gh-202](https://github.com/data-apis/array-api/issues/202#issuecomment-863405754).

    Notably, the PR adds notes which clarify the output array dtype when the input array has an integer dtype. While integer dtypes are not explicitly supported by the standard (due to mixed-type promotion being undefined), this PR adds language to require that, if an array having an integer dtype is provided, the returned array must have the default floating-point dtype.

    For floating-point input arrays, the returned array must have the same dtype as the input array.