### PR TITLE
Add support for broadcasting to `linalg.cross`

### DIFF
--- a/spec/API_specification/signatures/linalg.py
+++ b/spec/API_specification/signatures/linalg.py
@@ -26,16 +26,16 @@ def cholesky(x: array, /, *, upper: bool = False) -> array:
 
 def cross(x1: array, x2: array, /, *, axis: int = -1) -> array:
     """
-    Returns the cross product of 3-element vectors. If ``x1`` and ``x2`` are multi-dimensional arrays (i.e., both have a rank greater than ``1``), then the cross-product of each pair of corresponding 3-element vectors is independently computed.
+    Returns the cross product of 3-element vectors. If ``x1`` and/or ``x2`` are multi-dimensional arrays (i.e., the broadcasted result has a rank greater than ``1``), then the cross-product of each pair of corresponding 3-element vectors is independently computed.
 
     Parameters
     ----------
     x1: array
         first input array. Should have a numeric data type.
     x2: array
-        second input array. Must have the same shape as ``x1``.  Should have a numeric data type.
+        second input array. Must be compatible with ``x1`` (see :ref:`broadcasting`). The size of the axis over which to compute the cross product must be the same size as the respective axis in ``x1`` (i.e., broadcasting only applies to the non-compute axes). Should have a numeric data type.
     axis: int
-        the axis (dimension) of ``x1`` and ``x2`` containing the vectors for which to compute the cross product. If set to ``-1``, the function computes the cross product for vectors defined by the last axis (dimension). Default: ``-1``.
+        the axis (dimension) of ``x1`` and ``x2`` containing the vectors for which to compute the cross product. Must be an integer on the interval ``[-N, N)``, where ``N`` is the rank (number of dimensions) of the shape determined according to :ref:`broadcasting`. If specified as a negative integer, the function must determine the axis along which to compute the cross product by counting backward from the last dimension (where ``-1`` refers to the last dimension). By default, the function must compute the cross product over the last axis. Default: ``-1``.
 
     Returns
     -------

--- a/spec/API_specification/signatures/linear_algebra_functions.py
+++ b/spec/API_specification/signatures/linear_algebra_functions.py
@@ -92,8 +92,8 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     x1: array
         first input array. Should have a numeric data type.
     x2: array
-        second input array. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have a numeric data type.
-    axis:int
+        second input array. Must be compatible with ``x1`` (see :ref:`broadcasting`). The size of the axis over which to compute the dot product must be the same size as the respective axis in ``x1`` (i.e., broadcasting only applies to the non-compute axes). Should have a numeric data type.
+    axis: int
         axis over which to compute the dot product. Must be an integer on the interval ``[-N, N)``, where ``N`` is the rank (number of dimensions) of the shape determined according to :ref:`broadcasting`. If specified as a negative integer, the function must determine the axis along which to compute the dot product by counting backward from the last dimension (where ``-1`` refers to the last dimension). By default, the function must compute the dot product over the last axis. Default: ``-1``.
 
     Returns
@@ -105,7 +105,7 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     **Raises**
 
     -   if provided an invalid ``axis``.
-    -   if the size of the axis over which to compute the dot product is not the same for both ``x1`` and ``x2``.
+    -   if the size of the axis over which to compute the dot product is not the same (before broadcasting) for both ``x1`` and ``x2``.
     """
 
 __all__ = ['matmul', 'matrix_transpose', 'tensordot', 'vecdot']


### PR DESCRIPTION
This PR

-   addresses https://github.com/data-apis/array-api/issues/415 by adding support for broadcasting to `linalg.cross`. Broadcasting follows NumPy behavior in only broadcasting the non-compute dimensions. With the exception of TensorFlow, this behavior is consistent (or will be after PyTorch addresses its broadcasting behavior) among array libraries.
-   updates `vecdot` to match `linalg.cross` in being more explicit that broadcasting only applies to non-broadcast dimensions.