### PR TITLE
Clarify expected values in `eye` when `dtype` is a complex number data type

### DIFF
--- a/spec/API_specification/array_api/creation_functions.py
+++ b/spec/API_specification/array_api/creation_functions.py
@@ -112,6 +112,9 @@ def eye(n_rows: int, n_cols: Optional[int] = None, /, *, k: int = 0, dtype: Opti
     """
     Returns a two-dimensional array with ones on the ``k``\th diagonal and zeros elsewhere.
 
+    .. note::
+       An output array having a complex floating-point data type must have the value ``1 + 0j`` along the ``k``\th diagonal and ``0 + 0j`` elsewhere. 
+
     Parameters
     ----------
     n_rows: int


### PR DESCRIPTION
This PR

-   adds a note to `eye` concerning expected output values when `dtype` is either `complex64` or `complex128`. Namely, only real components along the kth diagonal are ones. Imaginary components are always zero for all elements.