### PR TITLE
Add note concerning division by zero for integer dtypes in floor_divide and remainder

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -608,6 +608,10 @@ Converts a zero-dimensional floating-point array to a Python `float` object.
 
 Evaluates `self_i // other_i` for each element of an array instance with the respective element of the array `other`.
 
+```{note}
+For input arrays which promote to an integer data type, the result of division by zero is unspecified and thus implementation-defined.
+```
+
 #### Parameters
 
 -   **self**: _&lt;array&gt;_
@@ -885,6 +889,10 @@ The `matmul` function must implement the same semantics as the built-in `@` oper
 ### \_\_mod\_\_(self, other, /)
 
 Evaluates `self_i % other_i` for each element of an array instance with the respective element of the array `other`.
+
+```{note}
+For input arrays which promote to an integer data type, the result of division by zero is unspecified and thus implementation-defined.
+```
 
 #### Parameters
 

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -668,6 +668,10 @@ Rounds each element `x_i` of the input array `x` to the greatest (i.e., closest 
 
 Rounds the result of dividing each element `x1_i` of the input array `x1` by the respective element `x2_i` of the input array `x2` to the greatest (i.e., closest to `+infinity`) integer-value number that is not greater than the division result.
 
+```{note}
+For input arrays which promote to an integer data type, the result of division by zero is unspecified and thus implementation-defined.
+```
+
 #### Parameters
 
 -   **x1**: _&lt;array&gt;_
@@ -1212,6 +1216,10 @@ For floating-point operands,
 ### remainder(x1, x2, /)
 
 Returns the remainder of division for each element `x1_i` of the input array `x1` and the respective element `x2_i` of the input array `x2`.
+
+```{note}
+For input arrays which promote to an integer data type, the result of division by zero is unspecified and thus implementation-defined.
+```
 
 #### Parameters
 


### PR DESCRIPTION
This PR

-   resolves https://github.com/data-apis/array-api/issues/199 by adding a note to `floor_divide` and `remainder` concerning expected behavior when input arrays promote to an integer dtype. Namely, that the result of division by zero is implementation defined (e.g., throwing an error, emitting a warning and returning zero, or something else).

cc @asmeurer 