### PR TITLE
Add complex number support to `astype`

### DIFF
--- a/spec/API_specification/array_api/data_type_functions.py
+++ b/spec/API_specification/array_api/data_type_functions.py
@@ -8,7 +8,9 @@ def astype(x: array, dtype: dtype, /, *, copy: bool = True) -> array:
        Casting floating-point ``NaN`` and ``infinity`` values to integral data types is not specified and is implementation-dependent.
 
     .. note::
-       When casting a complex floating-point array to a real-valued data type, imaginary components must be discarded (i.e., for a complex floating-point array ``x``, ``astype(x)`` must equal ``astype(real(x))``).
+       Casting a complex floating-point array to a real-valued data type should not be permitted.
+
+       Historically, libraries such as NumPy have discarded imaginary components such that, for a complex floating-point array ``x``, ``astype(x)`` equals ``astype(real(x))``). This behavior is not considered desirable
 
        More generally, the result of casting a complex floating-point array ``x`` to a real-valued data type must be equal to the result of casting a real-valued floating-point array containing only the real components of ``x``.
 

--- a/spec/API_specification/array_api/data_type_functions.py
+++ b/spec/API_specification/array_api/data_type_functions.py
@@ -10,9 +10,7 @@ def astype(x: array, dtype: dtype, /, *, copy: bool = True) -> array:
     .. note::
        Casting a complex floating-point array to a real-valued data type should not be permitted.
 
-       Historically, libraries such as NumPy have discarded imaginary components such that, for a complex floating-point array ``x``, ``astype(x)`` equals ``astype(real(x))``). This behavior is not considered desirable
-
-       More generally, the result of casting a complex floating-point array ``x`` to a real-valued data type must be equal to the result of casting a real-valued floating-point array containing only the real components of ``x``.
+       Historically, when casting a complex floating-point array to a real-valued data type, libraries such as NumPy have discarded imaginary components such that, for a complex floating-point array ``x``, ``astype(x)`` equals ``astype(real(x))``). This behavior is considered problematic as the choice to discard the imaginary component is arbitrary and introduces more than one way to achieve the same outcome (i.e., for a complex floating-point array ``x``, ``astype(x)`` and ``astype(real(x))`` versus only ``astype(imag(x))``). Instead, in order to avoid ambiguity and to promote clarity, this specification requires that array API consumers explicitly express which component should be cast to a specified real-valued data type.
 
     .. note::
        When casting a boolean input array to a real-valued data type, a value of ``True`` must cast to a real-valued number equal to ``1``, and a value of ``False`` must cast to a real-valued number equal to ``0``.
@@ -31,7 +29,7 @@ def astype(x: array, dtype: dtype, /, *, copy: bool = True) -> array:
     dtype: dtype
         desired data type.
     copy: bool
-        specifies whether to copy an array when the specified ``dtype`` matches the data type of the input array ``x``. If ``True``, a newly allocated array must always be returned. If ``False`` and the specified ``dtype`` matches the data type of the input array, the input array must be returned; otherwise, a newly allocated must be returned. Default: ``True``.
+        specifies whether to copy an array when the specified ``dtype`` matches the data type of the input array ``x``. If ``True``, a newly allocated array must always be returned. If ``False`` and the specified ``dtype`` matches the data type of the input array, the input array must be returned; otherwise, a newly allocated array must be returned. Default: ``True``.
 
     Returns
     -------

--- a/spec/API_specification/array_api/data_type_functions.py
+++ b/spec/API_specification/array_api/data_type_functions.py
@@ -8,9 +8,19 @@ def astype(x: array, dtype: dtype, /, *, copy: bool = True) -> array:
        Casting floating-point ``NaN`` and ``infinity`` values to integral data types is not specified and is implementation-dependent.
 
     .. note::
-       When casting a boolean input array to a real-valued data type, a value of ``True`` must cast to a numeric value equal to ``1``, and a value of ``False`` must cast to a numeric value equal to ``0``.
+       When casting a complex floating-point array to a real-valued data type, imaginary components must be discarded (i.e., for a complex floating-point array ``x``, ``astype(x)`` must equal ``astype(real(x))``).
 
+       More generally, the result of casting a complex floating-point array ``x`` to a real-valued data type must be equal to the result of casting a real-valued floating-point array containing only the real components of ``x``.
+
+    .. note::
+       When casting a boolean input array to a real-valued data type, a value of ``True`` must cast to a real-valued number equal to ``1``, and a value of ``False`` must cast to a real-valued number equal to ``0``.
+
+       When casting a boolean input array to a complex floating-point data type, a value of ``True`` must cast to a complex number equal to ``1 + 0j``, and a value of ``False`` must cast to a complex number equal to ``0 + 0j``.
+
+    .. note::
        When casting a real-valued input array to ``bool``, a value of ``0`` must cast to ``False``, and a non-zero value must cast to ``True``.
+
+       When casting a complex floating-point array to ``bool``, a value of ``0 + 0j`` must cast to ``False``, and all other values must cast to ``True``.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR:

-   adds complex number support to `astype`. As `astype` generally supports copying an array to _any_ specified data type irrespective of type promotion rules, no exception to general behavior is made for complex number arrays.

    Accordingly, following C, NumPy, and others, when casting a complex floating-point array to a real-valued data type, the imaginary component must be discarded and only the real component cast to the desired data type.

## Notes

-   The alternative to discarding the imaginary component is to require users call `real(x)` **before** calling `astype`. However, as `astype` is more generally used to force a type conversion, prohibiting casting complex-valued arrays to real-valued arrays did not seem ideal, nor consistent with, say, casting a floating-point array to an integral array (i.e., we allow casting a floating-point array to an integral array and don't require `astype(floor(x))`). Hence, this PR chooses to follow existing precedent and require that the imaginary component be discarded when performing the conversion.

```python
In [1]: z = np.asarray(1.5 + 2.6j)

In [2]: z.astype(dtype="float64")
<ipython-input-9-bea51b1612d9>:1: ComplexWarning: Casting complex values to real discards the imaginary part
  z.astype(dtype="float64")
Out[2]: array(1.5)

In [3]: z.astype(dtype="bool")
Out[3]: array(True)

In [4]: np.asarray(True).astype(dtype="complex128")
Out[4]: array(1.+0.j)

In [5]: np.asarray(False).astype(dtype="complex128")
Out[5]: array(0.+0.j)

In [6]: z.astype(dtype="int32")
<ipython-input-13-5f154e24a33c>:1: ComplexWarning: Casting complex values to real discards the imaginary part
  z.astype(dtype="int32")
Out[6]: array(1, dtype=int32)

In [7]: np.asarray(0+0j).astype(dtype="bool")
Out[7]: array(False)
```

## Updates

-   Based on discussions in the consortium workgroup and the 22 September 2022 workgroup meeting, consensus emerged to disallow casting from a complex floating-point dtype to a real-valued dtype. Instead, array API consumers should be explicit in specifying which component should be cast to a specified real-valued dtype.