### PR TITLE
Clarify expected results for `any` and `all` when operating on empty arrays

### DIFF
--- a/spec/API_specification/signatures/utility_functions.py
+++ b/spec/API_specification/signatures/utility_functions.py
@@ -4,6 +4,12 @@ def all(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keep
     """
     Tests whether all input array elements evaluate to ``True`` along a specified axis.
 
+    .. note::
+       Positive infinity, negative infinity, and NaN must all evaluate to ``True``.
+
+    .. note::
+       If ``x`` is an empty array or the size of the axis (dimension) along which to evaluate elements is zero, the test result must be ``True``.
+
     Parameters
     ----------
     x: array
@@ -22,6 +28,12 @@ def all(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keep
 def any(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> array:
     """
     Tests whether any input array element evaluates to ``True`` along a specified axis.
+
+    .. note::
+       Positive infinity, negative infinity, and NaN must all evaluate to ``True``.
+
+    .. note::
+       If ``x`` is an empty array or the size of the axis (dimension) along which to evaluate elements is zero, the test result must be ``False``.
 
     Parameters
     ----------

--- a/spec/API_specification/signatures/utility_functions.py
+++ b/spec/API_specification/signatures/utility_functions.py
@@ -5,7 +5,7 @@ def all(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keep
     Tests whether all input array elements evaluate to ``True`` along a specified axis.
 
     .. note::
-       Positive infinity, negative infinity, and NaN must all evaluate to ``True``.
+       Positive infinity, negative infinity, and NaN must evaluate to ``True``.
 
     .. note::
        If ``x`` is an empty array or the size of the axis (dimension) along which to evaluate elements is zero, the test result must be ``True``.
@@ -30,7 +30,7 @@ def any(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keep
     Tests whether any input array element evaluates to ``True`` along a specified axis.
 
     .. note::
-       Positive infinity, negative infinity, and NaN must all evaluate to ``True``.
+       Positive infinity, negative infinity, and NaN must evaluate to ``True``.
 
     .. note::
        If ``x`` is an empty array or the size of the axis (dimension) along which to evaluate elements is zero, the test result must be ``False``.


### PR DESCRIPTION
This PR

-   adds explicit guidance for `any` and `all` when operating on empty arrays. For the former, the test result should be `False` and, for the latter, the test result should be `True`. This matches both NumPy et al behavior (`np.any` and `np.all`), TF behavior (`tf.reduce_any` and `tf.reduce_all`), and Python behavior (`any` and `all`).
-   adds a note for both `any` and `all` that `+-inf` and `NaN` all evaluate to `True`.