### PR TITLE
Add complex number support to `cosh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules/
 __pycache__/
 *.pyc
 spec/**/generated
+tmp/

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -437,6 +437,9 @@ def cosh(x: array, /) -> array:
 
     **Special cases**
 
+    .. note::
+       For all operands, ``cosh(x)`` must equal ``cosh(-x)``.
+
     For real-valued floating-point operands,
 
     - If ``x_i`` is ``NaN``, the result is ``NaN``.
@@ -447,29 +450,26 @@ def cosh(x: array, /) -> array:
 
     For complex floating-point operands, let ``a = real(x_i)``, ``b = imag(x_i)``, and
 
-    - If ``a`` is either ``+0`` or ``-0`` and ``b`` is either ``+0`` or ``-0``, the result is ``1 + 0j``.
-    - If ``a`` is either ``+0`` or ``-0`` and ``b`` is ``+infinity``, the result is ``NaN + 0j`` (sign of the imaginary component is unspecified).
-    - If ``a`` is either ``+0`` or ``-0`` and ``b`` is ``NaN``, the result is ``NaN + 0j`` (sign of the imaginary component is unspecified).
+    .. note::
+       For complex floating-point operands, ``cosh(conj(x))`` must equal ``conj(cosh(x))``.
+
+    - If ``a`` is ``+0`` and ``b`` is ``+0``, the result is ``1 + 0j``.
+    - If ``a`` is ``+0`` and ``b`` is ``+infinity``, the result is ``NaN + 0j`` (sign of the imaginary component is unspecified).
+    - If ``a`` is ``+0`` and ``b`` is ``NaN``, the result is ``NaN + 0j`` (sign of the imaginary component is unspecified).
     - If ``a`` is a nonzero finite number and ``b`` is ``+infinity``, the result is ``NaN + NaN j``.
     - If ``a`` is a nonzero finite number and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
-    - If ``a`` is ``+infinity`` and ``b`` is either ``+0`` or ``-0``, the result is ``+infinity + 0j``.
-    - If ``a`` is ``+infinity`` and ``b`` is a nonzero finite number, the result is ``+infinity * cis(x_i)``.
+    - If ``a`` is ``+infinity`` and ``b`` is ``+0``, the result is ``+infinity + 0j``.
+    - If ``a`` is ``+infinity`` and ``b`` is a nonzero finite number, the result is ``+infinity * cis(b)``.
     - If ``a`` is ``+infinity`` and ``b`` is ``+infinity``, the result is ``+infinity + NaN j`` (sign of the real component is unspecified).
     - If ``a`` is ``+infinity`` and ``b`` is ``NaN``, the result is ``+infinity + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is either ``+0`` or ``-0``, the result is ``NaN + 0j`` (sign of the imaginary component is unspecified).
     - If ``a`` is ``NaN`` and ``b`` is a nonzero finite number, the result is ``NaN + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
 
-    where ``cis(x_i)`` is ``cos(x_i) + sin(x_i)*1j``.
+    where ``cis(v)`` is ``cos(v) + sin(v)*1j``.
 
     .. note::
        The hyperbolic cosine is an entire function in the complex plane and has no branch cuts. The function is periodic, with period :math:`2\pi j`, with respect to the imaginary component.
-
-    .. note::
-       For complex floating-point operands, ``cosh(conj(x))`` must equal ``conj(cosh(x))``.
-
-    .. note::
-       For all operands, ``cosh(x)`` must equal ``cosh(-x)``.
 
     Parameters
     ----------

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -463,7 +463,7 @@ def cosh(x: array, /) -> array:
     where ``cis(x_i)`` is ``cos(x_i) + sin(x_i)*1j``.
 
     .. note::
-       The hyperbolic cosine is an entire function in the complex plane and has no branch cuts. The function is periodic, with period :math:`2\pi j` with respect to the imaginary component.
+       The hyperbolic cosine is an entire function in the complex plane and has no branch cuts. The function is periodic, with period :math:`2\pi j`, with respect to the imaginary component.
 
     .. note::
        For complex floating-point operands, ``cosh(conj(x))`` must equal ``conj(cosh(x))``.

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -427,12 +427,17 @@ def cos(x: array, /) -> array:
     """
 
 def cosh(x: array, /) -> array:
-    """
-    Calculates an implementation-dependent approximation to the hyperbolic cosine, having domain ``[-infinity, +infinity]`` and codomain ``[-infinity, +infinity]``, for each element ``x_i`` in the input array ``x``.
+    r"""
+    Calculates an implementation-dependent approximation to the hyperbolic cosine for each element ``x_i`` in the input array ``x``.
+
+    The mathematical definition of the hyperbolic cosine is
+
+    .. math::
+       \operatorname{cosh}(x) = \frac{e^x + e^{-x}}{2}
 
     **Special cases**
 
-    For floating-point operands,
+    For real-valued floating-point operands,
 
     - If ``x_i`` is ``NaN``, the result is ``NaN``.
     - If ``x_i`` is ``+0``, the result is ``1``.
@@ -440,15 +445,41 @@ def cosh(x: array, /) -> array:
     - If ``x_i`` is ``+infinity``, the result is ``+infinity``.
     - If ``x_i`` is ``-infinity``, the result is ``+infinity``.
 
+    For complex floating-point operands, let ``a = real(x_i)``, ``b = imag(x_i)``, and
+
+    - If ``a`` is either ``+0`` or ``-0`` and ``b`` is either ``+0`` or ``-0``, the result is ``1 + 0j``.
+    - If ``a`` is either ``+0`` or ``-0`` and ``b`` is ``+infinity``, the result is ``NaN + 0j`` (sign of the imaginary component is unspecified).
+    - If ``a`` is either ``+0`` or ``-0`` and ``b`` is ``NaN``, the result is ``NaN + 0j`` (sign of the imaginary component is unspecified).
+    - If ``a`` is a nonzero finite number and ``b`` is ``+infinity``, the result is ``NaN + NaN j``.
+    - If ``a`` is a nonzero finite number and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
+    - If ``a`` is ``+infinity`` and ``b`` is either ``+0`` or ``-0``, the result is ``+infinity + 0j``.
+    - If ``a`` is ``+infinity`` and ``b`` is a nonzero finite number, the result is ``+infinity * cis(x_i)``.
+    - If ``a`` is ``+infinity`` and ``b`` is ``+infinity``, the result is ``+infinity + NaN j`` (sign of the real component is unspecified).
+    - If ``a`` is ``+infinity`` and ``b`` is ``NaN``, the result is ``+infinity + NaN j``.
+    - If ``a`` is ``NaN`` and ``b`` is either ``+0`` or ``-0``, the result is ``NaN + 0j`` (sign of the imaginary component is unspecified).
+    - If ``a`` is ``NaN`` and ``b`` is a nonzero finite number, the result is ``NaN + NaN j``.
+    - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
+
+    where ``cis(x_i)`` is ``cos(x_i) + sin(x_i)*1j``.
+
+    .. note::
+       The hyperbolic cosine is an entire function in the complex plane and has no branch cuts. The function is periodic, with period :math:`2\pi j` with respect to the imaginary component.
+
+    .. note::
+       For complex floating-point operands, ``cosh(conj(x))`` must equal ``conj(cosh(x))``.
+
+    .. note::
+       For all operands, ``cosh(x)`` must equal ``cosh(-x)``.
+
     Parameters
     ----------
     x: array
-        input array whose elements each represent a hyperbolic angle. Should have a real-valued floating-point data type.
+        input array whose elements each represent a hyperbolic angle. Should have a floating-point data type.
 
     Returns
     -------
     out: array
-        an array containing the hyperbolic cosine of each element in ``x``. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`.
+        an array containing the hyperbolic cosine of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
 def divide(x1: array, x2: array, /) -> array:


### PR DESCRIPTION
This PR

-   adds complex number support to `cosh` by documenting special cases. The hyperbolic cosine is an entire function in the complex plane. Thus, the function has no branch cuts.
-   updates the input and output array data types to be any floating-point data type, not just real-valued floating-point data types.
-   derives special cases from [C99](https://en.cppreference.com/w/c/numeric/complex/ccosh) and tested against NumPy (script found below).

<details>

```python
import numpy as np
import math

def is_equal_float(x, y):
    """Test whether two floating-point numbers are equal with special consideration for zeros and NaNs.

    Parameters
    ----------
    x : float
        First input number.
    y : float
        Second input number.

    Returns
    -------
    bool
        Boolean indicating whether two floating-point numbers are equal.

    Examples
    --------
    >>> is_equal_float(0.0, -0.0)
    False
    >>> is_equal_float(-0.0, -0.0)
    True
    """
    # Handle +-0:
    if x == 0.0 and y == 0.0:
        return math.copysign(1.0, x) == math.copysign(1.0, y)

    # Handle NaNs:
    if x != x:
        return y != y

    # Everything else, including infinities:
    return x == y


def is_equal(x, y):
    """Test whether two complex numbers are equal with special consideration for zeros and NaNs.

    Parameters
    ----------
    x : complex
        First input number.
    y : complex
        Second input number.

    Returns
    -------
    bool
        Boolean indicating whether two complex numbers are equal.

    Examples
    --------
    >>> import numpy as np
    >>> is_equal(complex(np.nan, np.nan), complex(np.nan, np.nan))
    True
    """
    return is_equal_float(x.real, y.real) and is_equal_float(x.imag, y.imag)


# Strided array consisting of input values and expected values:
values = [
    complex(0.0, 0.0),        # 0
    complex(1.0, 0.0),        # 0
    
    complex(-0.0, 0.0),       # 1
    complex(1.0, -0.0),       # 1
    
    complex(0.0, np.inf),     # 2
    complex(np.nan, 0),       # 2
    
    complex(0.0, np.nan),     # 3
    complex(np.nan, 0.0),     # 3
    
    complex(1.0, np.inf),     # 4
    complex(np.nan, np.nan),  # 4
    
    complex(1.0, np.nan),     # 5
    complex(np.nan, np.nan),  # 5
    
    complex(np.inf, 0.0),     # 6
    complex(np.inf, 0.0),     # 6
    
    complex(np.inf, -0.0),    # 7
    complex(np.inf, -0.0),    # 7
    
    complex(np.inf, 1.0),     # 8
    complex(np.inf, np.inf),  # 8
    
    complex(np.inf, np.inf),  # 9
    complex(np.inf, np.nan),  # 9
    
    complex(np.inf, np.nan),  # 10
    complex(np.inf, np.nan),  # 10
    
    complex(np.nan, 0.0),     # 11
    complex(np.nan, 0.0),     # 11
    
    complex(np.nan, 1.0),     # 12
    complex(np.nan, np.nan),  # 12

    complex(np.nan, 1.0),     # 13
    complex(np.nan, np.nan),  # 13
    
    complex(np.nan, np.nan),  # 14
    complex(np.nan, np.nan)   # 14
]

for i in range(len(values)//2):
    j = i * 2
    v = values[j]
    e = values[j+1]
    actual = np.cosh(v)
    print('Value: {value}'.format(value=str(v)))
    print('Actual: {actual}'.format(actual=str(actual)))
    print('Expected: {expected}'.format(expected=str(e)))
    print('Equal: {is_equal}'.format(is_equal=str(is_equal(actual, e))))
    print('\n')
```

```text
Value: 0j
Actual: (1+0j)
Expected: (1+0j)
Equal: True


Value: (-0+0j)
Actual: (1-0j)
Expected: (1-0j)
Equal: True


/path/to/ccosh.py:116: RuntimeWarning: invalid value encountered in cosh
  actual = np.cosh(v)
Value: infj
Actual: (nan+0j)
Expected: (nan+0j)
Equal: True


Value: nanj
Actual: (nan+0j)
Expected: (nan+0j)
Equal: True


Value: (1+infj)
Actual: (nan+nanj)
Expected: (nan+nanj)
Equal: True


Value: (1+nanj)
Actual: (nan+nanj)
Expected: (nan+nanj)
Equal: True


Value: (inf+0j)
Actual: (inf+0j)
Expected: (inf+0j)
Equal: True


Value: (inf-0j)
Actual: (inf-0j)
Expected: (inf-0j)
Equal: True


Value: (inf+1j)
Actual: (inf+infj)
Expected: (inf+infj)
Equal: True


Value: (inf+infj)
Actual: (inf+nanj)
Expected: (inf+nanj)
Equal: True


Value: (inf+nanj)
Actual: (inf+nanj)
Expected: (inf+nanj)
Equal: True


Value: (nan+0j)
Actual: (nan+0j)
Expected: (nan+0j)
Equal: True


Value: (nan+1j)
Actual: (nan+nanj)
Expected: (nan+nanj)
Equal: True


Value: (nan+1j)
Actual: (nan+nanj)
Expected: (nan+nanj)
Equal: True


Value: (nan+nanj)
Actual: (nan+nanj)
Expected: (nan+nanj)
Equal: True
```
</details>