### PR TITLE
Fix guidance for tensordot broadcasting

### DIFF
--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -90,7 +90,7 @@ Returns a tensor contraction of `x1` and `x2` over specific axes.
     -   second input array. Must be compatible with `x1` for all non-contracted axes (see {ref}`broadcasting`). Should have a numeric data type.
 
         ```{note}
-        Contracted axes must not be broadcasted.
+        Contracted axes (dimensions) must not be broadcasted.
         ```
 
 -   **axes**: _Union\[ int, Tuple\[ Sequence\[ int ], Sequence\[ int ] ] ]_

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -87,7 +87,7 @@ Returns a tensor contraction of `x1` and `x2` over specific axes.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
+    -   second input array. Must be compatible with `x1` in non-contracted dimensions (i.e., contracted dimensions must not be broadcasted; see {ref}`broadcasting`). Should have a numeric data type.
 
 -   **axes**: _Union\[ int, Tuple\[ Sequence\[ int ], Sequence\[ int ] ] ]_
 

--- a/spec/API_specification/linear_algebra_functions.md
+++ b/spec/API_specification/linear_algebra_functions.md
@@ -87,7 +87,11 @@ Returns a tensor contraction of `x1` and `x2` over specific axes.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array. Must be compatible with `x1` in non-contracted dimensions (i.e., contracted dimensions must not be broadcasted; see {ref}`broadcasting`). Should have a numeric data type.
+    -   second input array. Must be compatible with `x1` for all non-contracted axes (see {ref}`broadcasting`). Should have a numeric data type.
+
+        ```{note}
+        Contracted axes must not be broadcasted.
+        ```
 
 -   **axes**: _Union\[ int, Tuple\[ Sequence\[ int ], Sequence\[ int ] ] ]_
 


### PR DESCRIPTION
This PR

-   resolves https://github.com/data-apis/array-api/issues/294 by fixing an ambiguity in the documentation which seemed to indicate that input arrays must be broadcast compatible across all dimensions. This indication was contradicted in later guidance which required that contracted dimensions must match. The changes proposed in this PR resolve this ambiguity by restricting broadcasting to only non-contracted dimensions.