### PR TITLE
Update the specification for `remainder` to include special cases for floating-point operands

### DIFF
--- a/spec/API_specification/signatures/array_object.py
+++ b/spec/API_specification/signatures/array_object.py
@@ -634,6 +634,34 @@ class _array():
         .. note::
            For input arrays which promote to an integer data type, the result of division by zero is unspecified and thus implementation-defined.
 
+        **Special Cases**
+
+        .. note::
+           In general, this method is **not** recommended for floating-point operands as semantics do not follow IEEE 754. That this method is specified to accept floating-point operands is primarily for reasons of backward compatibility.
+
+        For floating-point operands, let ``self`` equal ``x1`` and ``other`` equal ``x2``.
+
+        - If either ``x1_i`` or ``x2_i`` is ``NaN``, the result is ``NaN``.
+        - If ``x1_i`` is either ``+infinity`` or ``-infinity`` and ``x2_i`` is either ``+infinity`` or ``-infinity``, the result is ``NaN``.
+        - If ``x1_i`` is either ``+0`` or ``-0`` and ``x2_i`` is either ``+0`` or ``-0``, the result is ``NaN``.
+        - If ``x1_i`` is ``+0`` and ``x2_i`` is greater than ``0``, the result is ``+0``.
+        - If ``x1_i`` is ``-0`` and ``x2_i`` is greater than ``0``, the result is ``+0``.
+        - If ``x1_i`` is ``+0`` and ``x2_i`` is less than ``0``, the result is ``-0``.
+        - If ``x1_i`` is ``-0`` and ``x2_i`` is less than ``0``, the result is ``-0``.
+        - If ``x1_i`` is greater than ``0`` and ``x2_i`` is ``+0``, the result is ``NaN``.
+        - If ``x1_i`` is greater than ``0`` and ``x2_i`` is ``-0``, the result is ``NaN``.
+        - If ``x1_i`` is less than ``0`` and ``x2_i`` is ``+0``, the result is ``NaN``.
+        - If ``x1_i`` is less than ``0`` and ``x2_i`` is ``-0``, the result is ``NaN``.
+        - If ``x1_i`` is ``+infinity`` and ``x2_i`` is a positive (i.e., greater than ``0``) finite number, the result is ``NaN``.
+        - If ``x1_i`` is ``+infinity`` and ``x2_i`` is a negative (i.e., less than ``0``) finite number, the result is ``NaN``.
+        - If ``x1_i`` is ``-infinity`` and ``x2_i`` is a positive (i.e., greater than ``0``) finite number, the result is ``NaN``.
+        - If ``x1_i`` is ``-infinity`` and ``x2_i`` is a negative (i.e., less than ``0``) finite number, the result is ``NaN``.
+        - If ``x1_i`` is a positive (i.e., greater than ``0``) finite number and ``x2_i`` is ``+infinity``, the result is ``x1_i``. (**note**: this result matches Python behavior.)
+        - If ``x1_i`` is a positive (i.e., greater than ``0``) finite number and ``x2_i`` is ``-infinity``, the result is ``x2_i``. (**note**: this result matches Python behavior.)
+        - If ``x1_i`` is a negative (i.e., less than ``0``) finite number and ``x2_i`` is ``+infinity``, the result is ``x2_i``. (**note**: this results matches Python behavior.)
+        - If ``x1_i`` is a negative (i.e., less than ``0``) finite number and ``x2_i`` is ``-infinity``, the result is ``x1_i``. (**note**: this result matches Python behavior.)
+        -   In the remaining cases, the result must match that of the Python ``%`` operator.
+
         Parameters
         ----------
         self: array

--- a/spec/API_specification/signatures/array_object.py
+++ b/spec/API_specification/signatures/array_object.py
@@ -660,7 +660,7 @@ class _array():
         - If ``x1_i`` is a positive (i.e., greater than ``0``) finite number and ``x2_i`` is ``-infinity``, the result is ``x2_i``. (**note**: this result matches Python behavior.)
         - If ``x1_i`` is a negative (i.e., less than ``0``) finite number and ``x2_i`` is ``+infinity``, the result is ``x2_i``. (**note**: this results matches Python behavior.)
         - If ``x1_i`` is a negative (i.e., less than ``0``) finite number and ``x2_i`` is ``-infinity``, the result is ``x1_i``. (**note**: this result matches Python behavior.)
-        -   In the remaining cases, the result must match that of the Python ``%`` operator.
+        - In the remaining cases, the result must match that of the Python ``%`` operator.
 
         Parameters
         ----------

--- a/spec/API_specification/signatures/elementwise_functions.py
+++ b/spec/API_specification/signatures/elementwise_functions.py
@@ -638,7 +638,7 @@ def floor_divide(x1: array, x2: array, /) -> array:
     - If ``x1_i`` is a negative (i.e., less than ``0``) finite number and ``x2_i`` is ``-infinity``, the result is ``+0``.
     - If ``x1_i`` and ``x2_i`` have the same mathematical sign and are both nonzero finite numbers, the result has a positive mathematical sign.
     - If ``x1_i`` and ``x2_i`` have different mathematical signs and are both nonzero finite numbers, the result has a negative mathematical sign.
-    -   In the remaining cases, where neither ``-infinity``, ``+0``, ``-0``, nor ``NaN`` is involved, the quotient must be computed and rounded to the greatest (i.e., closest to `+infinity`) representable integer-value number that is not greater than the division result. If the magnitude is too large to represent, the operation overflows and the result is an ``infinity`` of appropriate mathematical sign. If the magnitude is too small to represent, the operation underflows and the result is a zero of appropriate mathematical sign.
+    - In the remaining cases, where neither ``-infinity``, ``+0``, ``-0``, nor ``NaN`` is involved, the quotient must be computed and rounded to the greatest (i.e., closest to `+infinity`) representable integer-value number that is not greater than the division result. If the magnitude is too large to represent, the operation overflows and the result is an ``infinity`` of appropriate mathematical sign. If the magnitude is too small to represent, the operation underflows and the result is a zero of appropriate mathematical sign.
 
     Parameters
     ----------
@@ -1113,7 +1113,38 @@ def remainder(x1: array, x2: array, /) -> array:
     Returns the remainder of division for each element ``x1_i`` of the input array ``x1`` and the respective element ``x2_i`` of the input array ``x2``.
 
     .. note::
+       This function is equivalent to the Python modulus operator ``x1_i % x2_i`` and is complementary to the :func:`~signatures.elementwise_functions.floor_divide`.
+
+    .. note::
        For input arrays which promote to an integer data type, the result of division by zero is unspecified and thus implementation-defined.
+
+    **Special Cases**
+
+    .. note::
+       In general, similar to Python's ``%`` operator, this function is **not** recommended for floating-point operands as semantics do not follow IEEE 754. That this function is specified to accept floating-point operands is primarily for reasons of backward compatibility.
+
+    For floating-points operands,
+
+    - If either ``x1_i`` or ``x2_i`` is ``NaN``, the result is ``NaN``.
+    - If ``x1_i`` is either ``+infinity`` or ``-infinity`` and ``x2_i`` is either ``+infinity`` or ``-infinity``, the result is ``NaN``.
+    - If ``x1_i`` is either ``+0`` or ``-0`` and ``x2_i`` is either ``+0`` or ``-0``, the result is ``NaN``.
+    - If ``x1_i`` is ``+0`` and ``x2_i`` is greater than ``0``, the result is ``+0``.
+    - If ``x1_i`` is ``-0`` and ``x2_i`` is greater than ``0``, the result is ``+0``.
+    - If ``x1_i`` is ``+0`` and ``x2_i`` is less than ``0``, the result is ``-0``.
+    - If ``x1_i`` is ``-0`` and ``x2_i`` is less than ``0``, the result is ``-0``.
+    - If ``x1_i`` is greater than ``0`` and ``x2_i`` is ``+0``, the result is ``NaN``.
+    - If ``x1_i`` is greater than ``0`` and ``x2_i`` is ``-0``, the result is ``NaN``.
+    - If ``x1_i`` is less than ``0`` and ``x2_i`` is ``+0``, the result is ``NaN``.
+    - If ``x1_i`` is less than ``0`` and ``x2_i`` is ``-0``, the result is ``NaN``.
+    - If ``x1_i`` is ``+infinity`` and ``x2_i`` is a positive (i.e., greater than ``0``) finite number, the result is ``NaN``.
+    - If ``x1_i`` is ``+infinity`` and ``x2_i`` is a negative (i.e., less than ``0``) finite number, the result is ``NaN``.
+    - If ``x1_i`` is ``-infinity`` and ``x2_i`` is a positive (i.e., greater than ``0``) finite number, the result is ``NaN``.
+    - If ``x1_i`` is ``-infinity`` and ``x2_i`` is a negative (i.e., less than ``0``) finite number, the result is ``NaN``.
+    - If ``x1_i`` is a positive (i.e., greater than ``0``) finite number and ``x2_i`` is ``+infinity``, the result is ``x1_i``. (**note**: this result matches Python behavior.)
+    - If ``x1_i`` is a positive (i.e., greater than ``0``) finite number and ``x2_i`` is ``-infinity``, the result is ``x2_i``. (**note**: this result matches Python behavior.)
+    - If ``x1_i`` is a negative (i.e., less than ``0``) finite number and ``x2_i`` is ``+infinity``, the result is ``x2_i``. (**note**: this results matches Python behavior.)
+    - If ``x1_i`` is a negative (i.e., less than ``0``) finite number and ``x2_i`` is ``-infinity``, the result is ``x1_i``. (**note**: this result matches Python behavior.)
+    -   In the remaining cases, the result must match that of the Python ``%`` operator.
 
     Parameters
     ----------
@@ -1206,6 +1237,7 @@ def sinh(x: array, /) -> array:
     Calculates an implementation-dependent approximation to the hyperbolic sine, having domain ``[-infinity, +infinity]`` and codomain ``[-infinity, +infinity]``, for each element ``x_i`` of the input array ``x``.
 
     **Special cases**
+
     For floating-point operands,
 
     - If ``x_i`` is ``NaN``, the result is ``NaN``.

--- a/spec/API_specification/signatures/elementwise_functions.py
+++ b/spec/API_specification/signatures/elementwise_functions.py
@@ -1113,7 +1113,7 @@ def remainder(x1: array, x2: array, /) -> array:
     Returns the remainder of division for each element ``x1_i`` of the input array ``x1`` and the respective element ``x2_i`` of the input array ``x2``.
 
     .. note::
-       This function is equivalent to the Python modulus operator ``x1_i % x2_i`` and is complementary to the :func:`~signatures.elementwise_functions.floor_divide`.
+       This function is equivalent to the Python modulus operator ``x1_i % x2_i``.
 
     .. note::
        For input arrays which promote to an integer data type, the result of division by zero is unspecified and thus implementation-defined.

--- a/spec/API_specification/signatures/elementwise_functions.py
+++ b/spec/API_specification/signatures/elementwise_functions.py
@@ -1123,7 +1123,7 @@ def remainder(x1: array, x2: array, /) -> array:
     .. note::
        In general, similar to Python's ``%`` operator, this function is **not** recommended for floating-point operands as semantics do not follow IEEE 754. That this function is specified to accept floating-point operands is primarily for reasons of backward compatibility.
 
-    For floating-points operands,
+    For floating-point operands,
 
     - If either ``x1_i`` or ``x2_i`` is ``NaN``, the result is ``NaN``.
     - If ``x1_i`` is either ``+infinity`` or ``-infinity`` and ``x2_i`` is either ``+infinity`` or ``-infinity``, the result is ``NaN``.

--- a/spec/API_specification/signatures/elementwise_functions.py
+++ b/spec/API_specification/signatures/elementwise_functions.py
@@ -1144,7 +1144,7 @@ def remainder(x1: array, x2: array, /) -> array:
     - If ``x1_i`` is a positive (i.e., greater than ``0``) finite number and ``x2_i`` is ``-infinity``, the result is ``x2_i``. (**note**: this result matches Python behavior.)
     - If ``x1_i`` is a negative (i.e., less than ``0``) finite number and ``x2_i`` is ``+infinity``, the result is ``x2_i``. (**note**: this results matches Python behavior.)
     - If ``x1_i`` is a negative (i.e., less than ``0``) finite number and ``x2_i`` is ``-infinity``, the result is ``x1_i``. (**note**: this result matches Python behavior.)
-    -   In the remaining cases, the result must match that of the Python ``%`` operator.
+    - In the remaining cases, the result must match that of the Python ``%`` operator.
 
     Parameters
     ----------

--- a/spec/API_specification/signatures/elementwise_functions.py
+++ b/spec/API_specification/signatures/elementwise_functions.py
@@ -1118,7 +1118,7 @@ def remainder(x1: array, x2: array, /) -> array:
     .. note::
        For input arrays which promote to an integer data type, the result of division by zero is unspecified and thus implementation-defined.
 
-    **Special Cases**
+    **Special cases**
 
     .. note::
        In general, similar to Python's ``%`` operator, this function is **not** recommended for floating-point operands as semantics do not follow IEEE 754. That this function is specified to accept floating-point operands is primarily for reasons of backward compatibility.


### PR DESCRIPTION
This PR

-   updates the specification for `remainder` (and, by extension, the `__mod__` method) to include special cases for floating-point operands.
-   adds guidance intended to match Python's `%` operator.
-   adds a comment recommending against the use of `remainder` for floating-point operands, given that behavior does not follow IEEE 754 (i.e., results can deviate from `r = x - n*floor(x/y)`, particularly during overflow and underflow). As floating-point operand acceptance is common across all implementing array libraries, the specification permits their support for reasons of backward compatibility.
-   resolves https://github.com/data-apis/array-api/issues/385.