### PR TITLE
Fix mistake in description of return dtype for `matrix_rank`

### DIFF
--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -272,7 +272,7 @@ def matrix_rank(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> a
     Returns
     -------
     out: array
-        an array containing the ranks. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion` and must have shape ``(...)`` (i.e., must have a shape equal to ``shape(x)[:-2]``).
+        an array containing the ranks. The returned array must have the default integer data type and must have shape ``(...)`` (i.e., must have a shape equal to ``shape(x)[:-2]``).
     """
 
 def matrix_transpose(x: array, /) -> array:


### PR DESCRIPTION
This was a simple mistake, not discussed in the review for the PR that added `matrix_rank` (gh-128).

Closes gh-469