### PR TITLE
`expm1` should having float inputs

### DIFF
--- a/spec/API_specification/signatures/elementwise_functions.py
+++ b/spec/API_specification/signatures/elementwise_functions.py
@@ -562,7 +562,7 @@ def expm1(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a numeric data type.
+        input array. Should have a floating-point data type.
 
     Returns
     -------


### PR DESCRIPTION
Was `expm1()` accepting int dtypes an oversight? If so, here's a fix!

If not, I'm guessing the intention was to "allow" int dtypes here, but leave it as implementation-defined behaviour. In that case we'll need to add a note ala [`divide()`](https://data-apis.org/array-api/latest/API_specification/generated/signatures.elementwise_functions.divide.html).