### PR TITLE
Add complex number support to `negative`

### DIFF
--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -746,10 +746,13 @@ class _array():
         .. note::
            For signed integer data types, the numerical negative of the minimum representable integer is implementation-dependent.
 
+        .. note::
+           If ``self`` has a complex floating-point data type, both the real and imaginary components for each ``self_i`` must be negated (a result which follows from the rules of complex number multiplication).
+
         Parameters
         ----------
         self: array
-            array instance. Should have a real-valued data type.
+            array instance. Should have a numeric data type.
 
         Returns
         -------

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1014,10 +1014,13 @@ def negative(x: array, /) -> array:
     .. note::
        For signed integer data types, the numerical negative of the minimum representable integer is implementation-dependent.
 
+    .. note::
+       If ``x`` has a complex floating-point data type, both the real and imaginary components for each ``x_i`` must be negated (a result which follows from the rules of complex number multiplication).
+
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------


### PR DESCRIPTION
This PR

-   adds complex number support to `negative` (and `__neg__`). No special considerations need to be made for complex numbers, as negative follows the rules of complex number multiplication

    $$\textrm{negative}(z_i) = -1\cdot z_i = (-1+0j)\cdot z_i =(-1+0j)\cdot(a_i + b_ij) = (-1a_i + 0b_i) + (0a_i - 1b_i)j = -a_i - b_ij$$

    where $a_i = \textrm{Re}(z_i)$ and $b_i = \textrm{Im}(z_i)$. 