### PR TITLE
Update guidance for output array dtype inference in `full_like`

### DIFF
--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -239,10 +239,14 @@ Returns a new array filled with `fill_value` and having the same `shape` as an i
 
 -   **dtype**: _Optional\[ &lt;dtype&gt; ]_
 
-    -   output array data type. If `dtype` is `None`, the output array data type must be inferred from `fill_value` (see {ref}`function-full`). Default: `None`.
+    -   output array data type. If `dtype` is `None`, the output array data type must be inferred from `x`. Default: `None`.
 
         ```{note}
-        If `dtype` is `None` and the `fill_value` exceeds the precision of the resolved default output array data type, behavior is left unspecified and, thus, implementation-defined.
+        If `dtype` is `None` and the `fill_value` exceeds the precision of the resolved output array data type, behavior is unspecified and, thus, implementation-defined.
+        ```
+
+        ```{note}
+        If `dtype` is `None` and the `fill_value` has a data type (`int` or `float`) which does not participate in type promotion with the resolved output array data type (see {ref}`type-promotion`), behavior is unspecified and, thus, implementation-defined.
         ```
 
 -   **device**: _Optional\[ &lt;device&gt; ]_

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -246,7 +246,7 @@ Returns a new array filled with `fill_value` and having the same `shape` as an i
         ```
 
         ```{note}
-        If `dtype` is `None` and the `fill_value` has a data type (`int` or `float`) which does not participate in type promotion with the resolved output array data type (see {ref}`type-promotion`), behavior is unspecified and, thus, implementation-defined.
+        If `dtype` is `None` and the `fill_value` has a data type (`int` or `float`) which is not of the same data type kind as the resolved output array data type (see {ref}`type-promotion`), behavior is unspecified and, thus, implementation-defined.
         ```
 
 -   **device**: _Optional\[ &lt;device&gt; ]_


### PR DESCRIPTION
This PR

-   updates the guidance for output array dtype inference in `full_like`.

## Discussion

In [gh-167](https://github.com/data-apis/array-api/commit/e6d827afdbeb8db0f18288526231aa1904e63a5c#diff-f8b551edf45aca0f0a5926e0a6f4408c45f7a43ce0773d42179f5a16c1a99df9R238), guidance was changed (see [gh-31](https://github.com/data-apis/array-api/pull/31/files#diff-f8b551edf45aca0f0a5926e0a6f4408c45f7a43ce0773d42179f5a16c1a99df9R150)) to infer the dtype from the `fill_value`. However, this seems to have been a mistake, as scalar values do not have an array data type (only `int` or `float`) and do not participate in type promotion.

This PR reverts this change, but also includes an explicit note that, if the `fill_value` is not of the same data type "kind" as the resolved output array data type, then behavior is left unspecified (e.g., if `x.dtype` is `int64` and `fill_value` is `float`; e.g., `fill_value = 3.5`).