### PR TITLE
Update device guidance for `*_like` functions

### DIFF
--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -127,7 +127,7 @@ Returns an uninitialized array with the same `shape` as an input array `x`.
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
+    -   device on which to place the created array. If `device` is `None`, the output array device must be inferred from `x`. Default: `None`.
 
 #### Returns
 
@@ -247,7 +247,7 @@ Returns a new array filled with `fill_value` and having the same `shape` as an i
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
+    -   device on which to place the created array. If `device` is `None`, the output array device must be inferred from `x`. Default: `None`.
 
 #### Returns
 
@@ -370,7 +370,7 @@ Returns a new array filled with ones and having the same `shape` as an input arr
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
+    -   device on which to place the created array. If `device` is `None`, the output array device must be inferred from `x`. Default: `None`.
 
 #### Returns
 
@@ -478,7 +478,7 @@ Returns a new array filled with zeros and having the same `shape` as an input ar
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
-    -   device on which to place the created array. If `device` is `None`, the default device must be used, not `x.device`. Default: `None`.
+    -   device on which to place the created array. If `device` is `None`, the output array device must be inferred from `x`. Default: `None`.
 
 #### Returns
 


### PR DESCRIPTION
This PR

-   updates the output array device guidance for `*_like` creation functions to infer the output array device from the input array, if the `device` kwarg is `None`. This behavior is consistent with `dtype` and `shape` inference and consistent with, e.g., [Torch](https://pytorch.org/docs/1.9.0/generated/torch.ones_like.html?highlight=ones_like#torch.ones_like).

This change was discussed and agreed upon in the 2021-09-16 consortium meeting.