### PR TITLE
Disallow `k=None` for the `eye` function

### DIFF
--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -150,7 +150,7 @@ Returns a two-dimensional array with ones on the `k`th diagonal and zeros elsewh
 
     -   number of columns in the output array. If `None`, the default number of columns in the output array is equal to `n_rows`. Default: `None`.
 
--   **k**: _Optional\[ int ]_
+-   **k**: _int_
 
     -   index of the diagonal. A positive value refers to an upper diagonal, a negative value to a lower diagonal, and `0` to the main diagonal. Default: `0`.
 


### PR DESCRIPTION
Xref https://github.com/data-apis/array-api/issues/143 and https://github.com/numpy/numpy/pull/19969.

The spec currently claims that the `k` parameter of [`eye`](https://data-apis.org/array-api/latest/API_specification/creation_functions.html#eye-n-rows-n-cols-none-k-0-dtype-none-device-none) should accept either `None` or an integer, however not a single mention is made of `None` in the actual parameter-description. In fact, support for `k=None` seems to be absent from the limes of `np.eye` as well.

Based on this it seems the inclusion of the `k: Optional[int] = ...` annotation may have been accidental; hence the `Optional` encapsulation is removed in this PR. If this was a deliberate choice I'd instead propose to update the docs with a more explicit mention of `None` and its expected behavior.