### PR TITLE
Update broadcasting examples to include size `0` dimension cases

### DIFF
--- a/spec/API_specification/broadcasting.rst
+++ b/spec/API_specification/broadcasting.rst
@@ -100,6 +100,11 @@ The following examples demonstrate the application of the broadcasting algorithm
    ---------------------------------
    Result (4d array):  8 x 7 x 6 x 5
 
+   A      (4d array):  8 x 1 x 0 x 1
+   B      (3d array):      7 x 1 x 5
+   ---------------------------------
+   Result (4d array):  8 x 7 x 0 x 5
+
    A      (2d array):  5 x 4
    B      (1d array):      1
    -------------------------

--- a/spec/API_specification/broadcasting.rst
+++ b/spec/API_specification/broadcasting.rst
@@ -72,7 +72,7 @@ The following examples demonstrate the application of the broadcasting algorithm
 
    A      (4d array):  8 x 1 x 6 x 1
    B      (3d array):      7 x 1 x 5
-  ---------------------------------
+   ---------------------------------
    Result (4d array):  8 x 7 x 6 x 5
 
    A      (2d array):  5 x 4

--- a/spec/API_specification/broadcasting.rst
+++ b/spec/API_specification/broadcasting.rst
@@ -74,22 +74,27 @@ The following examples demonstrate the application of the broadcasting algorithm
    B      (3d array):      7 x 1 x 5
   ---------------------------------
    Result (4d array):  8 x 7 x 6 x 5
+
    A      (2d array):  5 x 4
    B      (1d array):      1
    -------------------------
    Result (2d array):  5 x 4
+
    A      (2d array):  5 x 4
    B      (1d array):      4
    -------------------------
    Result (2d array):   5 x 4
+
    A      (3d array):  15 x 3 x 5
    B      (3d array):  15 x 1 x 5
    ------------------------------
    Result (3d array):  15 x 3 x 5
+
    A      (3d array):  15 x 3 x 5
    B      (2d array):       3 x 5
    ------------------------------
    Result (3d array):  15 x 3 x 5
+   
    A      (3d array):  15 x 3 x 5
    B      (2d array):       3 x 1
    ------------------------------

--- a/spec/API_specification/broadcasting.rst
+++ b/spec/API_specification/broadcasting.rst
@@ -83,7 +83,7 @@ The following examples demonstrate the application of the broadcasting algorithm
    A      (2d array):  5 x 4
    B      (1d array):      4
    -------------------------
-   Result (2d array):   5 x 4
+   Result (2d array):  5 x 4
 
    A      (3d array):  15 x 3 x 5
    B      (3d array):  15 x 1 x 5
@@ -94,7 +94,7 @@ The following examples demonstrate the application of the broadcasting algorithm
    B      (2d array):       3 x 5
    ------------------------------
    Result (3d array):  15 x 3 x 5
-   
+
    A      (3d array):  15 x 3 x 5
    B      (2d array):       3 x 1
    ------------------------------

--- a/spec/API_specification/broadcasting.rst
+++ b/spec/API_specification/broadcasting.rst
@@ -70,6 +70,31 @@ The following examples demonstrate the application of the broadcasting algorithm
 
 ::
 
+   A      (1d array):  4
+   B      (1d array):  4
+   ---------------------
+   Result (1d array):  4
+
+   A      (1d array):  4
+   B      (1d array):  1
+   ---------------------
+   Result (1d array):  4
+
+   A      (1d array):  1
+   B      (1d array):  4
+   ---------------------
+   Result (1d array):  4
+
+   A      (1d array):  0
+   B      (1d array):  1
+   ---------------------
+   Result (1d array):  0
+
+   A      (1d array):  1
+   B      (1d array):  0
+   ---------------------
+   Result (1d array):  0
+
    A      (4d array):  8 x 1 x 6 x 1
    B      (3d array):      7 x 1 x 5
    ---------------------------------
@@ -85,6 +110,11 @@ The following examples demonstrate the application of the broadcasting algorithm
    -------------------------
    Result (2d array):  5 x 4
 
+   A      (2d array):  5 x 0
+   B      (1d array):      1
+   -------------------------
+   Result (2d array):  5 x 0
+
    A      (3d array):  15 x 3 x 5
    B      (3d array):  15 x 1 x 5
    ------------------------------
@@ -94,6 +124,11 @@ The following examples demonstrate the application of the broadcasting algorithm
    B      (2d array):       3 x 5
    ------------------------------
    Result (3d array):  15 x 3 x 5
+
+   A      (3d array):  15 x 0 x 5
+   B      (3d array):  15 x 1 x 5
+   ------------------------------
+   Result (3d array):  15 x 0 x 5
 
    A      (3d array):  15 x 3 x 5
    B      (2d array):       3 x 1
@@ -108,8 +143,14 @@ The following examples demonstrate array shapes which do **not** broadcast.
    A      (1d array):  3
    B      (1d array):  4           # dimension does not match
 
+   A      (1d array):  3
+   B      (1d array):  0           # dimension does not match
+
    A      (2d array):      2 x 1
    B      (3d array):  8 x 4 x 3   # second dimension does not match
+
+   A      (2d array):      2 x 1
+   B      (3d array):  8 x 0 x 3   # second dimension does not match
 
    A      (3d array):  15 x 3 x 5
    B      (2d array):  15 x 3      # singleton dimensions can only be prepended, not appended

--- a/spec/API_specification/broadcasting.rst
+++ b/spec/API_specification/broadcasting.rst
@@ -81,7 +81,7 @@ The following examples demonstrate the application of the broadcasting algorithm
    A      (2d array):  5 x 4
    B      (1d array):      4
    -------------------------
-   Result (2d array):  5 x 4
+   Result (2d array):   5 x 4
    A      (3d array):  15 x 3 x 5
    B      (3d array):  15 x 1 x 5
    ------------------------------


### PR DESCRIPTION
This PR

-   updates the broadcasting specification to include examples demonstrating expected behavior when a dimension has size `0`. Namely, size `0` dimensions are **not** special cased. See [gh-404](https://github.com/data-apis/array-api/issues/404).
-   fixes indentation and missing line breaks.