### PR TITLE
Specify shape behavior

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -270,7 +270,7 @@ This must equal the product of the array's dimensions.
 
 -   **out**: _Optional\[ int ]_
 
-    -   number of elements in an array. The returned value must be `None` if and only if an array dimension is unknown.
+    -   number of elements in an array. The returned value must be `None` if and only if one or more array dimensions are unknown.
 
 ```{note}
 For array libraries having graph-based computational models, an array may have unknown dimensions due to data-dependent operations.

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -251,7 +251,7 @@ Array dimensions.
 
 -   **out**: _Optional\[ Tuple\[ Optional\[ int ], ... ] ]_
 
-    -   array dimensions. An array dimension must be `None` if and only if a dimension is unknown.
+    -   array dimensions. The returned value must be `None` if and only if the rank of an array is unknown. An array dimension must be `None` if and only if a dimension is unknown.
 
 ```{note}
 For array libraries having graph-based computational models, array dimensions may be unknown due to data-dependent operations (e.g., boolean indexing; `A[:, B > 0]`) and thus cannot be statically resolved without knowing array contents.

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -234,13 +234,9 @@ Number of array dimensions (axes).
 
 #### Returns
 
--   **out**: _Optional\[ int ]_
+-   **out**: _int_
 
-    -   number of array dimensions (axes). The returned value must be `None` if and only if an array has unknown rank.
-
-```{note}
-For array libraries having graph-based computational models, an array may have an unknown rank due to operations which return an array having a data-dependent shape (e.g., returning an array of unique values).
-```
+    -   number of array dimensions (axes).
 
 (attribute-shape)=
 ### shape
@@ -249,9 +245,9 @@ Array dimensions.
 
 #### Returns
 
--   **out**: _Optional\[ Tuple\[ Optional\[ int ], ... ] ]_
+-   **out**: _Tuple\[ Optional\[ int ], ... ]_
 
-    -   array dimensions. The returned value must be `None` if and only if the rank of an array is unknown. An array dimension must be `None` if and only if a dimension is unknown.
+    -   array dimensions. An array dimension must be `None` if and only if a dimension is unknown.
 
 ```{note}
 For array libraries having graph-based computational models, array dimensions may be unknown due to data-dependent operations (e.g., boolean indexing; `A[:, B > 0]`) and thus cannot be statically resolved without knowing array contents.
@@ -274,10 +270,10 @@ This must equal the product of the array's dimensions.
 
 -   **out**: _Optional\[ int ]_
 
-    -   number of elements in an array. The returned value must be `None` if and only if the array rank or an array dimension is unknown.
+    -   number of elements in an array. The returned value must be `None` if and only if an array dimension is unknown.
 
 ```{note}
-For array libraries having graph-based computational models, an array may have unknown rank or dimensions due to data-dependent operations.
+For array libraries having graph-based computational models, an array may have unknown dimensions due to data-dependent operations.
 ```
 
 (attribute-T)=

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -234,11 +234,13 @@ Number of array dimensions (axes).
 
 #### Returns
 
--   **out**: _int_
+-   **out**: _Optional\[ int ]_
 
-    -   number of array dimensions (axes).
+    -   number of array dimensions (axes). The returned value must be `None` if and only if an array has unknown rank.
 
-_TODO: need to more carefully consider this in order to accommodate, e.g., graph tensors where the number of dimensions may be dynamic._
+```{note}
+For array libraries having graph-based computational models, an array may have an unknown rank due to operations which return an array having a data-dependent shape (e.g., returning an array of unique values).
+```
 
 (attribute-shape)=
 ### shape
@@ -247,24 +249,36 @@ Array dimensions.
 
 #### Returns
 
--   **out**: _Union\[ Tuple\[ int, ...], &lt;shape&gt; ]_
+-   **out**: _Optional\[ Tuple\[ Optional\[ int ], ... ] ]_
 
-    -   array dimensions as either a tuple or a custom shape object. If a shape object, the object must be immutable and must support indexing for dimension retrieval.
+    -   array dimensions. An array dimension must be `None` if and only if a dimension is unknown.
 
-_TODO: need to more carefully consider this in order to accommodate, e.g., graph tensors where a shape may be dynamic._
+```{note}
+For array libraries having graph-based computational models, array dimensions may be unknown due to data-dependent operations (e.g., boolean indexing; `A[:, B > 0]`) and thus cannot be statically resolved without knowing array contents.
+```
+
+```{note}
+The returned value should be a tuple; however, where warranted, an array library may choose to return a custom shape object. If an array library returns a custom shape object, the object must be immutable, must support indexing for dimension retrieval, and must behave similarly to a tuple.
+```
 
 (attribute-size)=
 ### size
 
-Number of elements in an array. This must equal the product of the array's dimensions.
+Number of elements in an array.
+
+```{note}
+This must equal the product of the array's dimensions.
+```
 
 #### Returns
 
--   **out**: _int_
+-   **out**: _Optional\[ int ]_
 
-    -   number of elements in an array.
+    -   number of elements in an array. The returned value must be `None` if and only if the array rank or an array dimension is unknown.
 
-_TODO: need to more carefully consider this in order to accommodate, e.g., graph tensors where the number of elements may be dynamic._
+```{note}
+For array libraries having graph-based computational models, an array may have unknown rank or dimensions due to data-dependent operations.
+```
 
 (attribute-T)=
 ### T
@@ -741,11 +755,6 @@ Computes the truth value of `self_i <= other_i` for each element of an array ins
 ```{note}
 Element-wise results must equal the results returned by the equivalent element-wise function [`less_equal(x1, x2)`](elementwise_functions.md#less_equalx1-x2-).
 ```
-
-(method-__len__)=
-### \_\_len\_\_(self, /)
-
-_TODO: need to more carefully consider this in order to accommodate, e.g., graph tensors where a shape may be dynamic. Furthermore, not clear whether this should be implemented, as, e.g., NumPy's behavior of returning the size of the first dimension is not necessarily intuitive, as opposed to, say, the total number of elements._
 
 (method-__lshift__)=
 ### \_\_lshift\_\_(self, other, /)


### PR DESCRIPTION
This PR

-   resolves [gh-97](https://github.com/data-apis/array-api/issues/97) and follows the guidance discussed [therein](https://github.com/data-apis/array-api/issues/97#issuecomment-948325555). **Update**: supporting unknown ranks is no longer included in this proposal (see [comment](https://github.com/data-apis/array-api/issues/97#issuecomment-961342592)).
-   allows `x.shape` to return a tuple with `None` elements to indicate that a dimension is unknown.
-   tightens guidance specifying that `x.shape` should return a tuple. A custom shape object is allowed so long as it behaves like a tuple.
-   removes `__len__` from the specification. NumPy, TF, and others return the size of the first dimension when `len()` (which calls `__len__`) is invoked on an array. In Python, [`__len__`](https://docs.python.org/3/reference/datamodel.html#object.__len__) should return integer `>=0`. Given the above changes accommodating unknown shapes/dimensions, returning an integer cannot be guaranteed as the first dimension could be unknown and thus `None`. Accordingly, this PR elects to remove `__len__` from the specification.