### PR TITLE
Align casting methods with Python behaviour

### DIFF
--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -227,7 +227,7 @@ class _array():
         Converts a zero-dimensional array to a Python ``bool`` object.
 
         .. note::
-           When casting a real-valued input array to ``bool``, a value equal to ``0`` must cast to ``False``, and a value not equal to ``0`` must cast to ``True``.
+           When casting a numeric input array to ``bool``, a value equal to ``0`` must cast to ``False``, and a value not equal to ``0`` must cast to ``True``.
 
         Parameters
         ----------

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -234,7 +234,7 @@ class _array():
         - If ``self`` is either ``+infinity`` or ``-infinity``, the result is ``True``.
         - If ``self`` is either ``+0`` or ``-0``, the result is ``False``.
 
-        For complex floating-point operands, special cases must be handled as if the operation is implemented as ``bool(real(self)) and bool(imag(self))``.
+        For complex floating-point operands, special cases must be handled as if the operation is implemented as ``bool(real(self))`` and ``bool(imag(self))``.
 
         Parameters
         ----------

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -245,7 +245,7 @@ class _array():
         Converts a zero-dimensional array to a Python ``complex`` object.
 
         .. note::
-           When casting a boolean input array, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
+           When casting a boolean input array, a value of ``True`` must cast to ``1+0j``, and a value of ``False`` must cast to ``0+0j``.
 
         Parameters
         ----------

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -257,6 +257,13 @@ class _array():
 
         - If ``self`` is ``True``, the result is ``1+0j``.
         - If ``self`` is ``False``, the result is ``0+0j``.
+        
+        For real-valued floating-point operands,
+        
+        - If ``self`` is ``NaN``, the result is ``NaN + NaN j``.
+        - If ``self`` is ``+infinity``, the result is ``+infinity + 0j``.
+        - If ``self`` is ``-infinity``, the result is ``-infinity + 0j``.
+        - If ``self`` is a finite number, the result is ``self + 0j``.
 
         Parameters
         ----------
@@ -266,7 +273,7 @@ class _array():
         Returns
         -------
         out: complex
-            a Python ``complex`` object representing the single element of the array instance. If ``self`` has a real-valued or boolean data type, the real component of the return value must equal the element of ``self`` and the imaginary component must be ``0``.
+            a Python ``complex`` object representing the single element of the array instance.
         """
 
     def __dlpack__(self: array, /, *, stream: Optional[Union[int, Any]] = None) -> PyCapsule:

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -234,7 +234,7 @@ class _array():
         - If ``self`` is either ``+infinity`` or ``-infinity``, the result is ``True``.
         - If ``self`` is either ``+0`` or ``-0``, the result is ``False``.
 
-        For complex floating-point operands, special cases must be handled as if the operation is implemented as ``bool(real(self))`` and ``bool(imag(self))``.
+        For complex floating-point operands, special cases must be handled as if the operation is implemented as the logical AND of ``bool(real(self))`` and ``bool(imag(self))``.
 
         Parameters
         ----------

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -229,7 +229,7 @@ class _array():
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Must have a boolean data type.
+            zero-dimensional array instance. Should have a boolean data type.
 
         Returns
         -------
@@ -244,7 +244,7 @@ class _array():
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Must have a complex data type.
+            zero-dimensional array instance. Should have a complex data type.
 
         Returns
         -------
@@ -361,7 +361,7 @@ class _array():
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Must have a real-valued floating-point data type.
+            zero-dimensional array instance. Should have a real-valued floating-point data type.
 
         Returns
         -------
@@ -498,7 +498,7 @@ class _array():
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Must have an integer data type.
+            zero-dimensional array instance. Should have an integer data type.
 
         Returns
         -------
@@ -513,7 +513,7 @@ class _array():
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Must have an integer data type.
+            zero-dimensional array instance. Should have an integer data type.
 
         Returns
         -------

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -224,12 +224,15 @@ class _array():
 
     def __bool__(self: array, /) -> bool:
         """
-        Converts a zero-dimensional boolean array to a Python ``bool`` object.
+        Converts a zero-dimensional array to a Python ``bool`` object.
+
+        .. note::
+           When casting a real-valued input array to ``bool``, a value of ``0`` must cast to ``False``, and a non-zero value must cast to ``True``.
 
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Should have a boolean data type.
+            zero-dimensional array instance.
 
         Returns
         -------
@@ -237,19 +240,22 @@ class _array():
             a Python ``bool`` object representing the single element of the array.
         """
 
-    def __complex__(self: array, /) -> bool:
+    def __complex__(self: array, /) -> complex:
         """
-        Converts a zero-dimensional complex array to a Python ``complex`` object.
+        Converts a zero-dimensional array to a Python ``complex`` object.
+
+        .. note::
+           When casting a boolean input array, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
 
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Should have a complex data type.
+            zero-dimensional array instance.
 
         Returns
         -------
         out: complex
-            a Python ``complex`` object representing the single element of the array.
+            a Python ``complex`` object representing the single element of the array. If ``self`` has a real-valued or boolean data type, ``out`` must represent the element of ``self`` in the real component.
         """
 
     def __dlpack__(self: array, /, *, stream: Optional[Union[int, Any]] = None) -> PyCapsule:
@@ -356,12 +362,18 @@ class _array():
 
     def __float__(self: array, /) -> float:
         """
-        Converts a zero-dimensional floating-point array to a Python ``float`` object.
+        Converts a zero-dimensional array to a Python ``float`` object.
+
+        .. note::
+           Casting integer values outside the representable bounds of Python's float type is not specified and is implementation-dependent.
+
+        .. note::
+           When casting a boolean input array, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
 
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Should have a real-valued floating-point data type.
+            zero-dimensional array instance. Should have a real-valued or boolean data type. If ``self`` has a complex data type, the function must raise a ``TypeError``.
 
         Returns
         -------
@@ -488,9 +500,9 @@ class _array():
            Element-wise results must equal the results returned by the equivalent element-wise function :func:`~array_api.greater`.
         """
 
-    def __index__(self: array, /) -> int:
+    def __index__(self: array, /) -> Union[int, bool]:
         """
-        Converts a zero-dimensional integer array to a Python ``int`` object.
+        Converts a zero-dimensional array to a Python object used in indexing.
 
         .. note::
            This method is called to implement `operator.index() <https://docs.python.org/3/reference/datamodel.html#object.__index__>`_. See also `PEP 357 <https://www.python.org/dev/peps/pep-0357/>`_.
@@ -498,27 +510,47 @@ class _array():
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Should have an integer data type.
+            zero-dimensional array instance. Should have an integer or boolean data type. If ``self`` has a floating-point or complex data type, the function must raise a ``TypeError``.
 
         Returns
         -------
-        out: int
-            a Python ``int`` object representing the single element of the array instance.
+        out: Union[int, bool]
+            a Python object representing the single element of the array instance. If ``self`` has an integer data type, ``out`` must be a Python ``int`` object. If ``self`` has a boolean data type, ``out`` must be a Python ``bool`` object.
         """
 
     def __int__(self: array, /) -> int:
         """
-        Converts a zero-dimensional integer array to a Python ``int`` object.
+        Converts a zero-dimensional array to a Python ``int`` object.
+
+        .. note::
+           Casting floating-point values outside the representable bounds of Python's non-arbitary integer type is not specified and is implementation-dependent.
+
+        .. note::
+           When casting a boolean input array, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
+
+        **Special cases**
+
+        For floating-point operands,
+
+        - If ``self`` is a finite number, the result is the integer part of ``self``.
 
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Should have an integer data type.
+            zero-dimensional array instance. Should have a real-valued or boolean data type. If ``self`` has a complex data type, the function must raise a ``TypeError``.
 
         Returns
         -------
         out: int
             a Python ``int`` object representing the single element of the array instance.
+
+
+        **Raises**
+
+        For floating-point operands,
+
+        - If ``self`` is either ``+infinity`` or ``-infinity``, raise ``OverflowError``.
+        - If ``self`` is ``NaN``, raise ``ValueError``.
         """
 
     def __invert__(self: array, /) -> array:

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -227,7 +227,7 @@ class _array():
         Converts a zero-dimensional array to a Python ``bool`` object.
 
         .. note::
-           When casting a numeric input array to ``bool``, a value equal to ``0`` must cast to ``False``, and a value not equal to ``0`` must cast to ``True``.
+           If ``self`` has a numeric data type, a value equal to ``0`` must cast to ``False``, and a value not equal to ``0`` must cast to ``True``.
 
         Parameters
         ----------
@@ -245,7 +245,7 @@ class _array():
         Converts a zero-dimensional array to a Python ``complex`` object.
 
         .. note::
-           When casting a boolean input array, a value of ``True`` must cast to ``1+0j``, and a value of ``False`` must cast to ``0+0j``.
+           If ``self`` has a boolean data type, a value of ``True`` must cast to ``1+0j``, and a value of ``False`` must cast to ``0+0j``.
 
         Parameters
         ----------
@@ -255,7 +255,7 @@ class _array():
         Returns
         -------
         out: complex
-            a Python ``complex`` object representing the single element of the array. If ``self`` has a real-valued or boolean data type, ``out`` must represent the element of ``self`` in the real component.
+            a Python ``complex`` object representing the single element of the array instance. If ``self`` has a real-valued or boolean data type, the real component of the return value must equal the element of ``self`` and the imaginary component must be ``0``.
         """
 
     def __dlpack__(self: array, /, *, stream: Optional[Union[int, Any]] = None) -> PyCapsule:
@@ -368,12 +368,12 @@ class _array():
            Casting integer values outside the representable bounds of Python's float type is not specified and is implementation-dependent.
 
         .. note::
-           When casting a boolean input array, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
+           If ``self`` has a boolean data type, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
 
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Should have a real-valued or boolean data type. If ``self`` has a complex data type, the function must raise a ``TypeError``.
+            zero-dimensional array instance. Should have a real-valued or boolean data type. If ``self`` has a complex floating-point data type, the function must raise a ``TypeError``.
 
         Returns
         -------
@@ -510,7 +510,7 @@ class _array():
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Should have an integer data type. If ``self`` has a floating-point or complex data type, the function must raise a ``TypeError``.
+            zero-dimensional array instance. Should have an integer data type. If ``self`` has a floating-point data type, the function must raise a ``TypeError``.
 
         Returns
         -------
@@ -523,7 +523,7 @@ class _array():
         Converts a zero-dimensional array to a Python ``int`` object.
 
         .. note::
-           When casting a boolean input array, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
+           If ``self`` has a boolean data type, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
 
         **Special cases**
 
@@ -534,7 +534,7 @@ class _array():
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Should have a real-valued or boolean data type. If ``self`` has a complex data type, the function must raise a ``TypeError``.
+            zero-dimensional array instance. Should have a real-valued or boolean data type. If ``self`` has a complex floating-point data type, the function must raise a ``TypeError``.
 
         Returns
         -------

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -226,8 +226,15 @@ class _array():
         """
         Converts a zero-dimensional array to a Python ``bool`` object.
 
-        .. note::
-           If ``self`` has a numeric data type, a value equal to ``0`` must cast to ``False``, and a value not equal to ``0`` must cast to ``True``.
+        **Special cases**
+
+        For real-valued floating-point operands,
+
+        - If ``self`` is ``NaN``, the result is ``True``.
+        - If ``self`` is either ``+infinity`` or ``-infinity``, the result is ``True``.
+        - If ``self`` is either ``+0`` or ``-0``, the result is ``False``.
+
+        For complex floating-point operands, special cases must be handled as if the operation is implemented as ``bool(real(self)) and bool(imag(self))``.
 
         Parameters
         ----------

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -500,9 +500,9 @@ class _array():
            Element-wise results must equal the results returned by the equivalent element-wise function :func:`~array_api.greater`.
         """
 
-    def __index__(self: array, /) -> Union[int, bool]:
+    def __index__(self: array, /) -> int:
         """
-        Converts a zero-dimensional array to a Python object used in indexing.
+        Converts a zero-dimensional integer array to a Python ``int`` object.
 
         .. note::
            This method is called to implement `operator.index() <https://docs.python.org/3/reference/datamodel.html#object.__index__>`_. See also `PEP 357 <https://www.python.org/dev/peps/pep-0357/>`_.
@@ -510,12 +510,12 @@ class _array():
         Parameters
         ----------
         self: array
-            zero-dimensional array instance. Should have an integer or boolean data type. If ``self`` has a floating-point or complex data type, the function must raise a ``TypeError``.
+            zero-dimensional array instance. Should have an integer data type. If ``self`` has a floating-point or complex data type, the function must raise a ``TypeError``.
 
         Returns
         -------
-        out: Union[int, bool]
-            a Python object representing the single element of the array instance. If ``self`` has an integer data type, ``out`` must be a Python ``int`` object. If ``self`` has a boolean data type, ``out`` must be a Python ``bool`` object.
+        out: int
+            a Python ``int`` object representing the single element of the array instance.
         """
 
     def __int__(self: array, /) -> int:

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -530,6 +530,7 @@ class _array():
         For floating-point operands,
 
         - If ``self`` is a finite number, the result is the integer part of ``self``.
+        - If ``self`` is ``-0``, the result is ``0``.
 
         Parameters
         ----------

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -523,9 +523,6 @@ class _array():
         Converts a zero-dimensional array to a Python ``int`` object.
 
         .. note::
-           Casting floating-point values outside the representable bounds of Python's non-arbitary integer type is not specified and is implementation-dependent.
-
-        .. note::
            When casting a boolean input array, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
 
         **Special cases**

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -237,6 +237,21 @@ class _array():
             a Python ``bool`` object representing the single element of the array.
         """
 
+    def __complex__(self: array, /) -> bool:
+        """
+        Converts a zero-dimensional complex array to a Python ``complex`` object.
+
+        Parameters
+        ----------
+        self: array
+            zero-dimensional array instance. Must have a complex data type.
+
+        Returns
+        -------
+        out: complex
+            a Python ``complex`` object representing the single element of the array.
+        """
+
     def __dlpack__(self: array, /, *, stream: Optional[Union[int, Any]] = None) -> PyCapsule:
         """
         Exports the array for consumption by :func:`~array_api.from_dlpack` as a DLPack capsule.

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -227,7 +227,7 @@ class _array():
         Converts a zero-dimensional array to a Python ``bool`` object.
 
         .. note::
-           When casting a real-valued input array to ``bool``, a value of ``0`` must cast to ``False``, and a non-zero value must cast to ``True``.
+           When casting a real-valued input array to ``bool``, a value equal to ``0`` must cast to ``False``, and a value not equal to ``0`` must cast to ``True``.
 
         Parameters
         ----------

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -251,8 +251,12 @@ class _array():
         """
         Converts a zero-dimensional array to a Python ``complex`` object.
 
-        .. note::
-           If ``self`` has a boolean data type, a value of ``True`` must cast to ``1+0j``, and a value of ``False`` must cast to ``0+0j``.
+        **Special cases**
+
+        For boolean operands,
+
+        - If ``self`` is ``True``, the result is ``1+0j``.
+        - If ``self`` is ``False``, the result is ``0+0j``.
 
         Parameters
         ----------
@@ -374,8 +378,12 @@ class _array():
         .. note::
            Casting integer values outside the representable bounds of Python's float type is not specified and is implementation-dependent.
 
-        .. note::
-           If ``self`` has a boolean data type, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
+        **Special cases**
+
+        For boolean operands,
+
+        - If ``self`` is ``True``, the result is ``1``.
+        - If ``self`` is ``False``, the result is ``0``.
 
         Parameters
         ----------
@@ -529,10 +537,12 @@ class _array():
         """
         Converts a zero-dimensional array to a Python ``int`` object.
 
-        .. note::
-           If ``self`` has a boolean data type, a value of ``True`` must cast to ``1``, and a value of ``False`` must cast to ``0``.
-
         **Special cases**
+
+        For boolean operands,
+
+        - If ``self`` is ``True``, the result is ``1``.
+        - If ``self`` is ``False``, the result is ``0``.
 
         For floating-point operands,
 

--- a/spec/API_specification/array_object.rst
+++ b/spec/API_specification/array_object.rst
@@ -283,6 +283,7 @@ Methods
    array.__and__
    array.__array_namespace__
    array.__bool__
+   array.__complex__
    array.__dlpack__
    array.__dlpack_device__
    array.__eq__


### PR DESCRIPTION
Resolves #486 (adding `x.__complex__()`).

Per interest in having the builtin casting methods ([`__bool__`](https://data-apis.org/array-api/draft/API_specification/generated/array_api.array.__bool__.html)/[`__int__`](https://data-apis.org/array-api/draft/API_specification/generated/array_api.array.__int__.html)/[`__float__`](https://data-apis.org/array-api/draft/API_specification/generated/array_api.array.__float__.html)/`__complex__`/[`__index__`](https://data-apis.org/array-api/latest/API_specification/generated/signatures.array_object.array.__index__.html?highlight=index)) support arrays of a different dtype kind, this PR also changes the language to clarify that adopters can support such casting.  EDIT: now aligning casting methods with Python behaviour generally

~~(I opted against requiring cross-kind casting in this PR—see https://github.com/data-apis/array-api/issues/486#issuecomment-1282158449)~~ See https://github.com/data-apis/array-api/issues/486#issuecomment-1298482573