### PR TITLE
Include `__array_api_version__` in API specification section

### DIFF
--- a/spec/API_specification/array_api/__init__.py
+++ b/spec/API_specification/array_api/__init__.py
@@ -12,3 +12,9 @@ from .sorting_functions import *
 from .statistical_functions import *
 from .utility_functions import *
 from . import linalg
+
+
+__array_api_version__: str = "2021.12"
+"""
+String representing the version of the array API specification which the conforming implementation adheres to.
+"""

--- a/spec/API_specification/array_api/__init__.py
+++ b/spec/API_specification/array_api/__init__.py
@@ -14,7 +14,7 @@ from .utility_functions import *
 from . import linalg
 
 
-__array_api_version__: str = "2021.12"
+__array_api_version__: str = "YYYY.MM"
 """
 String representing the version of the array API specification which the conforming implementation adheres to.
 """

--- a/spec/API_specification/index.rst
+++ b/spec/API_specification/index.rst
@@ -24,3 +24,4 @@ API specification
    statistical_functions
    type_promotion
    utility_functions
+   version

--- a/spec/API_specification/version.rst
+++ b/spec/API_specification/version.rst
@@ -17,5 +17,6 @@ Objects in API
 .. autosummary::
    :toctree: generated
    :template: attribute.rst
+   :nosignatures:
 
    __array_api_version__

--- a/spec/API_specification/version.rst
+++ b/spec/API_specification/version.rst
@@ -1,0 +1,21 @@
+Version
+=======
+
+    Array API specification for versioning.
+
+A conforming implementation of the array API standard must provide a `__array_api_version__` attribute - see :ref:`api-versioning` for details.
+
+
+Objects in API
+--------------
+
+.. currentmodule:: array_api
+
+..
+  NOTE: please keep the functions in alphabetical order
+
+.. autosummary::
+   :toctree: generated
+   :template: attribute.rst
+
+   __array_api_version__


### PR DESCRIPTION
`xp.__array_api_version__` has been specified in our [Versioning](https://data-apis.org/array-api/latest/future_API_evolution.html#versioning) section for a while now (~2yrs), but no such mention of it is found in the API specification section, which is probably why this wasn't implemented in numpy/numpy/pull/18585 and all subsequent adoption efforts across the ecosystem (happy to submit respective PRs after we get this in).

So this PR simply creates a `spec/API_specification/version.rst` file which includes a documented `__array_api_version__` attribute, which also will show up in our [`array-api/latest/API_specification/`](https://data-apis.org/array-api/latest/API_specification/index.html) page (as well as the sidebar).