### PR TITLE
Add guidance for when rounding special floating-point values

### DIFF
--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -1253,7 +1253,6 @@ Rounds each element `x_i` of the input array `x` to the nearest integer-valued n
 #### Special Cases
 
 -   If `x_i` is already integer-valued, the result is `x_i`.
--   If two integers are equally close to `x_i`, the result is the even integer closest to `x_i`.
 
 For floating-point operands,
 
@@ -1262,6 +1261,7 @@ For floating-point operands,
 -   If `x_i` is `+0`, the result is `+0`.
 -   If `x_i` is `-0`, the result is `-0`.
 -   If `x_i` is `NaN`, the result is `NaN`.
+-   If two integers are equally close to `x_i`, the result is the even integer closest to `x_i`.
 
 #### Parameters
 

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -449,6 +449,14 @@ Rounds each element `x_i` of the input array `x` to the smallest (i.e., closest 
 
 -   If `x_i` is already integer-valued, the result is `x_i`.
 
+For floating-point operands,
+
+-   If `x_i` is `+infinity`, the result is `+infinity`.
+-   If `x_i` is `-infinity`, the result is `-infinity`.
+-   If `x_i` is `+0`, the result is `+0`.
+-   If `x_i` is `-0`, the result is `-0`.
+-   If `x_i` is `NaN`, the result is `NaN`.
+
 #### Parameters
 
 -   **x**: _&lt;array&gt;_
@@ -650,6 +658,14 @@ Rounds each element `x_i` of the input array `x` to the greatest (i.e., closest 
 #### Special Cases
 
 -   If `x_i` is already integer-valued, the result is `x_i`.
+
+For floating-point operands,
+
+-   If `x_i` is `+infinity`, the result is `+infinity`.
+-   If `x_i` is `-infinity`, the result is `-infinity`.
+-   If `x_i` is `+0`, the result is `+0`.
+-   If `x_i` is `-0`, the result is `-0`.
+-   If `x_i` is `NaN`, the result is `NaN`.
 
 #### Parameters
 
@@ -1239,6 +1255,14 @@ Rounds each element `x_i` of the input array `x` to the nearest integer-valued n
 -   If `x_i` is already integer-valued, the result is `x_i`.
 -   If two integers are equally close to `x_i`, the result is the even integer closest to `x_i`.
 
+For floating-point operands,
+
+-   If `x_i` is `+infinity`, the result is `+infinity`.
+-   If `x_i` is `-infinity`, the result is `-infinity`.
+-   If `x_i` is `+0`, the result is `+0`.
+-   If `x_i` is `-0`, the result is `-0`.
+-   If `x_i` is `NaN`, the result is `NaN`.
+
 #### Parameters
 
 -   **x**: _&lt;array&gt;_
@@ -1453,6 +1477,14 @@ Rounds each element `x_i` of the input array `x` to the integer-valued number th
 #### Special Cases
 
 -   If `x_i` is already integer-valued, the result is `x_i`.
+
+For floating-point operands,
+
+-   If `x_i` is `+infinity`, the result is `+infinity`.
+-   If `x_i` is `-infinity`, the result is `-infinity`.
+-   If `x_i` is `+0`, the result is `+0`.
+-   If `x_i` is `-0`, the result is `-0`.
+-   If `x_i` is `NaN`, the result is `NaN`.
 
 #### Parameters
 


### PR DESCRIPTION
This PR

-   clarifies rounding behavior when encountering special floating-point values, such as `NaN`, `+-infinity`, and `+-0`. The lack of guidance was raised in https://github.com/data-apis/array-api/issues/199.
-   adds special cases to `ceil`, `floor`, `round`, and `trunc`.

cc @asmeurer 