### PR TITLE
Fix description for `trunc`

### DIFF
--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1600,7 +1600,7 @@ def tanh(x: array, /) -> array:
 
 def trunc(x: array, /) -> array:
     """
-    Rounds each element ``x_i`` of the input array ``x`` to the integer-valued number that is closest to but no greater than ``x_i``.
+    Rounds each element ``x_i`` of the input array ``x`` to the nearest integer-valued number that is closer to zero than ``x_i``.
 
     **Special cases**
 


### PR DESCRIPTION
This PR

- fixes the description for `trunc`. Currently, the description is incorrect for negative numbers (e.g., according to the description, `-1.5` should round to `-2.0` rather than `-1.0`).
- this was an oversight during review of [gh-12](https://github.com/data-apis/array-api/pull/12/files#diff-c63388022ee724b37174b4191598444df80aacb366d1f63677da4d14784df654R602).