### PR TITLE
Restrict `linspace` support to floating-point data types

### DIFF
--- a/spec/API_specification/signatures/creation_functions.py
+++ b/spec/API_specification/signatures/creation_functions.py
@@ -14,13 +14,20 @@ def arange(start: Union[int, float], /, stop: Optional[Union[int, float]] = None
     step: Union[int, float]
         the distance between two adjacent elements (``out[i+1] - out[i]``). Must not be ``0``; may be negative, this results in an empty array if ``stop >= start``. Default: ``1``.
     dtype: Optional[dtype]
-        output array data type. If ``dtype`` is ``None``, the output array data type must be inferred from ``start``, ``stop`` and ``step``. If those are all integers, the output array dtype must be the default integer dtype; if one or more have type ``float``, then the output array dtype must be the default floating-point data type. Default: ``None``.
+        output array data type. Should be a floating-point data type. If ``dtype`` is ``None``, the output array data type must be the default floating-point data type. Default: ``None``.
     device: Optional[device]
         device on which to place the created array. Default: ``None``.
 
 
     .. note::
        This function cannot guarantee that the interval does not include the ``stop`` value in those cases where ``step`` is not an integer and floating-point rounding errors affect the length of the output array.
+
+
+    .. note::
+       While this specification recommends that this function only return arrays having a floating-point data type, specification-compliant array libraries may choose to support output arrays having an integer data type (e.g., due to backward compatibility concerns). However, function behavior when generating integer output arrays is unspecified and, thus, is implementation-defined. Accordingly, using this function to generate integer output arrays is not portable.
+
+    .. note::
+       As mixed data type promotion is implementation-defined, behavior when ``start`` or ``stop`` exceeds the maximum safe integer of an output floating-point data type is implementation-defined. An implementation may choose to overflow or raise an exception.
 
     Returns
     -------

--- a/spec/API_specification/signatures/creation_functions.py
+++ b/spec/API_specification/signatures/creation_functions.py
@@ -22,7 +22,6 @@ def arange(start: Union[int, float], /, stop: Optional[Union[int, float]] = None
     .. note::
        This function cannot guarantee that the interval does not include the ``stop`` value in those cases where ``step`` is not an integer and floating-point rounding errors affect the length of the output array.
 
-
     .. note::
        While this specification recommends that this function only return arrays having a floating-point data type, specification-compliant array libraries may choose to support output arrays having an integer data type (e.g., due to backward compatibility concerns). However, function behavior when generating integer output arrays is unspecified and, thus, is implementation-defined. Accordingly, using this function to generate integer output arrays is not portable.
 


### PR DESCRIPTION
This PR

-   resolves https://github.com/data-apis/array-api/issues/392 in accordance with discussions during the 2022-02-17 consortium meeting. Namely, `linspace` should be limited to floating-point output data types, unless a conforming implementation has compelling reasons for supporting integer output data types (e.g., due to backward compatibility). However, integer output behavior is left implementation-defined and should not, in general, be considered portable.
-   adds a note concerning the conversion of `int` start and stop values to floating-point. Namely, that overflow behavior is implementation-defined. This follows similar guidance elsewhere in the specification.