### PR TITLE
Remove obsolete note

### DIFF
--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -349,24 +349,10 @@ request a specific API version:
 xp = x.__array_namespace__(api_version='2020.10')
 ```
 
-```{note}
-
-This is inspired by [NEP 37](https://numpy.org/neps/nep-0037-array-module.html#how-to-use-get-array-module),
-however it avoids adding a dependency on NumPy or having to provide a
-separate package just to do `get_array_module(x)`
-
-NEP 37 is still in flux (it was just accepted by JAX and TensorFlow on an
-experimental basis), and it's possible that that should be accepted instead.
-
-TBD: a decision must be made on this topic before a first version of the
-standard can become final. We prefer to delay this decision, to see how
-NEP 37 adoption will work out.
-```
-
 The `xp` namespace must contain all functionality specified in
-{ref}`api-specification`. It may contain other functionality, however it is
-recommended not to add other functions or objects, because that may make it
-harder for users to write code that will work with multiple array libraries.
+{ref}`api-specification`. The namespace may contain other functionality; however,
+including additional functionality is not recommended as doing so may hinder
+portability and inter-operation of array libraries within user code.
 
 
 ### Discoverability


### PR DESCRIPTION
This PR

-   removes an obsolete note concerning adoption. The note referenced NEP 37; however, that proposal has not seen the requisite movement necessary to change either the specification's use of `__array_namespace__` or the experimental implementation in NumPy. Accordingly, this PR chooses to remove the note to avoid creating any uncertainty regarding the preferred mechanism of exposing a conforming array implementation as a separate namespace.

cc @rgommers for visibility.