### PR TITLE
API: Specify that DLPack should use BufferError

### DIFF
--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -295,9 +295,9 @@ class _array():
         ------
         BufferError
             Implementations should raise ``BufferError`` when the data cannot
-            cannot be exported as DLPack (e.g. incompatible dtype or strides).
-            Other errors are raised when export fails for other reasons
-            (e.g. incorrect arguments passed or out of memory).
+            be exported as DLPack (e.g., incompatible dtype or strides). Other
+            errors are raised when export fails for other reasons (e.g., incorrect
+            arguments passed or out of memory).
 
         """
 

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -290,6 +290,15 @@ class _array():
         -------
         capsule: PyCapsule
             a DLPack capsule for the array. See :ref:`data-interchange` for details.
+
+        Raises
+        ------
+        BufferError
+            Implementations should raise ``BufferError`` when the data cannot
+            cannot be exported as DLPack (e.g. incompatible dtype or strides).
+            Other errors are raised when export fails for other reasons
+            (e.g. incorrect arguments passed or out of memory).
+
         """
 
     def __dlpack_device__(self: array, /) -> Tuple[Enum, int]:


### PR DESCRIPTION
I would actually like MUST, but since most implementations currently don't actually give a ``BufferError``, writing it as SHOULD instead.

First part of closing https://github.com/numpy/numpy/issues/20742