### PR TITLE
Use `Sequence` from `typing` instead of `collections.abc`

### DIFF
--- a/spec/API_specification/signatures/_types.py
+++ b/spec/API_specification/signatures/_types.py
@@ -43,5 +43,5 @@ class NestedSequence(Protocol[_T_co]):
 
 
 __all__ = ['Any', 'List', 'Literal', 'NestedSequence', 'Optional',
-'PyCapsule', 'SupportsBufferProtocol', 'SupportsDLPack', 'Tuple', 'Union',
+'PyCapsule', 'SupportsBufferProtocol', 'SupportsDLPack', 'Tuple', 'Union', 'Sequence',
 'array', 'device', 'dtype', 'ellipsis', 'finfo_object', 'iinfo_object', 'Enum']

--- a/spec/API_specification/signatures/linalg.py
+++ b/spec/API_specification/signatures/linalg.py
@@ -1,6 +1,5 @@
-from ._types import Literal, Optional, Tuple, Union, array
+from ._types import Literal, Optional, Tuple, Union, Sequence, array
 from .constants import inf
-from collections.abc import Sequence
 
 def cholesky(x: array, /, *, upper: bool = False) -> array:
     """

--- a/spec/API_specification/signatures/linear_algebra_functions.py
+++ b/spec/API_specification/signatures/linear_algebra_functions.py
@@ -1,5 +1,4 @@
-from ._types import Tuple, Union, array
-from collections.abc import Sequence
+from ._types import Tuple, Union, Sequence, array
 
 def matmul(x1: array, x2: array, /) -> array:
     """


### PR DESCRIPTION
The `tensordot()` signatures in both the top-level and linalg extension signatures use `Sequence` for type hinting. They were previously imported from `collections.abc`, but they should be imported from `typing` as indeed we want the type hint as opposed to the abstract base class.

Correct typing here is necessary when importing the signatures directory as a Python module (otherwise you get `TypeError: 'ABCMeta' object is not subscriptable`), like we probably want to do in the test suite. cc @asmeurer 