### PR TITLE
Move broadcast functions to list of functions for manipulating arrays

### DIFF
--- a/spec/API_specification/data_type_functions.rst
+++ b/spec/API_specification/data_type_functions.rst
@@ -19,8 +19,6 @@ Objects in API
    :template: method.rst
 
    astype
-   broadcast_arrays
-   broadcast_to
    can_cast
    finfo
    iinfo

--- a/spec/API_specification/manipulation_functions.rst
+++ b/spec/API_specification/manipulation_functions.rst
@@ -21,6 +21,8 @@ Objects in API
    :toctree: generated
    :template: method.rst
 
+   broadcast_arrays
+   broadcast_to
    concat
    expand_dims
    flip

--- a/spec/API_specification/signatures/data_type_functions.py
+++ b/spec/API_specification/signatures/data_type_functions.py
@@ -124,4 +124,4 @@ def result_type(*arrays_and_dtypes: Union[array, dtype]) -> dtype:
         the dtype resulting from an operation involving the input arrays and dtypes.
     """
 
-__all__ = ['astype', 'broadcast_arrays', 'broadcast_to', 'can_cast', 'finfo', 'iinfo', 'result_type']
+__all__ = ['astype', 'can_cast', 'finfo', 'iinfo', 'result_type']

--- a/spec/API_specification/signatures/data_type_functions.py
+++ b/spec/API_specification/signatures/data_type_functions.py
@@ -1,4 +1,4 @@
-from ._types import List, Tuple, Union, array, dtype, finfo_object, iinfo_object
+from ._types import Union, array, dtype, finfo_object, iinfo_object
 
 def astype(x: array, dtype: dtype, /, *, copy: bool = True) -> array:
     """
@@ -25,38 +25,6 @@ def astype(x: array, dtype: dtype, /, *, copy: bool = True) -> array:
     -------
     out: array
         an array having the specified data type. The returned array must have the same shape as ``x``.
-    """
-
-def broadcast_arrays(*arrays: array) -> List[array]:
-    """
-    Broadcasts one or more arrays against one another.
-
-    Parameters
-    ----------
-    arrays: array
-        an arbitrary number of to-be broadcasted arrays.
-
-    Returns
-    -------
-    out: List[array]
-        a list of broadcasted arrays. Each array must have the same shape. Each array must have the same dtype as its corresponding input array.
-    """
-
-def broadcast_to(x: array, /, shape: Tuple[int, ...]) -> array:
-    """
-    Broadcasts an array to a specified shape.
-
-    Parameters
-    ----------
-    x: array
-        array to broadcast.
-    shape: Tuple[int, ...]
-        array shape. Must be compatible with ``x`` (see :ref:`broadcasting`). If the array is incompatible with the specified shape, the function should raise an exception.
-
-    Returns
-    -------
-    out: array
-        an array having a specified shape. Must have the same data type as ``x``.
     """
 
 def can_cast(from_: Union[dtype, array], to: dtype, /) -> bool:

--- a/spec/API_specification/signatures/manipulation_functions.py
+++ b/spec/API_specification/signatures/manipulation_functions.py
@@ -178,4 +178,4 @@ def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) ->
            This specification leaves type promotion between data type families (i.e., ``intxx`` and ``floatxx``) unspecified.
     """
 
-__all__ = ['concat', 'expand_dims', 'flip', 'permute_dims', 'reshape', 'roll', 'squeeze', 'stack']
+__all__ = [ 'broadcast_arrays', 'broadcast_to', 'concat', 'expand_dims', 'flip', 'permute_dims', 'reshape', 'roll', 'squeeze', 'stack']

--- a/spec/API_specification/signatures/manipulation_functions.py
+++ b/spec/API_specification/signatures/manipulation_functions.py
@@ -1,5 +1,37 @@
 from ._types import List, Optional, Tuple, Union, array
 
+def broadcast_arrays(*arrays: array) -> List[array]:
+    """
+    Broadcasts one or more arrays against one another.
+
+    Parameters
+    ----------
+    arrays: array
+        an arbitrary number of to-be broadcasted arrays.
+
+    Returns
+    -------
+    out: List[array]
+        a list of broadcasted arrays. Each array must have the same shape. Each array must have the same dtype as its corresponding input array.
+    """
+
+def broadcast_to(x: array, /, shape: Tuple[int, ...]) -> array:
+    """
+    Broadcasts an array to a specified shape.
+
+    Parameters
+    ----------
+    x: array
+        array to broadcast.
+    shape: Tuple[int, ...]
+        array shape. Must be compatible with ``x`` (see :ref:`broadcasting`). If the array is incompatible with the specified shape, the function should raise an exception.
+
+    Returns
+    -------
+    out: array
+        an array having a specified shape. Must have the same data type as ``x``.
+    """
+
 def concat(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: Optional[int] = 0) -> array:
     """
     Joins a sequence of arrays along an existing axis.


### PR DESCRIPTION
This PR

-   moves the broadcast functions `broadcast_arrays` and `broadcast_to` to the list of manipulation functions. Their inclusion in the list of data type functions seems to have been an oversight in https://github.com/data-apis/array-api/pull/132. This PR rectifies this and follows NumPy in defining these functions as manipulation functions.
-   does not change the normative content, merely their organization within the specification.