### PR TITLE
Clarify in-place operations mirror special case behaviour

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -153,12 +153,13 @@ an array object supporting the following in-place Python operators:
 - `<<=`. May be implemented via `__ilshift__`.
 - `>>=`. May be implemented via `__irshift__`.
 
-An in-place operation must follow all the special cases of its respective
-standard operation (e.g. `__radd__` has the same special case behaviour as
-`__add__`).
-
 An in-place operation must not change the dtype or shape of the in-place array
 as a result of {ref}`type-promotion` or {ref}`broadcasting`.
+
+An in-place operation must follow all the functionality of its respective
+standard operation (including special casing), e.g. the resulting array `x1`
+after in-place addition `x1 += x2` would always equal the result of standard
+addition `x1 + x2`.
 
 ```{note}
 

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -153,6 +153,10 @@ an array object supporting the following in-place Python operators:
 - `<<=`. May be implemented via `__ilshift__`.
 - `>>=`. May be implemented via `__irshift__`.
 
+An in-place operation must follow all the special cases of its respective
+standard operation (e.g. `__radd__` has the same special case behaviour as
+`__add__`).
+
 An in-place operation must not change the dtype or shape of the in-place array
 as a result of {ref}`type-promotion` or {ref}`broadcasting`.
 

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -156,10 +156,10 @@ an array object supporting the following in-place Python operators:
 An in-place operation must not change the dtype or shape of the in-place array
 as a result of {ref}`type-promotion` or {ref}`broadcasting`.
 
-An in-place operation must follow all the functionality of its respective
-standard operation (including special casing), e.g. the resulting array `x1`
-after in-place addition `x1 += x2` would always equal the result of standard
-addition `x1 + x2`.
+An in-place operation must have the same behavior (including special cases) as
+its respective binary (i.e., two operand, non-assignment) operation. For example,
+after in-place addition `x1 += x2`, the modified array `x1` must always equal the
+result of the equivalent binary arithmetic operation `x1 = x1 + x2`.
 
 ```{note}
 


### PR DESCRIPTION
Currently it's ambiguous if in-place operations need to follow the special case behaviour of their standard operation (and elementwise) counter-parts. This PR notes that this indeed is the case.