### PR TITLE
Include entry points as an optional feature

### DIFF
--- a/spec/conf.py
+++ b/spec/conf.py
@@ -143,4 +143,5 @@ extlinks = {
     ),
     "durole": ("http://docutils.sourceforge.net/docs/ref/rst/" "roles.html#%s", ""),
     "dudir": ("http://docutils.sourceforge.net/docs/ref/rst/" "directives.html#%s", ""),
+    "pypa": ("https://packaging.python.org/%s", ""),
 }

--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -369,6 +369,38 @@ recommended not to add other functions or objects, because that may make it
 harder for users to write code that will work with multiple array libraries.
 
 
+### Discoverability
+
+Libraries that wish to [create arrays](../API_specification/creation_functions.md)
+using multiple array libraries would still need to explicitly import each
+library, as [`__array_namespace__()`](method-__array_namespace__) only makes an
+API namespace accessible when consuming arrays.
+
+To address this issue, an {pypa}`entry point <specifications/entry-points/>` may
+be provided by a conforming implementation to make its API namespace
+discoverable:
+
+```python
+from importlib.metadata import entry_points
+
+try:
+    eps = entry_points()['array_api']
+    ep = next(ep for ep in eps if ep.name == 'package_name')
+except TypeError:
+    # The dict interface for entry_points() is deprecated in py3.10,
+    # supplanted by a new select interface.
+    ep = entry_points(group='array_api', name='package_name')
+
+xp = ep.load()
+```
+
+The properties of an entry point should have:
+
+- `array_api` as the **group**
+- The package name as the **name**
+- The import path to the API namespace as the **object reference**
+
+
 * * *
 
 ## Conformance

--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -371,7 +371,7 @@ harder for users to write code that will work with multiple array libraries.
 
 ### Discoverability
 
-To assist array-consuming libraries which need to create arrays originating from multiple conforming array implementations, conforming implementations may provide an {pypa}`entry point <specifications/entry-points/>` in order to make an array API namespace discoverable:
+To assist array-consuming libraries which need to create arrays originating from multiple conforming array implementations, conforming implementations may provide an {pypa}`entry point <specifications/entry-points/>` in order to make an array API namespace discoverable. For example,
 
 ```python
 from importlib.metadata import entry_points

--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -371,7 +371,7 @@ harder for users to write code that will work with multiple array libraries.
 
 ### Discoverability
 
-To assist array-consuming libraries which need to create arrays originating from multiple conforming array implementations, conforming implementations may provide a {pypa}`entry point <specifications/entry-points/>` in order to make an array API namespace discoverable:
+To assist array-consuming libraries which need to create arrays originating from multiple conforming array implementations, conforming implementations may provide an {pypa}`entry point <specifications/entry-points/>` in order to make an array API namespace discoverable:
 
 ```python
 from importlib.metadata import entry_points

--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -371,14 +371,7 @@ harder for users to write code that will work with multiple array libraries.
 
 ### Discoverability
 
-Libraries that wish to [create arrays](../API_specification/creation_functions.md)
-using multiple array libraries would still need to explicitly import each
-library, as [`__array_namespace__()`](method-__array_namespace__) only makes an
-API namespace accessible when consuming arrays.
-
-To address this issue, an {pypa}`entry point <specifications/entry-points/>` may
-be provided by a conforming implementation to make its API namespace
-discoverable:
+To assist array-consuming libraries which need to create arrays originating from multiple conforming array implementations, conforming implementations may provide an {pypa}`entry point <specifications/entry-points/>` in order to make an array API namespace discoverable:
 
 ```python
 from importlib.metadata import entry_points
@@ -394,11 +387,11 @@ except TypeError:
 xp = ep.load()
 ```
 
-The properties of an entry point should have:
+An entry point must have the following properties:
 
-- `array_api` as the **group**
-- The package name as the **name**
-- The import path to the API namespace as the **object reference**
+-   **group**: equal to `array_api`.
+-   **name**: equal to the package name.
+-   **object reference**: equal to the array API namespace import path.
 
 
 * * *

--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -371,7 +371,7 @@ harder for users to write code that will work with multiple array libraries.
 
 ### Discoverability
 
-To assist array-consuming libraries which need to create arrays originating from multiple conforming array implementations, conforming implementations may provide an {pypa}`entry point <specifications/entry-points/>` in order to make an array API namespace discoverable:
+To assist array-consuming libraries which need to create arrays originating from multiple conforming array implementations, conforming implementations may provide a {pypa}`entry point <specifications/entry-points/>` in order to make an array API namespace discoverable:
 
 ```python
 from importlib.metadata import entry_points


### PR DESCRIPTION
Resolves #244 by adding a subsection that goes over entry points as an optional thing to adopt in the "How to adopt this API" section.

I thought to give an example of how it would be used, like how `xp = x.__array_namespace__()` is shown above. It's a bit awkward due to the [dict interface deprecation](https://importlib-metadata.readthedocs.io/en/latest/history.html#v3-9-0), but it seemed better to address it in the code example than in a separate note.

I also thought to give an example of defining an entry point in setup.py i.e. `entry_points={'array_api': ['package_name = package_name.array_api']}`, but that is a bit out-of-scope really.