### PR TITLE
Specify behavior of statistical reductions over the empty set

### DIFF
--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -20,6 +20,10 @@ A conforming implementation of the array API standard must provide and support t
 
 Calculates the maximum value of the input array `x`.
 
+```{note}
+When the number of elements over which to compute the maximum value is zero, the maximum value is implementation-defined. Specification-compliant libraries may choose to error, return a sentinel value (e.g., if `x` is a floating-point input array, return `NaN`), or return the minimum possible value for the input array `x` data type (e.g., if `x` is a floating-point array, return `-infinity`).
+```
+
 #### Parameters
 
 -   **x**: _&lt;array&gt;_
@@ -75,6 +79,10 @@ For a floating-point input array `x`, let `N` equal the number of elements over 
 ### min(x, /, *, axis=None, keepdims=False)
 
 Calculates the minimum value of the input array `x`.
+
+```{note}
+When the number of elements over which to compute the minimum value is zero, the minimum value is implementation-defined. Specification-compliant libraries may choose to error, return a sentinel value (e.g., if `x` is a floating-point input array, return `NaN`), or return the maximum possible value for the input array `x` data type (e.g., if `x` is a floating-point array, return `+infinity`).
+```
 
 #### Parameters
 

--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -47,9 +47,9 @@ Calculates the arithmetic mean of the input array `x`.
 
 #### Special Cases
 
-For a floating-point input array `x`,
+For a floating-point input array `x`, let `N` equal the number of elements over which to compute the arithmetic mean and
 
--   if axis (or axes) along which arithmetic means is zero-dimensional, the arithmetic mean is `NaN`.
+-   if `N` is `0`, the arithmetic mean is `NaN`.
 
 #### Parameters
 
@@ -103,9 +103,9 @@ Calculates the product of input array `x` elements.
 
 #### Special Cases
 
-For an input array `x`,
+For an input array `x`, let `N` equal the number of elements over which to compute the product and
 
--   if an axis (or axes) along which to compute products is zero-dimensional, the product is `1`.
+-   if `N` is `0`, the product is `1` (i.e., the empty product).
 
 #### Parameters
 
@@ -131,6 +131,12 @@ For an input array `x`,
 ### std(x, /, *, axis=None, correction=0.0, keepdims=False)
 
 Calculates the standard deviation of the input array `x`.
+
+#### Special Cases
+
+For a floating-point input array `x`, let `N` equal the number of elements over which to compute the standard deviation and
+
+-  if `N - correction` is less than or equal to `0`, the standard deviation is `NaN`.
 
 #### Parameters
 
@@ -163,9 +169,9 @@ Calculates the sum of the input array `x`.
 
 #### Special Cases
 
-For an input array `x`,
+For an input array `x`, let `N` equal the number of elements over which to compute the sum and
 
--   if an axis (or axes) along which to compute products is zero-dimensional, the sum is `0`.
+-   if `N` is `0`, the sum is `0` (i.e., the empty sum).
 
 #### Parameters
 
@@ -191,6 +197,12 @@ For an input array `x`,
 ### var(x, /, *, axis=None, correction=0.0, keepdims=False)
 
 Calculates the variance of the input array `x`.
+
+#### Special Cases
+
+For a floating-point input array `x`, let `N` equal the number of elements over which to compute the variance and
+
+-  if `N - correction` is less than or equal to `0`, the variance is `NaN`.
 
 #### Parameters
 

--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -47,9 +47,9 @@ Calculates the arithmetic mean of the input array `x`.
 
 #### Special Cases
 
-For an input array `x`,
+For a floating-point input array `x`,
 
--   if axis (or axes) along which arithmetic means is zero-dimensional, the computed mean is `NaN`.
+-   if axis (or axes) along which arithmetic means is zero-dimensional, the arithmetic mean is `NaN`.
 
 #### Parameters
 
@@ -100,6 +100,12 @@ Calculates the minimum value of the input array `x`.
 ### prod(x, /, *, axis=None, keepdims=False)
 
 Calculates the product of input array `x` elements.
+
+#### Special Cases
+
+For an input array `x`,
+
+-   if an axis (or axes) along which to compute products is zero-dimensional, the product is `1`.
 
 #### Parameters
 

--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -161,6 +161,12 @@ Calculates the standard deviation of the input array `x`.
 
 Calculates the sum of the input array `x`.
 
+#### Special Cases
+
+For an input array `x`,
+
+-   if an axis (or axes) along which to compute products is zero-dimensional, the sum is `0`.
+
 #### Parameters
 
 -   **x**: _&lt;array&gt;_

--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -45,6 +45,12 @@ Calculates the maximum value of the input array `x`.
 
 Calculates the arithmetic mean of the input array `x`.
 
+#### Special Cases
+
+For an input array `x`,
+
+-   if axis (or axes) along which arithmetic means is zero-dimensional, the computed mean is `NaN`.
+
 #### Parameters
 
 -   **x**: _&lt;array&gt;_


### PR DESCRIPTION
This PR

-   specifies the behavior of statistical reductions when the number of elements over which to compute a reduction is zero and resolves [gh-232](https://github.com/data-apis/array-api/issues/232).
-   Notably, this PR proposes

     -   `max`: implementation-defined (due to no consistent maximum value across all supported data types).
     -   `mean`: return `NaN`.
     -   `min`: implementation-defined (due to no consistent minimum value across all supported data types).
     -   `prod`: return `1` (empty product).
     -   `std`: return `NaN`.
     -   `sum`: return `0` (empty sum).
     -   `var`: return `NaN`.