### PR TITLE
`iinfo()` and `finfo()` result holds `dtype` attribute

### DIFF
--- a/spec/API_specification/array_api/data_type_functions.py
+++ b/spec/API_specification/array_api/data_type_functions.py
@@ -80,6 +80,10 @@ def finfo(type: Union[dtype, array], /) -> finfo_object:
         - **smallest_normal**: *float*
 
           smallest positive real-valued floating-point number with full precision.
+
+        - **dtype**: dtype
+
+          real-valued floating-point data type.
     """
 
 def iinfo(type: Union[dtype, array], /) -> iinfo_object:

--- a/spec/API_specification/array_api/data_type_functions.py
+++ b/spec/API_specification/array_api/data_type_functions.py
@@ -111,6 +111,10 @@ def iinfo(type: Union[dtype, array], /) -> iinfo_object:
         - **min**: *int*
 
           smallest representable number.
+
+        - **dtype**: dtype
+
+          integer data type.
     """
 
 def result_type(*arrays_and_dtypes: Union[array, dtype]) -> dtype:


### PR DESCRIPTION
In yesterdays meeting @oleksandr-pavlyk bought up that NumPy's `iinfo()`/`finfo()` returns info objects with a `dtype` attribute. ~There seemed to be no objections, but it turns out `dtype` wasn't actually document for NumPy...~ Resolved in https://github.com/numpy/numpy/pull/22334

~I've left this PR separate from #484 to keep things atomic, incase things become finicky. It depends on that PR because of the subtle distinction I made in `finfo()` to clarify attributes relate to real-valued floats... just want that to resolve (i.e. be merged) first.~ That was merged, so happy with this PR on my end!