### PR TITLE
Remove shape parity for inverse indices in set functions

### DIFF
--- a/spec/API_specification/set_functions.md
+++ b/spec/API_specification/set_functions.md
@@ -48,7 +48,7 @@ Each `nan` value should have a count of one, while the counts for signed zeros s
 
         -   first element must have the field name `values` and must be an array containing the unique elements of `x`. The array must have the same data type as `x`.
         -   second element must have the field name `indices` and must be an array containing the indices (first occurrences) of `x` that result in `values`. The array must have the same shape as `values` and must have the default array index data type.
-        -   third element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and must have the default array index data type.
+        -   third element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the default array index data type.
         -   fourth element must have the field name `counts` and must be an array containing the number of times each unique element occurs in `x`. The returned array must have same shape as `values` and must have the default array index data type.
 
         ```{note}
@@ -127,7 +127,7 @@ As signed zeros are not distinct, using `inverse_indices` to reconstruct the inp
     -   a namedtuple `(values, inverse_indices)` whose
 
         -   first element must have the field name `values` and must be an array containing the unique elements of `x`. The array must have the same data type as `x`.
-        -   second element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the same shape as `x` and have the default array index data type.
+        -   second element must have the field name `inverse_indices` and must be an array containing the indices of `values` that reconstruct `x`. The array must have the default array index data type.
 
         ```{note}
         The order of unique elements is not specified and may vary between implementations.


### PR DESCRIPTION
I still get confused with inverse indices, but I think the spec is wrong to state the returned array must have the same shape... how would you reconstruct the input array `x` otherwise heh. This follows NumPy behaviour (and indeed `numpy.array_api`).