### PR TITLE
Disallow providing a stack of vectors to `linalg.solve`

### DIFF
--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -484,7 +484,7 @@ Whether an array library explicitly checks whether an input array is full rank i
 
 -   **x2**: _&lt;array&gt;_
 
-    -   ordinate (or "dependent variable") array `B`. If `x2` has shape `(..., M)`, `x2` is equivalent to an array having shape `(..., M, 1)`, and `shape(x2)` must be compatible with `shape(x1)[:-1]` (see {ref}`broadcasting`). If `x2` has shape `(..., M, K)`, each column `k` defines a set of ordinate values for which to compute a solution, and `shape(x2)[:-1]` must be compatible with `shape(x1)[:-1]` (see {ref}`broadcasting`). Should have a floating-point data type.
+    -   ordinate (or "dependent variable") array `B`. If `x2` has shape `(M)`, `x2` is equivalent to an array having shape `(..., M, 1)`. If `x2` has shape `(..., M, K)`, each column `k` defines a set of ordinate values for which to compute a solution, and `shape(x2)[:-1]` must be compatible with `shape(x1)[:-1]` (see {ref}`broadcasting`). Should have a floating-point data type.
 
 #### Returns
 

--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -484,7 +484,7 @@ Whether an array library explicitly checks whether an input array is full rank i
 
 -   **x2**: _&lt;array&gt;_
 
-    -   ordinate (or "dependent variable") array `B`. If `x2` has shape `(M)`, `x2` is equivalent to an array having shape `(..., M, 1)`. If `x2` has shape `(..., M, K)`, each column `k` defines a set of ordinate values for which to compute a solution, and `shape(x2)[:-1]` must be compatible with `shape(x1)[:-1]` (see {ref}`broadcasting`). Should have a floating-point data type.
+    -   ordinate (or "dependent variable") array `B`. If `x2` has shape `(M,)`, `x2` is equivalent to an array having shape `(..., M, 1)`. If `x2` has shape `(..., M, K)`, each column `k` defines a set of ordinate values for which to compute a solution, and `shape(x2)[:-1]` must be compatible with `shape(x1)[:-1]` (see {ref}`broadcasting`). Should have a floating-point data type.
 
 #### Returns
 


### PR DESCRIPTION
This PR

-   resolves https://github.com/data-apis/array-api/issues/285 by disallowing providing stacks of one-dimensional vectors. This resolves an ambiguity when `M=K` and determination of broadcasting semantics.