### PR TITLE
Machine readability fixes for operator special cases

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1214,7 +1214,7 @@ For floating-point operands, let `self` equal `x1` and `other` equal `x2`.
 -   If `x1_i` is either `+infinity` or `-infinity` and `x2_i` is either `+infinity` or `-infinity`, the result is `NaN`.
 -   If `x1_i` is either `+0` or `-0` and `x2_i` is either `+0` or `-0`, the result is `NaN`.
 -   If `x1_i` is `+0` and `x2_i` is greater than `0`, the result is `+0`.
--   If `x1_i` is `-0` and `x2_i` is greater than `0`, the result `-0`.
+-   If `x1_i` is `-0` and `x2_i` is greater than `0`, the result is `-0`.
 -   If `x1_i` is `+0` and `x2_i` is less than `0`, the result is `-0`.
 -   If `x1_i` is `-0` and `x2_i` is less than `0`, the result is `+0`.
 -   If `x1_i` is greater than `0` and `x2_i` is `+0`, the result is `+infinity`.

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1092,7 +1092,7 @@ For floating-point operands, let `self` equal `x1` and `other` equal `x2`.
 -   If `abs(x1_i)` is less than `1` and `x2_i` is `-infinity`, the result is `+infinity`.
 -   If `x1_i` is `+infinity` and `x2_i` is greater than `0`, the result is `+infinity`.
 -   If `x1_i` is `+infinity` and `x2_i` is less than `0`, the result is `+0`.
--   If `x1_i` is `-infinity` and `x2_i` is greater than `0`, the result is `-infinity`.
+-   If `x1_i` is `-infinity`, `x2_i` is greater than `0`, and `x2_i` is an odd integer value, the result is `-infinity`.
 -   If `x1_i` is `-infinity`, `x2_i` is greater than `0`, and `x2_i` is not an odd integer value, the result is `+infinity`.
 -   If `x1_i` is `-infinity`, `x2_i` is less than `0`, and `x2_i` is an odd integer value, the result is `-0`.
 -   If `x1_i` is `-infinity`, `x2_i` is less than `0`, and `x2_i` is not an odd integer value, the result is `+0`.


### PR DESCRIPTION
`__truediv__` had a consistency issue, and `__pow__` was not updated with `xp.pow()` in #108. This does not conflict with #221.