### PR TITLE
Update return data types for those APIs returning indices and counts

### DIFF
--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -47,9 +47,9 @@ Each `nan` value should have a count of one, while the counts for signed zeros s
     -   a namedtuple `(values, indices, inverse_indices, counts)` whose
 
         -   first element must have the field name `values` and must be an array containing the unique elements of `x`. The array must have the same data type as `x`.
-        -   second element must have the field name `indices` and must be an array containing the indices (first occurrences) of `x` that result in `values`. The array must have the same shape as `values` and must have the default integer data type.
-        -   third element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and must have the default integer data type.
-        -   fourth element must have the field name `counts` and must be an array containing the number of times each unique element occurs in `x`. The returned array must have same shape as `values` and must have the default integer data type.
+        -   second element must have the field name `indices` and must be an array containing the indices (first occurrences) of `x` that result in `values`. The array must have the same shape as `values` and must have the default array index data type.
+        -   third element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and must have the default array index data type.
+        -   fourth element must have the field name `counts` and must be an array containing the number of times each unique element occurs in `x`. The returned array must have same shape as `values` and must have the default array index data type.
 
         ```{note}
         The order of unique elements is not specified and may vary between implementations.
@@ -88,7 +88,7 @@ Each `nan` value should have a count of one, while the counts for signed zeros s
     -   a namedtuple `(values, counts)` whose
 
         -   first element must have the field name `values` and must be an array containing the unique elements of `x`. The array must have the same data type as `x`.
-        -   second element must have the field name `counts` and must be an array containing the number of times each unique element occurs in `x`. The returned array must have same shape as `values` and must have the default integer data type.
+        -   second element must have the field name `counts` and must be an array containing the number of times each unique element occurs in `x`. The returned array must have same shape as `values` and must have the default array index data type.
 
         ```{note}
         The order of unique elements is not specified and may vary between implementations.
@@ -127,7 +127,7 @@ As signed zeros are not distinct, using `inverse_indices` to reconstruct the inp
     -   a namedtuple `(values, inverse_indices)` whose
 
         -   first element must have the field name `values` and must be an array containing the unique elements of `x`. The array must have the same data type as `x`.
-        -   second element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and have the default integer data type.
+        -   second element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and have the default array index data type.
 
         ```{note}
         The order of unique elements is not specified and may vary between implementations.


### PR DESCRIPTION
This PR 

-   is a follow-up PR to https://github.com/data-apis/array-api/pull/322, which adds guidance for conforming implementations to specify a "default array index data type". This PR subsequently updates the return data types for those APIs returning indices and/or counts (e.g., `unique*`, `argsort`, `argmin`, `argmax`, `nonzero`).

**Note**: the return types for APIs listed above which are not a `unique*` variant are already spec'd to return the default array index data type.