### PR TITLE
Add specification for explicitly casting an array to a specified dtype

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx-material==0.0.30
 myst-parser
 sphinx_markdown_tables
 sphinx_copybutton
+docutils<0.18

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -59,7 +59,7 @@ Convert the input to an array.
 
 -   **obj**: _Union\[ &lt;array&gt;, bool, int, float, NestedSequence\[ bool | int | float ], SupportsDLPack, SupportsBufferProtocol ]_
 
-    -   Object to be converted to an array. Can be a Python scalar, a (possibly nested) sequence of Python scalars, or an object supporting DLPack or the Python buffer protocol.
+    -   object to be converted to an array. May be a Python scalar, a (possibly nested) sequence of Python scalars, or an object supporting DLPack or the Python buffer protocol.
 
     :::{tip}
     An object supporting DLPack has `__dlpack__` and `__dlpack_device__` methods.
@@ -68,7 +68,19 @@ Convert the input to an array.
 
 -   **dtype**: _Optional\[ &lt;dtype&gt; ]_
 
-    -   output array data type. If `dtype` is `None`, the output array data type must be inferred from the data type(s) in `obj`. If all input values are Python scalars, then if they're all `bool` the output dtype will be `bool`; if they're a mix of `bool`s and `int` the output dtype will be the default integer data type; if they contain `float`s the output dtype will be the default floating-point data type. Default: `None`.
+    -   output array data type. If `dtype` is `None`, the output array data type must be inferred from the data type(s) in `obj`. If all input values are Python scalars, then
+
+        -   if all values are of type `bool`, the output data type must be `bool`.
+        -   if the values are a mixture of `bool`s and `int`, the output data type must be the default integer data type.
+        -   if one or more values are `float`s, the output data type must be the default floating-point data type.
+
+        Default: `None`.
+
+        ```{note}
+        If `dtype` is not `None`, then array conversions should obey {ref}`type-promotion` rules. Conversions not specified according to {ref}`type-promotion` rules may or may not be permitted by a conforming array library.
+
+        To perform an explicit cast, use {ref}`function-astype`.
+        ```
 
 -   **device**: _Optional\[ &lt;device&gt; ]_
 
@@ -76,13 +88,13 @@ Convert the input to an array.
 
 -   **copy**: _Optional\[ bool ]_
 
-    -   Whether or not to make a copy of the input. If `True`, always copies. If `False`, never copies for input which supports DLPack or the buffer protocol, and raises `ValueError` in case that would be necessary. If `None`, reuses existing memory buffer if possible, copies otherwise. Default: `None`.
+    -   boolean indicating whether or not to copy the input. If `True`, the function must always copy. If `False`, the function must never copy for input which supports DLPack or the buffer protocol, and raises `ValueError` in case a copy would be necessary. If `None`, the function must reuse existing memory buffer if possible and copy otherwise. Default: `None`.
 
 #### Returns
 
 -   **out**: _&lt;array&gt;_
 
-    -   An array containing the data from `obj`.
+    -   an array containing the data from `obj`.
 
 
 (function-empty)=

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -88,7 +88,7 @@ Convert the input to an array.
 
 -   **copy**: _Optional\[ bool ]_
 
-    -   boolean indicating whether or not to copy the input. If `True`, the function must always copy. If `False`, the function must never copy for input which supports DLPack or the buffer protocol, and raises `ValueError` in case a copy would be necessary. If `None`, the function must reuse existing memory buffer if possible and copy otherwise. Default: `None`.
+    -   boolean indicating whether or not to copy the input. If `True`, the function must always copy. If `False`, the function must never copy for input which supports DLPack or the buffer protocol and must raise a `ValueError` in case a copy would be necessary. If `None`, the function must reuse existing memory buffer if possible and copy otherwise. Default: `None`.
 
 #### Returns
 

--- a/spec/API_specification/data_type_functions.md
+++ b/spec/API_specification/data_type_functions.md
@@ -7,6 +7,32 @@ A conforming implementation of the array API standard must provide and support t
 <!-- NOTE: please keep the constants in alphabetical order -->
 
 ## Objects in API
+
+(function-astype)=
+### astype(x, dtype, /)
+
+Copies an array to a specified data type irrespective of {ref}`type-promotion` rules.
+
+```{note}
+Casting floating-point `NaN` and `infinity` values to integral data types is not specified and implementation-dependent.
+```
+
+#### Parameters
+
+-   **x**: _&lt;array&gt;_
+
+    -   array to cast.
+    
+-   **dtype**: _&lt;dtype&gt;_
+
+    -   desired data type.
+    
+#### Returns
+
+-   **out**: _&lt;array&gt;_
+
+    -   an array having the specified data type. The returned array must have the same shape as `x`.
+
 (function-broadcast_arrays)=
 ### broadcast_arrays(*arrays)
 

--- a/spec/API_specification/data_type_functions.md
+++ b/spec/API_specification/data_type_functions.md
@@ -9,7 +9,7 @@ A conforming implementation of the array API standard must provide and support t
 ## Objects in API
 
 (function-astype)=
-### astype(x, dtype, /)
+### astype(x, dtype, /, *, copy=True)
 
 Copies an array to a specified data type irrespective of {ref}`type-promotion` rules.
 
@@ -26,6 +26,10 @@ Casting floating-point `NaN` and `infinity` values to integral data types is not
 -   **dtype**: _&lt;dtype&gt;_
 
     -   desired data type.
+    
+-   **copy**: _&lt;bool&gt;_
+
+    -   specifies whether to copy an array when the specified `dtype` matches the data type of the input array `x`. If `True`, a newly allocated array must always be returned. If `False` and the specified `dtype` matches the data type of the input array, the input array must be returned; otherwise, a newly allocated must be returned. Default: `True`.
     
 #### Returns
 

--- a/spec/API_specification/data_type_functions.md
+++ b/spec/API_specification/data_type_functions.md
@@ -14,7 +14,7 @@ A conforming implementation of the array API standard must provide and support t
 Copies an array to a specified data type irrespective of {ref}`type-promotion` rules.
 
 ```{note}
-Casting floating-point `NaN` and `infinity` values to integral data types is not specified and implementation-dependent.
+Casting floating-point `NaN` and `infinity` values to integral data types is not specified and is implementation-dependent.
 ```
 
 #### Parameters


### PR DESCRIPTION
This PR

-   specifies an `astype` API for explicitly casting an array to a specified dtype.
-   adds a functional API rather than an array object method following conventions set forth in this specification to maintain a minimal array object API.
-   uses the `astype` name to mirror the NumPy array object method [`x.astype()`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.astype.html).
-   includes a `copy` kwarg to allow returning the input array iff `copy` is `False` and the specified `dtype` matches the data type of the input array. Every library except TensorFlow supports this kwarg. During the consortium meeting on 21 October 2021, TF supported including the `copy` kwarg in the specification.
-   updates conversion guidance for `asarray` to only require support for conversions following type promotion rules described in this specification. With the addition of `astype`, overloading `asarray` with comprehensive casting semantics for input arrays is not necessary.
-    resolves https://github.com/data-apis/array-api/issues/264.

## Prior Art

-   TF [`cast`](https://www.tensorflow.org/api_docs/python/tf/cast): only supports providing a `dtype` argument.
-   NumPy [`x.astype`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.astype.html): supports `order`, `casting`, and `copy` kwargs.
-   CuPy [`x.astype`](https://docs.cupy.dev/en/stable/reference/generated/cupy.ndarray.html#cupy.ndarray.astype): supports `order` and `copy` kwargs.
-   Dask [`x.astype`](https://docs.dask.org/en/latest/generated/dask.array.Array.astype.html): supports `casting` and `copy` kwargs.
-   Torch [`to`](https://pytorch.org/docs/stable/generated/torch.Tensor.to.html#torch.Tensor.to): supports `copy` and `device` kwargs.
-   MXNet [`x.astype`](https://mxnet.apache.org/versions/1.8.0/api/python/docs/api/ndarray/ndarray.html#mxnet.ndarray.NDArray.astype): supports `copy` kwarg.