### PR TITLE
Complex dtype support in `finfo()`

### DIFF
--- a/spec/API_specification/array_api/data_type_functions.py
+++ b/spec/API_specification/array_api/data_type_functions.py
@@ -63,23 +63,23 @@ def finfo(type: Union[dtype, array], /) -> finfo_object:
 
         - **bits**: *int*
 
-          number of bits occupied by the floating-point data type.
+          number of bits occupied by the real-valued floating-point data type.
 
         - **eps**: *float*
 
-          difference between 1.0 and the next smallest representable floating-point number larger than 1.0 according to the IEEE-754 standard.
+          difference between 1.0 and the next smallest representable real-valued floating-point number larger than 1.0 according to the IEEE-754 standard.
 
         - **max**: *float*
 
-          largest representable number.
+          largest representable real-valued number.
 
         - **min**: *float*
 
-          smallest representable number.
+          smallest representable real-valued number.
 
         - **smallest_normal**: *float*
 
-          smallest positive floating-point number with full precision.
+          smallest positive real-valued floating-point number with full precision.
     """
 
 def iinfo(type: Union[dtype, array], /) -> iinfo_object:

--- a/spec/API_specification/array_api/data_type_functions.py
+++ b/spec/API_specification/array_api/data_type_functions.py
@@ -46,12 +46,15 @@ def can_cast(from_: Union[dtype, array], to: dtype, /) -> bool:
 
 def finfo(type: Union[dtype, array], /) -> finfo_object:
     """
-    Machine limits for real-valued floating-point data types.
+    Machine limits for floating-point data types.
 
     Parameters
     ----------
     type: Union[dtype, array]
-        the kind of real-valued floating-point data-type about which to get information.
+        the kind of floating-point data-type about which to get information. If complex, the information is about its component data type.
+
+        .. note::
+           Complex floating-point data types are specified to always use the same precision for both its real and imaginary components, so the information should be true for either component.
 
     Returns
     -------


### PR DESCRIPTION
Per discussion in #433 and yesterdays meeting, this PR makes `finfo()` support complex dtypes by returning information of its real-valued component dtype, e.g.

```python
>>> xp.finfo(xp.complex64)
finfo_object(
    bits=32,
    eps=1.1920928955078125e-07,
    max=3.4028234663852886e+38,
    min=-3.4028234663852886e+38,
    smallest_normal=1.1754943508222875e-38
)
>>> xp.finfo(xp.float32)
... # should contain the same information as above
```

(see #485 RE `.dtype`)