### PR TITLE
Fix signature for linalg.vecdot

### DIFF
--- a/spec/extensions/linear_algebra_functions.md
+++ b/spec/extensions/linear_algebra_functions.md
@@ -573,7 +573,7 @@ Returns the sum along the specified diagonals of a matrix (or a stack of matrice
         The returned array must have the same data type as `x`.
 
 (function-linalg-vecdot)=
-### linalg.vecdot(x1, x2, /, *, axis=None)
+### linalg.vecdot(x1, x2, /, *, axis=-1)
 
 Alias for {ref}`function-vecdot`.
 


### PR DESCRIPTION
This PR:

-   resolves https://github.com/data-apis/array-api/issues/355. [gh-281](https://github.com/data-apis/array-api/pull/281) failed to include updating the default for `axis` to `-1`.