### PR TITLE
Add `newaxis` constant for use in array indexing

### DIFF
--- a/spec/API_specification/constants.rst
+++ b/spec/API_specification/constants.rst
@@ -22,4 +22,5 @@ Objects in API
    e
    inf
    nan
+   newaxis
    pi

--- a/spec/API_specification/signatures/constants.py
+++ b/spec/API_specification/signatures/constants.py
@@ -15,6 +15,11 @@ nan = float('nan')
 IEEE 754 floating-point representation of Not a Number (``NaN``).
 """
 
+newaxis = None
+"""
+An alias for ``None`` which is useful for indexing arrays.
+"""
+
 pi = 3.141592653589793
 """
 IEEE 754 floating-point representation of the mathematical constant ``π``.
@@ -22,4 +27,4 @@ IEEE 754 floating-point representation of the mathematical constant ``π``.
 ``pi = 3.1415926535897932384626433...``
 """
 
-__all__ = ['e', 'inf', 'nan', 'pi']
+__all__ = ['e', 'inf', 'nan', 'newaxis', 'pi']


### PR DESCRIPTION
This PR

-   adds the constant `newaxis` to the specification, as an alias for `None`. This change was discussed and supported in the March 24, 2022 consortium meeting.
-   addresses readability concerns when performing array indexing (e.g., `A[:, newaxis]` vs `A[:, None]`, where the former more explicitly conveys that the selection tuple results in an array with an additional dimension).

## Notes

`newaxis` as an alias for `None` enjoys broad support among array libraries. Only PyTorch and Dask lack explicit support.

-   NumPy: `np.newaxis`
-   PyTorch: no equivalent, but supports `None`
-   MXNet: `mx.np.newaxis`
-   TensorFlow: `tf.newaxis`
-   CuPy: `cupy.newaxis`
-   Dask: no equivalent, but supports `np.newaxis` (i.e., `None`)