### PR TITLE
Specify numeric arrays for `argmin` and `argmax`

### DIFF
--- a/spec/API_specification/searching_functions.md
+++ b/spec/API_specification/searching_functions.md
@@ -25,7 +25,7 @@ Returns the indices of the maximum values along a specified axis. When the maxim
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 -   **axis**: _Optional\[ int ]_
 
@@ -50,7 +50,7 @@ Returns the indices of the minimum values along a specified axis. When the minim
 
 -   **x**: _&lt;array&gt;_
 
-    -   input array.
+    -   input array. Should have a numeric data type.
 
 -   **axis**: _Optional\[ int ]_
 


### PR DESCRIPTION
Remains consistent with `min` and `max`.