### PR TITLE
Add a version menu to the Sphinx build

### DIFF
--- a/spec/conf.py
+++ b/spec/conf.py
@@ -172,8 +172,8 @@ html_theme_options = {
         #"customization": "Configuration options to personalize your site.",
     },
 
-    #"version_dropdown": True,
-    #"version_json": "_static/versions.json",
+    "version_dropdown": True,
+    "version_json": "../versions.json",
     "table_classes": ["plain"],
 }
 

--- a/spec/conf.py
+++ b/spec/conf.py
@@ -62,6 +62,8 @@ nitpick_ignore = [
     ('py:class', 'collections.abc.Sequence'),
     ('py:class', "Optional[Union[int, float, Literal[inf, - inf, 'fro', 'nuc']]]"),
     ('py:class', "Union[int, float, Literal[inf, - inf]]"),
+    ('py:obj', "typing.Optional[typing.Union[int, float, typing.Literal[inf, - inf, 'fro', 'nuc']]]"),
+    ('py:obj', "typing.Union[int, float, typing.Literal[inf, - inf]]"),
     ('py:class', 'PyCapsule'),
     ('py:class', 'enum.Enum'),
     ('py:class', 'ellipsis'),

--- a/spec/conf.py
+++ b/spec/conf.py
@@ -125,7 +125,7 @@ html_sidebars = {
 html_theme_options = {
 
     # Set the name of the project to appear in the navigation.
-    'nav_title': 'Python array API standard',
+    'nav_title': f'Python array API standard {release}',
 
     # Set you GA account ID to enable tracking
     #'google_analytics_account': 'UA-XXXXX',


### PR DESCRIPTION
To make this work, we need to add a `versions.json` file to the root of the gh-pages branch that looks like

```json
{
   "label": "target"
}
```

Where `label` is the text label for the version and `target` is the name of the directory containing that version.

Right now, without that, it will just say "No versions found".