### PR TITLE
Arrays must share the same dtype in `meshgrid()`

### DIFF
--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -322,7 +322,7 @@ Returns coordinate matrices from coordinate vectors.
 
 -    **arrays**: _&lt;array&gt;_
 
-     -   an arbitrary number of one-dimensional arrays representing grid coordinates. Must have numeric data types.
+     -   an arbitrary number of one-dimensional arrays representing grid coordinates. Each array must have the same numeric data type.
 
 -    **indexing**: _str_
 
@@ -342,7 +342,7 @@ Returns coordinate matrices from coordinate vectors.
 
          Similarly, for the three-dimensional case with input one-dimensional arrays of length `M`, `N`, and `P`, if matrix indexing `ij`, then each returned array must have shape `(M, N, P)`, and, if Cartesian indexing `xy`, then each returned array must have shape `(N, M, P)`.
 
-         The returned arrays must have a numeric data type determined by {ref}`type-promotion`.
+         Each returned array must have the same data type as the input arrays.
 
 (function-ones)=
 ### ones(shape, *, dtype=None, device=None)

--- a/spec/API_specification/creation_functions.md
+++ b/spec/API_specification/creation_functions.md
@@ -322,7 +322,7 @@ Returns coordinate matrices from coordinate vectors.
 
 -    **arrays**: _&lt;array&gt;_
 
-     -   an arbitrary number of one-dimensional arrays representing grid coordinates. Each array must have the same numeric data type.
+     -   an arbitrary number of one-dimensional arrays representing grid coordinates. Each array should have the same numeric data type.
 
 -    **indexing**: _str_
 
@@ -342,7 +342,7 @@ Returns coordinate matrices from coordinate vectors.
 
          Similarly, for the three-dimensional case with input one-dimensional arrays of length `M`, `N`, and `P`, if matrix indexing `ij`, then each returned array must have shape `(M, N, P)`, and, if Cartesian indexing `xy`, then each returned array must have shape `(N, M, P)`.
 
-         Each returned array must have the same data type as the input arrays.
+         Each returned array should have the same data type as the input arrays.
 
 (function-ones)=
 ### ones(shape, *, dtype=None, device=None)


### PR DESCRIPTION
This PR clarifies that input arrays must share the same dtype.

Allowing mixed dtypes complicates both user expectations and developer implementations for the returned arrays, which is currently outlined as all having the same promoted dtype (differing from both NumPy and PyTorch behaviour). It also does not seem like anyone would use or desire input arrays of mixed dtypes.

```python
>>> x1 = np.arange(5, dtype=np.int32)
>>> x2 = np.arange(5, dtype=np.int64)
>>> out1, out2 = np.meshgrid(x1, x2)
>>> out1.dtype
int32  # same as x1.dtype
>>> out2.dtype
int64  # same as x2.dtype
...
>>> t1 = torch.arange(5, dtype=torch.int32)
>>> t2 = torch.arange(5, dtype=torch.int64)
>>> torch.meshgrid(t1, t2)
RuntimeError: meshgrid expects all tensors to have the same dtype
```