### PR TITLE
Require static memory allocation for PyCapsule names

### DIFF
--- a/spec/design_topics/data_interchange.md
+++ b/spec/design_topics/data_interchange.md
@@ -124,6 +124,9 @@ be inspected by name.
 The consumer must set the PyCapsule name to `"used_dltensor"`, and call the
 `deleter` of the `DLPackManagedTensor` when it no longer needs the data.
 
+Note: the capsule names ``"dltensor"`` and `"used_dltensor"` must be statically
+allocated.
+
 When the `strides` field in the `DLTensor` struct is `NULL`, it indicates a
 row-major compact array. If the array is of size zero, the data pointer in
 `DLTensor` should be set to either `NULL` or `0`.


### PR DESCRIPTION
This PR fixes a technical overlook. According to [the Python documentation](https://docs.python.org/3/c-api/capsule.html), the only requirement for PyCapsule names is that it must outlive the capsule, but it can be either statically or dynamically allocated. For the latter, the suggestion (not requirement) is to free it when the destructor is launched.

This brings in two issues. First, the DLPack protocol requires the consumer to overwrite the name, but if the name is dynamically allocated, the following operation would raise a compiler warning to the very least:
```C
const char* old_name = PyCapsule_GetName(capsule)
free((void*)old_name);  // lost constness
int result = PyCapsule_SetName(PyCapsule_GetName, new_name);
```
A further problem is we do not know if `free` is the correct deallocation routine, which leads to potential crash hazard. 

The second problem is a symmetric one w.r.t the 1st: if the consumer also allocates a name dynamically, by the time of destruction it *could* be freed by the producer's (mismatching) deallocation routine.

This PR suggests a simple fix by asking all libraries to allocate the names statically. This has no practical impact because it's already the status quo, at least in CuPy and PyTorch.