### PR TITLE
Update `iinfo` description to be consistent with `finfo`

### DIFF
--- a/spec/API_specification/array_api/data_type_functions.py
+++ b/spec/API_specification/array_api/data_type_functions.py
@@ -91,7 +91,7 @@ def iinfo(type: Union[dtype, array], /) -> iinfo_object:
     Returns
     -------
     out: iinfo object
-        a class with that encapsules the following attributes:
+        an object having the following attributes:
 
         - **bits**: *int*
 


### PR DESCRIPTION
This PR

-   updates the return value description for `iinfo` to be consistent with `finfo`. The current description seems to have meant to say "encapsulates". The changes introduced in this PR use a simpler sentence construction which mirrors that of `finfo`.