### PR TITLE
PR: Add sphinx math dollar extension

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ myst-parser
 sphinx_markdown_tables
 sphinx_copybutton
 docutils<0.18
+sphinx-math-dollar

--- a/spec/conf.py
+++ b/spec/conf.py
@@ -40,6 +40,8 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
     'sphinx.ext.autodoc',
+    'sphinx_math_dollar',
+    'sphinx.ext.mathjax'
 ]
 
 autosummary_generate = True
@@ -47,6 +49,21 @@ autodoc_typehints = 'signature'
 add_module_names = False
 napoleon_custom_sections = [('Returns', 'params_style')]
 default_role = 'code'
+
+# Mathjax configuration
+mathjax_config = {
+    'tex2jax': {
+        'inlineMath': [ ["\\(","\\)"] ],
+        'displayMath': [["\\[","\\]"] ],
+    },
+}
+
+mathjax3_config = {
+  "tex": {
+    "inlineMath": [['\\(', '\\)']],
+    "displayMath": [["\\[", "\\]"]],
+  }
+}
 
 # nitpicky = True makes Sphinx warn whenever a cross-reference target can't be
 # found.


### PR DESCRIPTION
This PR adds `sphinx_math_dollar` extension so we can use dollar sign syntax in rst files.