### PR TITLE
Split `unique` into separate functions

### DIFF
--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -13,12 +13,12 @@ A conforming implementation of the array API standard must provide and support t
 <!-- NOTE: please keep the functions in alphabetical order -->
 
 (function-unique)=
-### unique(x, /, *, return_counts=False, return_index=False, return_inverse=False)
+### unique(x, /)
 
 :::{admonition} Data-dependent output shape
 :class: important
 
-The shapes of one or more of output arrays for this function depend on the data values in the input array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
+The shapes of one of the output arrays for this function depend on the data values in the input array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
 :::
 
 Returns the unique elements of an input array `x`.
@@ -29,40 +29,66 @@ Returns the unique elements of an input array `x`.
 
     -   input array. If `x` has more than one dimension, the function must flatten `x` and return the unique elements of the flattened array.
 
--   **return_counts**: _bool_
+#### Returns
 
-    -   If `True`, the function must also return the number of times each unique element occurs in `x`. Default: `False`.
+-   **out**: _Tuple\[ &lt;array&gt;, &lt;array&gt;, &lt;array&gt;, &lt;array&gt; ]_
 
--   **return_index**: _bool_
+    -   a namedtuple `(values, indices, inverse_indices, counts)` whose
 
-    -   If `True`, the function must also return the indices (first occurrences) of `x` that result in the unique array. Default: `False`.
+        -   first element must have the field name `values` and must be an array containing the unique elements of `x`.
+        -   second element must have the field name `indices` and must be an array containing the indices (first occurrences) of `x` that result in `values`. The array must have the same shape as `values` and must have the default integer data type.
+        -   third element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and must have the default integer data type.
+        -   fourth element must have the field name `counts` and must be an array containing the number of times each unique element occurs in `x`. The returned array must have same shape as `x` and must have the default integer data type.
 
--   **return_inverse**: _bool_
+(function-unique-inverse)=
+### unique_inverse(x, /)
 
-    -   If `True`, the function must also return the indices of the unique array that reconstruct `x`. Default: `False`.
+Returns the unique elements of an input array `x` and the indices from the set of unique elements that reconstruct `x`.
+
+:::{admonition} Data-dependent output shape
+:class: important
+
+The shape of one of the output arrays for this function depends on the data values in the input array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
+:::
+
+#### Parameters
+
+-   **x**: _&lt;array&gt;_
+
+    -   input array. If `x` has more than one dimension, the function must flatten `x` and return the unique elements of the flattened array.
 
 #### Returns
 
--   **out**: _Union\[ &lt;array&gt;, Tuple\[ &lt;array&gt;, ... ] ]_
+-   **out**: _Tuple\[ &lt;array&gt;, &lt;array&gt; ]_
 
-    -   if `return_counts`, `return_index`, and `return_inverse` are all `False`, an array containing the set of unique elements in `x`; otherwise, a tuple containing two or more of the following arrays (in order):
+    -   a namedtuple `(values, inverse_indices)` whose
 
-        -   **unique**: _&lt;array&gt;_
+        -   first element must have the field name `values` and must be an array containing the unique elements of `x`.
+        -   second element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and have the default integer data type.
 
-            -   an array containing the set of unique elements in `x`. The returned array must have the same data type as `x`.
+(function-unique-values)=
+### unique_values(x, /)
 
-            ```{note}
-            The order of elements is not specified, and may vary between implementations.
-            ```
+:::{admonition} Data-dependent output shape
+:class: important
 
-        -   **indices**: _&lt;array&gt;_
+The shape of the output array for this function depends on the data values in the input array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
+:::
 
-            -   an array containing the indices (first occurrences) of `x` that result in `unique`. The returned array must have the default integer data type.
+Returns the unique elements of an input array `x`.
 
-        -   **inverse**: _&lt;array&gt;_
+#### Parameters
 
-            -   an array containing the indices of `unique` that reconstruct `x`. The returned array must have the default integer data type.
+-   **x**: _&lt;array&gt;_
 
-        -   **counts**: _&lt;array&gt;_
+    -   input array. If `x` has more than one dimension, the function must flatten `x` and return the unique elements of the flattened array.
 
-            -   an array containing the number of times each unique element occurs in `x`. The returned array must have the default integer data type.
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array containing the set of unique elements in `x`. The returned array must have the same data type as `x`.
+
+        ```{note}
+        The order of elements is not specified and may vary between implementations.
+        ```

--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -18,7 +18,7 @@ A conforming implementation of the array API standard must provide and support t
 :::{admonition} Data-dependent output shape
 :class: important
 
-The shapes of one of the output arrays for this function depend on the data values in the input array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
+The shapes of two of the output arrays for this function depend on the data values in the input array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See {ref}`data-dependent-output-shapes` section for more details.
 :::
 
 Returns the unique elements of an input array `x`.

--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -38,7 +38,7 @@ Returns the unique elements of an input array `x`.
         -   first element must have the field name `values` and must be an array containing the unique elements of `x`.
         -   second element must have the field name `indices` and must be an array containing the indices (first occurrences) of `x` that result in `values`. The array must have the same shape as `values` and must have the default integer data type.
         -   third element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and must have the default integer data type.
-        -   fourth element must have the field name `counts` and must be an array containing the number of times each unique element occurs in `x`. The returned array must have same shape as `x` and must have the default integer data type.
+        -   fourth element must have the field name `counts` and must be an array containing the number of times each unique element occurs in `x`. The returned array must have same shape as `values` and must have the default integer data type.
 
 (function-unique-inverse)=
 ### unique_inverse(x, /)

--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -40,6 +40,10 @@ Returns the unique elements of an input array `x`.
         -   third element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and must have the default integer data type.
         -   fourth element must have the field name `counts` and must be an array containing the number of times each unique element occurs in `x`. The returned array must have same shape as `values` and must have the default integer data type.
 
+        ```{note}
+        The order of unique elements is not specified and may vary between implementations.
+        ```
+
 (function-unique-inverse)=
 ### unique_inverse(x, /)
 
@@ -66,6 +70,10 @@ The shape of one of the output arrays for this function depends on the data valu
         -   first element must have the field name `values` and must be an array containing the unique elements of `x`.
         -   second element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and have the default integer data type.
 
+        ```{note}
+        The order of unique elements is not specified and may vary between implementations.
+        ```
+
 (function-unique-values)=
 ### unique_values(x, /)
 
@@ -90,5 +98,5 @@ Returns the unique elements of an input array `x`.
     -   an array containing the set of unique elements in `x`. The returned array must have the same data type as `x`.
 
         ```{note}
-        The order of elements is not specified and may vary between implementations.
+        The order of unique elements is not specified and may vary between implementations.
         ```


### PR DESCRIPTION
This PR

-   resolves [gh-212](https://github.com/data-apis/array-api/issues/212) by splitting `unique` into separate functions with a fixed number of arguments, thus addressing the concerns regarding `unique`'s polymorphic behavior.

-   splits `unique` in the following functions:

    -   `unique(x, /)`: returns (1) unique values, (2) indices of first occurrence, (3) reverse indices, and (4) counts. This is the equivalent of the previous API with `return_index`, `return_inverse`, and `return_counts` kwargs as `True`.
    -   `unique_inverse(x,/)`: returns (1) unique values and (2) reverse indices. As discussed in the [OP](https://github.com/data-apis/array-api/issues/212#issue-934066289) for [gh-212](https://github.com/data-apis/array-api/issues/212), this addresses the fairly common use case of setting `return_inverse` to `True` in the previous API.
    -    `unique_values(x,/)`: only returns (1) unique values. This is the most common use of the previous API.

-   chose to retain `return_index` as a return value in `unique` as this returned array does have value in being able to construct the array of unique values and because deriving this returned array is somewhat tedious to construct via the objects in this specification otherwise.

-   eliminates polymorphic return behavior by removing kwargs from the respective APIs which affect which and how many arrays are returned.

-   adds guidance on expected output array shapes.

-   requires that named tuples be returned.