### PR TITLE
Disable the html_prettify setting

### DIFF
--- a/spec/conf.py
+++ b/spec/conf.py
@@ -114,7 +114,7 @@ html_theme_options = {
     #'repo_name': 'Project',
 
     "html_minify": False,
-    "html_prettify": True,
+    "html_prettify": False,
     "css_minify": True,
     "logo_icon": "&#xe869",
     "repo_type": "github",


### PR DESCRIPTION
This fixes the issue where every code block would have an extra space inserted
after it.

Fixes #139.