### PR TITLE
Add `__index__` to array object

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -659,6 +659,10 @@ Element-wise results must equal the results returned by the equivalent element-w
 
 Converts a zero-dimensional integer array to a Python `int` object.
 
+```{note}
+This method is called to implement [`operator.index()`](https://docs.python.org/3/reference/datamodel.html#object.__index__). See also [PEP 357](https://www.python.org/dev/peps/pep-0357/).
+```
+
 #### Parameters
 
 -   **self**: _&lt;array&gt;_

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -654,6 +654,23 @@ Computes the truth value of `self_i > other_i` for each element of an array inst
 Element-wise results must equal the results returned by the equivalent element-wise function [`greater(x1, x2)`](elementwise_functions.md#greaterx1-x2-).
 ```
 
+(method-__index__)=
+### \_\_index\_\_(self, /)
+
+Converts a zero-dimensional integer array to a Python `int` object.
+
+#### Parameters
+
+-   **self**: _&lt;array&gt;_
+
+    -   zero-dimensional array instance. Must have an integer data type.
+
+#### Returns
+
+-   **out**: _&lt;int&gt;_
+
+    -   a Python `int` object representing the single element of the array instance.
+
 (method-__int__)=
 ### \_\_int\_\_(self, /)
 


### PR DESCRIPTION
This PR

-   adds `__index__` to the array object, which is called to implement [`operator.index()`](https://docs.python.org/3/reference/datamodel.html#object.__index__) (see also [PEP 0357](https://www.python.org/dev/peps/pep-0357/)).
-   allows a zero-dimensional array to be used as an index when indexing lists and other built-in Python objects supporting slices.
-   resolves [gh-231](https://github.com/data-apis/array-api/issues/231).
