### PR TITLE
Clarify expected behavior when providing a complex number array to `nonzero`

### DIFF
--- a/spec/API_specification/array_api/searching_functions.py
+++ b/spec/API_specification/array_api/searching_functions.py
@@ -42,6 +42,12 @@ def nonzero(x: array, /) -> Tuple[array, ...]:
     """
     Returns the indices of the array elements which are non-zero.
 
+    .. note::
+       If ``x`` has a complex floating-point data type, non-zero elements are those elements having at least one component (real or imaginary) which is non-zero.
+
+    .. note::
+       If ``x`` has a boolean data type, non-zero elements are those elements which are equal to ``True``.
+
     .. admonition:: Data-dependent output shape
        :class: admonition important
 


### PR DESCRIPTION
This PR

-   clarifies expected behavior when providing a complex number array to `nonzero`. Namely, nonzero elements are those elements have either a real or imaginary component (or both) which is non-zero.
-   adds a note clarifying that, for boolean arrays, `True` is non-zero.