### PR TITLE
Add note concerning the casting of boolean input arrays

### DIFF
--- a/spec/API_specification/data_type_functions.md
+++ b/spec/API_specification/data_type_functions.md
@@ -17,6 +17,12 @@ Copies an array to a specified data type irrespective of {ref}`type-promotion` r
 Casting floating-point `NaN` and `infinity` values to integral data types is not specified and is implementation-dependent.
 ```
 
+```{note}
+When casting a boolean input array to a numeric data type, a value of `True` must cast to a numeric value equal to `1`, and a value of `False` must cast to a numeric value equal to `0`.
+
+When casting a numeric input array to `bool`, a value of `0` must cast to `False`, and a non-zero value must cast to `True`.
+```
+
 #### Parameters
 
 -   **x**: _&lt;array&gt;_


### PR DESCRIPTION
This PR

-   adds a clarifying note regarding the casting of boolean input arrays. Namely, that `True` and `False` must cast to `1` and `0` numeric values, respectively, and `0` and non-zero numeric values must cast to `False` and `True`, respectively.
-    this was discussed during the consortium meeting held on 21 October 2021. 