### PR TITLE
Clarify that the results of division operations on integer array data types resulting in floating-point outputs is implementation-defined 

### DIFF
--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1249,6 +1249,10 @@ Element-wise results must equal the results returned by the equivalent element-w
 
 Evaluates `self_i / other_i` for each element of an array instance with the respective element of the array `other`.
 
+```{note}
+If one or both of `self` and `other` have integer data types, the result is unspecified and thus implementation-dependent.
+```
+
 #### Special Cases
 
 For floating-point operands, let `self` equal `x1` and `other` equal `x2`.

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1250,7 +1250,9 @@ Element-wise results must equal the results returned by the equivalent element-w
 Evaluates `self_i / other_i` for each element of an array instance with the respective element of the array `other`.
 
 ```{note}
-If one or both of `self` and `other` have integer data types, the result is unspecified and thus implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
+If one or both of `self` and `other` have integer data types, the result is implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
+
+Specification-compliant libraries may choose to raise an error or return an array containing the element-wise results. If an array is returned, it must have a floating-point data type.
 ```
 
 #### Special Cases

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1115,7 +1115,7 @@ Calculates an implementation-dependent approximation of exponentiation by raisin
 ```{note}
 If both `self` and `other` have integer data types, the result of `__pow__` when `other_i` is negative (i.e., less than zero) is unspecified and thus implementation-dependent.
 
-If `self` has an integer data type and `other` has a floating-point data type, behavior is implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
+If `self` has an integer data type and `other` has a floating-point data type, behavior is implementation-dependent, as type promotion between data type "kinds" (e.g., integer versus floating-point) is unspecified.
 ```
 
 #### Special Cases
@@ -1250,9 +1250,9 @@ Element-wise results must equal the results returned by the equivalent element-w
 Evaluates `self_i / other_i` for each element of an array instance with the respective element of the array `other`.
 
 ```{note}
-If one or both of `self` and `other` have integer data types, the result is implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
+If one or both of `self` and `other` have integer data types, the result is implementation-dependent, as type promotion between data type "kinds" (e.g., integer versus floating-point) is unspecified.
 
-Specification-compliant libraries may choose to raise an error or return an array containing the element-wise results. If an array is returned, it must have a floating-point data type.
+Specification-compliant libraries may choose to raise an error or return an array containing the element-wise results. If an array is returned, the array must have a floating-point data type.
 ```
 
 #### Special Cases

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1250,7 +1250,7 @@ Element-wise results must equal the results returned by the equivalent element-w
 Evaluates `self_i / other_i` for each element of an array instance with the respective element of the array `other`.
 
 ```{note}
-If one or both of `self` and `other` have integer data types, the result is unspecified and thus implementation-dependent.
+If one or both of `self` and `other` have integer data types, the result is unspecified and thus implementation-dependent (type promotion between data type “kinds” (integer versus floating-point) is unspecified).
 ```
 
 #### Special Cases

--- a/spec/API_specification/array_object.md
+++ b/spec/API_specification/array_object.md
@@ -1115,7 +1115,7 @@ Calculates an implementation-dependent approximation of exponentiation by raisin
 ```{note}
 If both `self` and `other` have integer data types, the result of `__pow__` when `other_i` is negative (i.e., less than zero) is unspecified and thus implementation-dependent.
 
-If `self` has an integer data type and `other` has a floating-point data type, behavior is implementation-dependent (type promotion between data type "kinds" (integer versus floating-point) is unspecified).
+If `self` has an integer data type and `other` has a floating-point data type, behavior is implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
 ```
 
 #### Special Cases
@@ -1250,7 +1250,7 @@ Element-wise results must equal the results returned by the equivalent element-w
 Evaluates `self_i / other_i` for each element of an array instance with the respective element of the array `other`.
 
 ```{note}
-If one or both of `self` and `other` have integer data types, the result is unspecified and thus implementation-dependent (type promotion between data type “kinds” (integer versus floating-point) is unspecified).
+If one or both of `self` and `other` have integer data types, the result is unspecified and thus implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
 ```
 
 #### Special Cases

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -529,7 +529,9 @@ For floating-point operands,
 Calculates the division for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
 
 ```{note}
-If one or both of the input arrays have integer data types, the result is unspecified and thus implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
+If one or both of the input arrays have integer data types, the result is implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
+
+Specification-compliant libraries may choose to raise an error or return an array containing the element-wise results. If an array is returned, it must have a floating-point data type.
 ```
 
 #### Special Cases

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -528,6 +528,10 @@ For floating-point operands,
 
 Calculates the division for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
 
+```{note}
+If one or both of the input arrays have integer data types, the result is unspecified and thus implementation-dependent.
+```
+
 #### Special Cases
 
 For floating-point operands,

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -529,7 +529,7 @@ For floating-point operands,
 Calculates the division for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
 
 ```{note}
-If one or both of the input arrays have integer data types, the result is unspecified and thus implementation-dependent.
+If one or both of the input arrays have integer data types, the result is unspecified and thus implementation-dependent (type promotion between data type “kinds” (integer versus floating-point) is unspecified).
 ```
 
 #### Special Cases

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -529,9 +529,9 @@ For floating-point operands,
 Calculates the division for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
 
 ```{note}
-If one or both of the input arrays have integer data types, the result is implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
+If one or both of the input arrays have integer data types, the result is implementation-dependent, as type promotion between data type "kinds" (e.g., integer versus floating-point) is unspecified.
 
-Specification-compliant libraries may choose to raise an error or return an array containing the element-wise results. If an array is returned, it must have a floating-point data type.
+Specification-compliant libraries may choose to raise an error or return an array containing the element-wise results. If an array is returned, the array must have a floating-point data type.
 ```
 
 #### Special Cases
@@ -1229,7 +1229,7 @@ Calculates an implementation-dependent approximation of exponentiation by raisin
 ```{note}
 If both `x1` and `x2` have integer data types, the result of `pow` when `x2_i` is negative (i.e., less than zero) is unspecified and thus implementation-dependent.
 
-If `x1` has an integer data type and `x2` has a floating-point data type, behavior is implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
+If `x1` has an integer data type and `x2` has a floating-point data type, behavior is implementation-dependent, as type promotion between data type "kinds" (e.g., integer versus floating-point) is unspecified.
 ```
 
 #### Special Cases

--- a/spec/API_specification/elementwise_functions.md
+++ b/spec/API_specification/elementwise_functions.md
@@ -529,7 +529,7 @@ For floating-point operands,
 Calculates the division for each element `x1_i` of the input array `x1` with the respective element `x2_i` of the input array `x2`.
 
 ```{note}
-If one or both of the input arrays have integer data types, the result is unspecified and thus implementation-dependent (type promotion between data type “kinds” (integer versus floating-point) is unspecified).
+If one or both of the input arrays have integer data types, the result is unspecified and thus implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
 ```
 
 #### Special Cases
@@ -1227,7 +1227,7 @@ Calculates an implementation-dependent approximation of exponentiation by raisin
 ```{note}
 If both `x1` and `x2` have integer data types, the result of `pow` when `x2_i` is negative (i.e., less than zero) is unspecified and thus implementation-dependent.
 
-If `x1` has an integer data type and `x2` has a floating-point data type, behavior is implementation-dependent (type promotion between data type "kinds" (integer versus floating-point) is unspecified).
+If `x1` has an integer data type and `x2` has a floating-point data type, behavior is implementation-dependent. This is because type promotion between data type “kinds” (i.e. integer versus floating-point) is unspecified.
 ```
 
 #### Special Cases

--- a/spec/API_specification/statistical_functions.md
+++ b/spec/API_specification/statistical_functions.md
@@ -21,7 +21,7 @@ A conforming implementation of the array API standard must provide and support t
 Calculates the maximum value of the input array `x`.
 
 ```{note}
-When the number of elements over which to compute the maximum value is zero, the maximum value is implementation-defined. Specification-compliant libraries may choose to error, return a sentinel value (e.g., if `x` is a floating-point input array, return `NaN`), or return the minimum possible value for the input array `x` data type (e.g., if `x` is a floating-point array, return `-infinity`).
+When the number of elements over which to compute the maximum value is zero, the maximum value is implementation-defined. Specification-compliant libraries may choose to raise an error, return a sentinel value (e.g., if `x` is a floating-point input array, return `NaN`), or return the minimum possible value for the input array `x` data type (e.g., if `x` is a floating-point array, return `-infinity`).
 ```
 
 #### Special Cases
@@ -92,7 +92,7 @@ Let `N` equal the number of elements over which to compute the arithmetic mean.
 Calculates the minimum value of the input array `x`.
 
 ```{note}
-When the number of elements over which to compute the minimum value is zero, the minimum value is implementation-defined. Specification-compliant libraries may choose to error, return a sentinel value (e.g., if `x` is a floating-point input array, return `NaN`), or return the maximum possible value for the input array `x` data type (e.g., if `x` is a floating-point array, return `+infinity`).
+When the number of elements over which to compute the minimum value is zero, the minimum value is implementation-defined. Specification-compliant libraries may choose to raise an error, return a sentinel value (e.g., if `x` is a floating-point input array, return `NaN`), or return the maximum possible value for the input array `x` data type (e.g., if `x` is a floating-point array, return `+infinity`).
 ```
 
 #### Special Cases


### PR DESCRIPTION
Resolve #361 by noting any instance of int as out-of-scope.