### PR TITLE
Update guidance for `pow` and `divide` concerning arrays with integer dtypes

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1075,6 +1075,12 @@ Element-wise results must equal the results returned by the equivalent element-w
 
 Calculates an implementation-dependent approximation of exponentiation by raising each element (the base) of an array instance to the power of `other_i` (the exponent), where `other_i` is the corresponding element of the array `other`.
 
+```{note}
+If both `self` and `other` have integer data types, the result of `__pow__` when `other_i` is negative (i.e., less than zero) is unspecified and thus implementation-dependent.
+
+If `self` has an integer data type and `other` has a floating-point data type, behavior is implementation-dependent (type promotion between data type "kinds" (integer versus floating-point) is unspecified).
+```
+
 #### Special Cases
 
 For floating-point operands, let `self` equal `x1` and `other` equal `x2`.
@@ -1247,7 +1253,7 @@ For floating-point operands, let `self` equal `x1` and `other` equal `x2`.
 
 -   **out**: _&lt;array&gt;_
 
-    -   an array containing the element-wise results. The returned array must have a data type determined by {ref}`type-promotion`.
+    -   an array containing the element-wise results. The returned array should have a floating-point data type determined by {ref}`type-promotion`.
 
 ```{note}
 Element-wise results must equal the results returned by the equivalent element-wise function [`divide(x1, x2)`](elementwise_functions.md#dividex1-x2-).

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -559,11 +559,11 @@ For floating-point operands,
 
 -   **x1**: _&lt;array&gt;_
 
-    -   dividend input array. Should have a floating-point data type.
+    -   dividend input array. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   divisor input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a floating-point data type.
+    -   divisor input array. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 
@@ -1183,6 +1183,12 @@ Computes the numerical positive of each element `x_i` (i.e., `y_i = +x_i`) of th
 
 Calculates an implementation-dependent approximation of exponentiation by raising each element `x1_i` (the base) of the input array `x1` to the power of `x2_i` (the exponent), where `x2_i` is the corresponding element of the input array `x2`.
 
+```{note}
+If both `x1` and `x2` have integer data types, the result of `pow` when `x2_i` is negative (i.e., less than zero) is unspecified and thus implementation-dependent.
+
+If `x1` has an integer data type and `x2` has a floating-point data type, behavior is implementation-dependent (type promotion between data type "kinds" (integer versus floating-point) is unspecified).
+```
+
 #### Special Cases
 
 For floating-point operands,
@@ -1216,11 +1222,11 @@ For floating-point operands,
 
 -   **x1**: _&lt;array&gt;_
 
-    -   first input array whose elements correspond to the exponentiation base. Should have a floating-point data type.
+    -   first input array whose elements correspond to the exponentiation base. Should have a numeric data type.
 
 -   **x2**: _&lt;array&gt;_
 
-    -   second input array whose elements correspond to the exponentiation exponent. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a floating-point data type.
+    -   second input array whose elements correspond to the exponentiation exponent. Must be compatible with `x1` (see {ref}`broadcasting`). Should have a numeric data type.
 
 #### Returns
 


### PR DESCRIPTION
This PR

-   supersedes https://github.com/data-apis/array-api/pull/221
-   adds guidance for `pow` and `divide` for arrays having integer data types, as discussed in https://github.com/data-apis/array-api/pull/173.
-   adds a note that, when providing arrays having integer data types to `pow`, the result of `x1_i**x2_i` is implementation-defined for `x2_i < 0` (e.g., `5**(-1)` as the result is a fraction).
-   specifies that the result of "true division" be an array having a floating-point data type.
-   makes input data type guidance consistent between `__pow__`/`pow` and `__truediv__`/`divide`.

cc @asmeurer @rgommers 