### PR TITLE
Update guidance for linalg `rtol` tolerance cutoff to accommodate non-SVD-like algorithms

### DIFF
--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -345,7 +345,7 @@ Returns the rank (i.e., number of non-zero singular values) of a matrix (or a st
 
 -   **rtol**: _Optional\[ Union\[ float, &lt;array&gt; ] ]_
 
-    -   relative tolerance for small singular values. Singular values less than or equal to `rtol * largest_singular_value` are set to zero. If a `float`, the value is equivalent to a zero-dimensional array having a floating-point data type determined by {ref}`type-promotion` (as applied to `x`) and must be broadcast against each matrix. If an `array`, must have a floating-point data type and must be compatible with `shape(x)[:-2]` (see {ref}`broadcasting`). If `None`, the default value is `max(M, N) * eps`, where `eps` must be the machine epsilon associated with the floating-point data type determined by {ref}`type-promotion` (as applied to `x`). Default: `None`.
+    -   relative tolerance for small singular values. Singular values approximately less than or equal to `rtol * largest_singular_value` are set to zero. If a `float`, the value is equivalent to a zero-dimensional array having a floating-point data type determined by {ref}`type-promotion` (as applied to `x`) and must be broadcast against each matrix. If an `array`, must have a floating-point data type and must be compatible with `shape(x)[:-2]` (see {ref}`broadcasting`). If `None`, the default value is `max(M, N) * eps`, where `eps` must be the machine epsilon associated with the floating-point data type determined by {ref}`type-promotion` (as applied to `x`). Default: `None`.
 
 #### Returns
 
@@ -392,7 +392,7 @@ Returns the (Moore-Penrose) pseudo-inverse of a matrix (or a stack of matrices) 
 
 -   **rtol**: _Optional\[ Union\[ float, &lt;array&gt; ] ]_
 
-    -   relative tolerance for small singular values. Singular values less than or equal to `rtol * largest_singular_value` are set to zero. If a `float`, the value is equivalent to a zero-dimensional array having a floating-point data type determined by {ref}`type-promotion` (as applied to `x`) and must be broadcast against each matrix. If an `array`, must have a floating-point data type and must be compatible with `shape(x)[:-2]` (see {ref}`broadcasting`). If `None`, the default value is `max(M, N) * eps`, where `eps` must be the machine epsilon associated with the floating-point data type determined by {ref}`type-promotion` (as applied to `x`). Default: `None`.
+    -   relative tolerance for small singular values. Singular values approximately less than or equal to `rtol * largest_singular_value` are set to zero. If a `float`, the value is equivalent to a zero-dimensional array having a floating-point data type determined by {ref}`type-promotion` (as applied to `x`) and must be broadcast against each matrix. If an `array`, must have a floating-point data type and must be compatible with `shape(x)[:-2]` (see {ref}`broadcasting`). If `None`, the default value is `max(M, N) * eps`, where `eps` must be the machine epsilon associated with the floating-point data type determined by {ref}`type-promotion` (as applied to `x`). Default: `None`.
 
 #### Returns
 


### PR DESCRIPTION
This PR

-   resolves https://github.com/data-apis/array-api/issues/216 by updating the guidance for `rtol` to accommodate non-SVD-like algorithms. Namely, instead of a strict cutoff of less than or equal to, this PR updates the guidance to say "approximately less than or equal to" to allow conforming implementations some wiggle room should they choose a non-SVD-like algorithm for implementing `pinv`. For `matrix_rank`, the API is already defined in terms of singular values, so, in practice, an implementation is likely to be SVD-based; in which case, the more strict guidance is likely to hold.
-   in general, the previous guidance should hold true, given the prevalent usage of LAPACK; however, array libraries should be able to use alternative algorithms in accordance with the design principle to be "implementation agnostic". A future refinement could be to define the tolerance in terms of condition numbers, but that is left to future consideration.