### PR TITLE
Update guidance for unsigned integer data types for `sum` and `prod`

### DIFF
--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -134,7 +134,9 @@ For an input array `x`, let `N` equal the number of elements over which to compu
     -   data type of the returned array. If `None`,
     
         -   if the default data type corresponding to the data type "kind" (integer or floating-point) of `x` has a smaller range of values than the data type of `x` (e.g., `x` has data type `int64` and the default data type is `int32`, or `x` has data type `uint64` and the default data type is `int64`), the returned array must have the same data type as `x`.
-        -   otherwise, the returned array must have the default data type corresponding to the data type "kind" (integer or floating-point) of `x`.
+        -   if `x` has a floating-point data type, the returned array must have the default floating-point data type.
+        -   if `x` has a signed integer data type (e.g., `int16`), the returned array must have the default integer data type.
+        -   if `x` has an unsigned integer data type (e.g., `uint16`), the returned array must have an unsigned integer data type having the same number of bits as the default integer data type (e.g., if the default integer data type is `int32`, the returned array must have a `uint32` data type).
 
         If the data type (either specified or resolved) differs from the data type of `x`, the input array should be cast to the specified data type before computing the product. Default: `None`.
 
@@ -217,7 +219,9 @@ For an input array `x`, let `N` equal the number of elements over which to compu
     -   data type of the returned array. If `None`,
     
         -   if the default data type corresponding to the data type "kind" (integer or floating-point) of `x` has a smaller range of values than the data type of `x` (e.g., `x` has data type `int64` and the default data type is `int32`, or `x` has data type `uint64` and the default data type is `int64`), the returned array must have the same data type as `x`.
-        -   otherwise, the returned array must have the default data type corresponding to the data type "kind" (integer or floating-point) of `x`.
+        -   if `x` has a floating-point data type, the returned array must have the default floating-point data type.
+        -   if `x` has a signed integer data type (e.g., `int16`), the returned array must have the default integer data type.
+        -   if `x` has an unsigned integer data type (e.g., `uint16`), the returned array must have an unsigned integer data type having the same number of bits as the default integer data type (e.g., if the default integer data type is `int32`, the returned array must have a `uint32` data type).
 
         If the data type (either specified or resolved) differs from the data type of `x`, the input array should be cast to the specified data type before computing the sum. Default: `None`.
 


### PR DESCRIPTION
This PR

-   updates the guidance for `sum` and `prod` when `x` has an unsigned integer data type with a smaller range of values than the default integer data type and the `dtype` kwarg is `None`. Namely, when providing a `uint8` array, the returned array should have a `uint32` data type when the default integer data type is `int32`. This is in contrast to current guidance which requires that the returned array have an `int32` data type. In short, the returned array should have a data type whose "signedness" matches the input array. Returning a signed integer array when providing an unsigned integer array is likely to violate user expectations.

The changes introduced in this PR match NumPy's current behavior.