### PR TITLE
Add `conj` specification for computing the complex conjugate

### DIFF
--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -401,6 +401,34 @@ def ceil(x: array, /) -> array:
         an array containing the rounded result for each element in ``x``. The returned array must have the same data type as ``x``.
     """
 
+def conj(x: array, /) -> array:
+    """
+    Returns the complex conjugate for each element ``x_i`` of the input array ``x``.
+
+    For complex numbers of the form
+
+    .. math::
+       a + bj
+
+    the complex conjugate is defined as
+
+    .. math::
+       a - bj
+
+    Hence, the returned complex conjugate must be computed by negating the imaginary component of each element ``x_i``.
+
+    Parameters
+    ----------
+    x: array
+        input array. Should have a complex-floating point data type.
+
+    Returns
+    -------
+    out: array
+        an array containing the element-wise results. The returned array must have the same data type as ``x``.
+    """
+
+
 def cos(x: array, /) -> array:
     """
     Calculates an implementation-dependent approximation to the cosine, having domain ``(-infinity, +infinity)`` and codomain ``[-1, +1]``, for each element ``x_i`` of the input array ``x``. Each element ``x_i`` is assumed to be expressed in radians.
@@ -1390,4 +1418,4 @@ def trunc(x: array, /) -> array:
         an array containing the rounded result for each element in ``x``. The returned array must have the same data type as ``x``.
     """
 
-__all__ = ['abs', 'acos', 'acosh', 'add', 'asin', 'asinh', 'atan', 'atan2', 'atanh', 'bitwise_and', 'bitwise_left_shift', 'bitwise_invert', 'bitwise_or', 'bitwise_right_shift', 'bitwise_xor', 'ceil', 'cos', 'cosh', 'divide', 'equal', 'exp', 'expm1', 'floor', 'floor_divide', 'greater', 'greater_equal', 'isfinite', 'isinf', 'isnan', 'less', 'less_equal', 'log', 'log1p', 'log2', 'log10', 'logaddexp', 'logical_and', 'logical_not', 'logical_or', 'logical_xor', 'multiply', 'negative', 'not_equal', 'positive', 'pow', 'remainder', 'round', 'sign', 'sin', 'sinh', 'square', 'sqrt', 'subtract', 'tan', 'tanh', 'trunc']
+__all__ = ['abs', 'acos', 'acosh', 'add', 'asin', 'asinh', 'atan', 'atan2', 'atanh', 'bitwise_and', 'bitwise_left_shift', 'bitwise_invert', 'bitwise_or', 'bitwise_right_shift', 'bitwise_xor', 'ceil', 'conj', 'cos', 'cosh', 'divide', 'equal', 'exp', 'expm1', 'floor', 'floor_divide', 'greater', 'greater_equal', 'isfinite', 'isinf', 'isnan', 'less', 'less_equal', 'log', 'log1p', 'log2', 'log10', 'logaddexp', 'logical_and', 'logical_not', 'logical_or', 'logical_xor', 'multiply', 'negative', 'not_equal', 'positive', 'pow', 'remainder', 'round', 'sign', 'sin', 'sinh', 'square', 'sqrt', 'subtract', 'tan', 'tanh', 'trunc']

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -415,7 +415,7 @@ def conj(x: array, /) -> array:
     .. math::
        a - bj
 
-    Hence, the returned complex conjugate must be computed by negating the imaginary component of each element ``x_i``.
+    Hence, the returned complex conjugates must be computed by negating the imaginary component of each element ``x_i``.
 
     Parameters
     ----------

--- a/spec/API_specification/elementwise_functions.rst
+++ b/spec/API_specification/elementwise_functions.rst
@@ -44,6 +44,7 @@ Objects in API
    bitwise_right_shift
    bitwise_xor
    ceil
+   conj
    cos
    cosh
    divide

--- a/spec/conf.py
+++ b/spec/conf.py
@@ -51,13 +51,6 @@ napoleon_custom_sections = [('Returns', 'params_style')]
 default_role = 'code'
 
 # Mathjax configuration
-mathjax_config = {
-    'tex2jax': {
-        'inlineMath': [ ["\\(","\\)"] ],
-        'displayMath': [["\\[","\\]"] ],
-    },
-}
-
 mathjax3_config = {
   "tex": {
     "inlineMath": [['\\(', '\\)']],


### PR DESCRIPTION
This PR

-   adds support for computing the complex conjugate via `conj`, which is widely [implemented](https://github.com/data-apis/array-api-comparison/blob/7ecfa9867ec43a28e914b35868c041443d31d772/signatures/mathematical-functions-elementwise/conj.md) by array libraries.
-   follows the conventions set forth for element-wise mathematical functions.
-   restricts input array types to complex floating-point arrays, following the precedent in https://github.com/data-apis/array-api/pull/427.

## Notes

-   Re: restricting to complex dtypes. We should note that this, similar to `real`, runs contrary to array libraries, more generally, which allow real-valued arrays as input and define `conj` as a no-op for those inputs (see [PyTorch v1.11](https://pytorch.org/docs/1.11/generated/torch.conj.html), [TensorFlow](https://www.tensorflow.org/api_docs/python/tf/math/conj), and NumPy). However, this PR chooses to be consistent with `real` in requiring users to provide a complex number array for the primary reason that, in most cases, when a user is calling `conj(z)`, the expectation is that `z` is complex-valued, and, if real-valued, this is likely a bug.