### PR TITLE
Remove the `Sequence` encapsulation of variadic parameters

### DIFF
--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -304,7 +304,7 @@ Returns coordinate matrices from coordinate vectors.
 
 #### Parameters
 
--    **arrays**: _Sequence\[ &lt;array&gt; ]_
+-    **arrays**: _&lt;array&gt;_
 
      -   one-dimensional arrays representing grid coordinates. Must have a numeric data type.
 

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -306,7 +306,7 @@ Returns coordinate matrices from coordinate vectors.
 
 -    **arrays**: _&lt;array&gt;_
 
-     -   one-dimensional arrays representing grid coordinates. Must have a numeric data type.
+     -   an arbitrary number of one-dimensional arrays representing grid coordinates. Must have numeric data types.
 
 -    **indexing**: _str_
 

--- a/spec/API_specification/data_type_functions.md
+++ b/spec/API_specification/data_type_functions.md
@@ -16,7 +16,7 @@ Broadcasts one or more arrays against one another.
 
 -   **arrays**: _&lt;array&gt;_
 
-    -   arrays to broadcast.
+    -   an arbitrary number of to-be broadcasted arrays.
 
 #### Returns
 
@@ -136,7 +136,7 @@ If provided mixed dtypes (e.g., integer and floating-point), the returned dtype 
 
 -   **arrays_and_dtypes**: _Union\[ &lt;array&gt;, &lt;dtype&gt; \]_
 
-    -   input arrays and dtypes.
+    -   an arbitrary number of input arrays and/or dtypes.
 
 #### Returns
 

--- a/spec/API_specification/data_type_functions.md
+++ b/spec/API_specification/data_type_functions.md
@@ -14,7 +14,7 @@ Broadcasts one or more arrays against one another.
 
 #### Parameters
 
--   **arrays**: _Sequence\[ &lt;array&gt; ]_
+-   **arrays**: _&lt;array&gt;_
 
     -   arrays to broadcast.
 
@@ -134,7 +134,7 @@ If provided mixed dtypes (e.g., integer and floating-point), the returned dtype 
 
 #### Parameters
 
--   **arrays_and_dtypes**: _Sequence\[ Union\[ &lt;array&gt;, &lt;dtype&gt; \] \]_
+-   **arrays_and_dtypes**: _Union\[ &lt;array&gt;, &lt;dtype&gt; \]_
 
     -   input arrays and dtypes.
 


### PR DESCRIPTION
Xref https://github.com/data-apis/array-api/issues/143 and https://github.com/numpy/numpy/pull/19969.

Variadic parameters were previously all encapsulated in a `Sequence` type, implying that each individual parameter must be a `Sequence` (rather than the encapsulated type).

Examples
---------
``` python
from typing import List

def func1(*args: List[int]) -> None: ...
func1([1], [2], [3])

def func2(*args: int) -> None: ...
func2(1, 2, 3)
```