### PR TITLE
Remove `einsum`

### DIFF
--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -15,11 +15,6 @@ A conforming implementation of the array API standard must provide and support t
 
 <!-- NOTE: please keep the functions in alphabetical order -->
 
-(function-einsum)=
-### einsum()
-
-TODO
-
 (function-matmul)=
 ### matmul(x1, x2, /)
 

--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -229,11 +229,6 @@ Computes the eigenvalues of a symmetric matrix (or a stack of symmetric matrices
 Eigenvalue sort order is left unspecified.
 ```
 
-(function-linalg-einsum)=
-### linalg.einsum()
-
-Alias for {ref}`function-einsum`.
-
 (function-linalg-inv)=
 ### linalg.inv(x, /)
 


### PR DESCRIPTION
This PR

-   removes the `einsum` TODO. The addition of `einsum` is delayed until the 2022 specification revision.