### PR TITLE
Fix failing preview.yml GitHub Actions job

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,6 +14,3 @@ jobs:
           artifact-path: 0/build/latest/index.html
           circleci-jobs: build_page
           job-title: Check the rendered docs here!
-      - name: Array API preview
-        run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA


### PR DESCRIPTION
This seems like a bug in the docs of the action, this step is unnecessary and is failing.