### PR TITLE
Add complex number support to `round`

### DIFF
--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -378,7 +378,15 @@ def ceil(x: array, /) -> array:
     """
     Rounds each element ``x_i`` of the input array ``x`` to the smallest (i.e., closest to ``-infinity``) integer-valued number that is not less than ``x_i``.
 
+    .. note::
+       For complex floating-point operands, real and imaginary components must be independently rounded to the smallest integer-valued number that is not less than the component value.
+    
+       Rounded real and imaginary components must be equal to their equivalent rounded real-valued floating-point counterparts (i.e., for complex-valued ``x``, ``real(ceil(x))`` must equal ``ceil(real(x)))`` and ``imag(ceil(x))`` must equal ``ceil(imag(x))``).
+
     **Special cases**
+
+    .. note::
+       For complex floating-point operands, the following special cases apply to real and imaginary components independently (e.g., if ``real(x_i)`` is ``NaN``, the rounded real component is ``NaN``).
 
     - If ``x_i`` is already integer-valued, the result is ``x_i``.
 
@@ -393,7 +401,7 @@ def ceil(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------
@@ -574,7 +582,15 @@ def floor(x: array, /) -> array:
     """
     Rounds each element ``x_i`` of the input array ``x`` to the greatest (i.e., closest to ``+infinity``) integer-valued number that is not greater than ``x_i``.
 
+    .. note::
+       For complex floating-point operands, real and imaginary components must be independently rounded to the greatest integer-valued number that is not greater than the component value.
+    
+       Rounded real and imaginary components must be equal to their equivalent rounded real-valued floating-point counterparts (i.e., for complex-valued ``x``, ``real(floor(x))`` must equal ``floor(real(x)))`` and ``imag(floor(x))`` must equal ``floor(imag(x))``).
+
     **Special cases**
+
+    .. note::
+       For complex floating-point operands, the following special cases apply to real and imaginary components independently (e.g., if ``real(x_i)`` is ``NaN``, the rounded real component is ``NaN``).
 
     - If ``x_i`` is already integer-valued, the result is ``x_i``.
 
@@ -589,7 +605,7 @@ def floor(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------
@@ -1163,7 +1179,15 @@ def round(x: array, /) -> array:
     """
     Rounds each element ``x_i`` of the input array ``x`` to the nearest integer-valued number.
 
+    .. note::
+       For complex floating-point operands, real and imaginary components must be independently rounded to the nearest integer-valued number.
+    
+       Rounded real and imaginary components must be equal to their equivalent rounded real-valued floating-point counterparts (i.e., for complex-valued ``x``, ``real(round(x))`` must equal ``round(real(x)))`` and ``imag(round(x))`` must equal ``round(imag(x))``).
+
     **Special cases**
+
+    .. note::
+       For complex floating-point operands, the following special cases apply to real and imaginary components independently (e.g., if ``real(x_i)`` is ``NaN``, the rounded real component is ``NaN``).
 
     - If ``x_i`` is already integer-valued, the result is ``x_i``.
 
@@ -1179,7 +1203,7 @@ def round(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------
@@ -1367,7 +1391,15 @@ def trunc(x: array, /) -> array:
     """
     Rounds each element ``x_i`` of the input array ``x`` to the integer-valued number that is closest to but no greater than ``x_i``.
 
+    .. note::
+       For complex floating-point operands, real and imaginary components must be independently rounded to the integer-valued number that is closest to but no greater than the component value.
+    
+       Rounded real and imaginary components must be equal to their equivalent rounded real-valued floating-point counterparts (i.e., for complex-valued ``x``, ``real(trunc(x))`` must equal ``trunc(real(x)))`` and ``imag(trunc(x))`` must equal ``trunc(imag(x))``).
+
     **Special cases**
+
+    .. note::
+       For complex floating-point operands, the following special cases apply to real and imaginary components independently (e.g., if ``real(x_i)`` is ``NaN``, the rounded real component is ``NaN``).
 
     - If ``x_i`` is already integer-valued, the result is ``x_i``.
 
@@ -1382,7 +1414,7 @@ def trunc(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -378,15 +378,7 @@ def ceil(x: array, /) -> array:
     """
     Rounds each element ``x_i`` of the input array ``x`` to the smallest (i.e., closest to ``-infinity``) integer-valued number that is not less than ``x_i``.
 
-    .. note::
-       For complex floating-point operands, real and imaginary components must be independently rounded to the smallest integer-valued number that is not less than the component value.
-    
-       Rounded real and imaginary components must be equal to their equivalent rounded real-valued floating-point counterparts (i.e., for complex-valued ``x``, ``real(ceil(x))`` must equal ``ceil(real(x)))`` and ``imag(ceil(x))`` must equal ``ceil(imag(x))``).
-
     **Special cases**
-
-    .. note::
-       For complex floating-point operands, the following special cases apply to real and imaginary components independently (e.g., if ``real(x_i)`` is ``NaN``, the rounded real component is ``NaN``).
 
     - If ``x_i`` is already integer-valued, the result is ``x_i``.
 
@@ -401,7 +393,7 @@ def ceil(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a numeric data type.
+        input array. Should have a real-valued data type.
 
     Returns
     -------
@@ -582,15 +574,7 @@ def floor(x: array, /) -> array:
     """
     Rounds each element ``x_i`` of the input array ``x`` to the greatest (i.e., closest to ``+infinity``) integer-valued number that is not greater than ``x_i``.
 
-    .. note::
-       For complex floating-point operands, real and imaginary components must be independently rounded to the greatest integer-valued number that is not greater than the component value.
-    
-       Rounded real and imaginary components must be equal to their equivalent rounded real-valued floating-point counterparts (i.e., for complex-valued ``x``, ``real(floor(x))`` must equal ``floor(real(x)))`` and ``imag(floor(x))`` must equal ``floor(imag(x))``).
-
     **Special cases**
-
-    .. note::
-       For complex floating-point operands, the following special cases apply to real and imaginary components independently (e.g., if ``real(x_i)`` is ``NaN``, the rounded real component is ``NaN``).
 
     - If ``x_i`` is already integer-valued, the result is ``x_i``.
 
@@ -605,7 +589,7 @@ def floor(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a numeric data type.
+        input array. Should have a real-valued data type.
 
     Returns
     -------
@@ -1391,15 +1375,7 @@ def trunc(x: array, /) -> array:
     """
     Rounds each element ``x_i`` of the input array ``x`` to the integer-valued number that is closest to but no greater than ``x_i``.
 
-    .. note::
-       For complex floating-point operands, real and imaginary components must be independently rounded to the integer-valued number that is closest to but no greater than the component value.
-    
-       Rounded real and imaginary components must be equal to their equivalent rounded real-valued floating-point counterparts (i.e., for complex-valued ``x``, ``real(trunc(x))`` must equal ``trunc(real(x)))`` and ``imag(trunc(x))`` must equal ``trunc(imag(x))``).
-
     **Special cases**
-
-    .. note::
-       For complex floating-point operands, the following special cases apply to real and imaginary components independently (e.g., if ``real(x_i)`` is ``NaN``, the rounded real component is ``NaN``).
 
     - If ``x_i`` is already integer-valued, the result is ``x_i``.
 
@@ -1414,7 +1390,7 @@ def trunc(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a numeric data type.
+        input array. Should have a real-valued data type.
 
     Returns
     -------


### PR DESCRIPTION
This PR

-   adds complex number support to `round`. Namely, when applying `round` to complex number operands, the real and imaginary components must be independently rounded.

## Notes

-   Currently, array libraries generally only support rounding complex numbers in `round`, but not `ceil`, `floor`, or `trunc`. Reasons for not extending complex number support to `floor`, `ceil`, and `trunc` are discussed in a [comment](https://github.com/data-apis/array-api/pull/440#issuecomment-1140775432) below.