### PR TITLE
Add complex number support to `sin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules/
 __pycache__/
 *.pyc
 spec/**/generated
+tmp/

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1235,7 +1235,7 @@ def sin(x: array, /) -> array:
        For complex arguments, the mathematical definition of sine is
 
        .. math::
-          \begin{align} \operatorname{sin}(x) &= \frac{e^{jx} - e^{-jx}}{2j} \\ &= \frac{\operatorname{sinh}(jx)}{1j} \\ &= \frac{\operatorname{sinh}(jx)}{1j} \cdot \frac{1j}{1j} \\ &= (-1j) \cdot \operatorname{sinh}(jx) \end{align}
+          \begin{align} \operatorname{sin}(x) &= \frac{e^{jx} - e^{-jx}}{2j} \\ &= \frac{\operatorname{sinh}(jx)}{j} \\ &= \frac{\operatorname{sinh}(jx)}{j} \cdot \frac{j}{j} \\ &= -j \cdot \operatorname{sinh}(jx) \end{align}
 
        where :math:`\operatorname{sinh}` is the hyperbolic sine.
 

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1212,27 +1212,42 @@ def sign(x: array, /) -> array:
     """
 
 def sin(x: array, /) -> array:
-    """
-    Calculates an implementation-dependent approximation to the sine, having domain ``(-infinity, +infinity)`` and codomain ``[-1, +1]``, for each element ``x_i`` of the input array ``x``. Each element ``x_i`` is assumed to be expressed in radians.
+    r"""
+    Calculates an implementation-dependent approximation to the sine for each element ``x_i`` of the input array ``x``.
+
+    Each element ``x_i`` is assumed to be expressed in radians.
 
     **Special cases**
 
-    For floating-point operands,
+    For real-valued floating-point operands,
 
     - If ``x_i`` is ``NaN``, the result is ``NaN``.
     - If ``x_i`` is ``+0``, the result is ``+0``.
     - If ``x_i`` is ``-0``, the result is ``-0``.
     - If ``x_i`` is either ``+infinity`` or ``-infinity``, the result is ``NaN``.
 
+    For complex floating-point operands, special cases must be handled as if the operation is implemented as ``-1j * sinh(x*1j)``.
+
+    .. note::
+       The sine is an entire function on the complex plane and has no branch cuts.
+
+    .. note::
+       For complex arguments, the mathematical definition of sine is
+
+       .. math::
+          \begin{align} \operatorname{sin}(x) &= \frac{e^{jx} - e^{-jx}}{2j} \\ &= \frac{\operatorname{sinh}(jx)}{1j} \\ &= \frac{\operatorname{sinh}(jx)}{1j} \cdot \frac{1j}{1j} \\ &= (-1j) \cdot \operatorname{sinh}(jx) \end{align}
+
+       where :math:`\operatorname{sinh}` is the hyperbolic sine.
+
     Parameters
     ----------
     x: array
-        input array whose elements are each expressed in radians. Should have a real-valued floating-point data type.
+        input array whose elements are each expressed in radians. Should have a floating-point data type.
 
     Returns
     -------
     out: array
-        an array containing the sine of each element in ``x``. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`.
+        an array containing the sine of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
 def sinh(x: array, /) -> array:


### PR DESCRIPTION
This PR

-   adds complex number support to `sin` by documenting special cases. The sine is an entire function in the complex plane. Thus, the function has no branch cuts.
-   updates the input and output array data types to be any floating-point data type, not just real-valued floating-point data types.
-   derives special cases from [C99](https://en.cppreference.com/w/c/numeric/complex/csin).