### PR TITLE
`expand_dims()` signature change (and slight doc fix)

### DIFF
--- a/spec/API_specification/manipulation_functions.md
+++ b/spec/API_specification/manipulation_functions.md
@@ -57,7 +57,7 @@ Expands the shape of an array by inserting a new axis (dimension) of size one at
 
 -   **out**: _&lt;array&gt;_
 
-    -   an expanded output array having the same data type and shape as `x`.
+    -   an expanded output array having the same data type as `x`.
 
 (function-flip)=
 ### flip(x, /, *, axis=None)

--- a/spec/API_specification/manipulation_functions.md
+++ b/spec/API_specification/manipulation_functions.md
@@ -39,7 +39,7 @@ Joins a sequence of arrays along an existing axis.
         ```
 
 (function-expand_dims)=
-### expand_dims(x, /, *, axis)
+### expand_dims(x, /, axis)
 
 Expands the shape of an array by inserting a new axis (dimension) of size one at the position specified by `axis`.
 


### PR DESCRIPTION
 In #167 @rgommers gave us the current `expand_dims()` signature:
```python
expand_dims(x, /, *, axis)
```
I believe it makes sense to remove the keyword-only requirement of `axis`, given it has no default value:
```python
expand_dims(x, /, axis)
```
This keeps in line with the related function `squeeze()`. Notably all other manipulation functions that have arguments after `*` have defaults. Personally I've never seen a keyword-only argument that has no default, and I'm wondering if this behaviour could confuse developers and users.