### PR TITLE
Fix `axis` description in `expand_dims`

### DIFF
--- a/spec/API_specification/signatures/manipulation_functions.py
+++ b/spec/API_specification/signatures/manipulation_functions.py
@@ -29,7 +29,7 @@ def expand_dims(x: array, /, *, axis: int = 0) -> array:
     x: array
         input array.
     axis: int
-        axis position. Must follow Python's indexing rules: zero-based and negative indices must be counted backward from the last dimension. If ``x`` has rank ``N``, a valid ``axis`` must reside on the interval ``[-N-1, N+1]``. An ``IndexError`` exception must be raised if provided an invalid ``axis`` position.
+        axis position (zero-based). If ``x`` has rank (i.e, number of dimensions) ``N``, a valid ``axis`` must reside on the closed-interval ``[-N-1, N]``. If provided a negative ``axis``, the axis position at which to insert a singleton dimension must be computed as ``N + axis + 1``. Hence, if provided ``-1``, the resolved axis position must be ``N`` (i.e., a singleton dimension must be appended to the input array ``x``). If provided ``-N-1``, the resolved axis position must be ``0`` (i.e., a singleton dimension must be prepended to the input array ``x``). An ``IndexError`` exception must be raised if provided an invalid ``axis`` position.
 
     Returns
     -------


### PR DESCRIPTION
This PR

-   fixes the specification description of the `axis` kwarg in `expand_dims`. The current guidance indicates that `axis` should follow normal Python indexing rules, where a negative index counts back from the last dimension. This would indicate the `-1` would correspond to `N-1` where `N` is the rank of the input array. However, in order to ensure symmetry between positive and negative `axis` values for appending and prepending singleton dimensions, `-1` should resolve to appending a singleton dimension to the end of the array. In a sense, `axis` follows normal Python indexing rules, but for the output array which has an additional dimension and not the input array. This PR aims to clarify this ambiguity.