### PR TITLE
Use raw string for docstrings containing escape sequences

### DIFF
--- a/spec/API_specification/array_api/creation_functions.py
+++ b/spec/API_specification/array_api/creation_functions.py
@@ -29,7 +29,7 @@ def arange(start: Union[int, float], /, stop: Optional[Union[int, float]] = None
     """
 
 def asarray(obj: Union[array, bool, int, float, complex, NestedSequence, SupportsBufferProtocol], /, *, dtype: Optional[dtype] = None, device: Optional[device] = None, copy: Optional[bool] = None) -> array:
-    """
+    r"""
     Convert the input to an array.
 
     Parameters

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -598,7 +598,7 @@ def floor(x: array, /) -> array:
     """
 
 def floor_divide(x1: array, x2: array, /) -> array:
-    """
+    r"""
     Rounds the result of dividing each element ``x1_i`` of the input array ``x1`` by the respective element ``x2_i`` of the input array ``x2`` to the greatest (i.e., closest to `+infinity`) integer-value number that is not greater than the division result.
 
     .. note::

--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -459,7 +459,7 @@ def vecdot(x1: array, x2: array, /, *, axis: int = None) -> array:
     """
 
 def vector_norm(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False, ord: Union[int, float, Literal[inf, -inf]] = 2) -> array:
-    """
+    r"""
     Computes the vector norm of a vector (or batch of vectors) ``x``.
 
     Parameters


### PR DESCRIPTION
Hello, my first pull-request here. 😃
When running array-api-tests against CuPy, I experienced the following error:

```py
+ ARRAY_API_TESTS_MODULE=cupy.array_api
+ pytest
ImportError while loading conftest '/tmp/tmp.IchRO6sbmt/array-api-tests/conftest.py'.
conftest.py:7: in <module>
    from array_api_tests import _array_module as xp
array_api_tests/__init__.py:6: in <module>
    from ._array_module import mod as _xp
array_api_tests/_array_module.py:4: in <module>
    from . import stubs
array_api_tests/stubs.py:30: in <module>
    name_to_mod[name] = import_module(f"signatures.{name}")
E     File "/tmp/tmp.IchRO6sbmt/array-api-tests/array-api/spec/API_specification/signatures/elementwise_functions.py", line 601
E       """
E       ^
E   SyntaxError: invalid escape sequence \s
```

This was because there are unescaped uses of `\` in several docstrings of array-api code, and CuPy runs tests with `error::DeprecationWarning` warning filter which strictly checks the invalid escape sequences.

This PR fixes the issue by using raw string for such docstrings, in the same way as done in `cholesky`:
https://github.com/data-apis/array-api/blob/6a35bc11d16403ad25d6bf9f0d3ebf87fe25c24b/spec/API_specification/array_api/linalg.py#L4-L5

I confirmed there are no invalid escape sequences anymore:

```sh
find . -name "*.pyc" -delete
python -W error::DeprecationWarning -m compileall spec
```

Thanks.