### PR TITLE
Add complex number support to `vecdot`

### DIFF
--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -87,7 +87,7 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     """
     Computes the (vector) dot product of two arrays.
     
-    Let ``x1`` equal :math:`a` and ``x2`` equal :math:`b`. The dot product is defined as
+    Let :math:`\mathbf{a}` be a vector in ``x1`` and :math:`\mathbf{b}` be a corresponding vector in ``x2``. The dot product is defined as
     
     .. math::
        \mathbf{a} \cdot \mathbf{b} = \sum_{i=0}^{n-1} a_i\overline{b_i}

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -90,9 +90,9 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     The dot product is defined as
     
     .. math::
-       \textbf{x1} \cdot \textbf{x2} = \sum_{i=1}^{n} = x1_i\overline{x2_i}
+       \textbf{x1} \cdot \textbf{x2} = \sum_{i=0}^{n-1} = x1_i\overline{x2_i}
        
-    over the dimension specified by ``axis`` and where :math:`\overline{x2_i}` denotes the complex conjugate if ``x2`` is complex and the identity if ``x2`` is real-valued.
+    over the dimension specified by ``axis`` and where :math:`n` is the dimension size and :math:`\overline{x2_i}` denotes the complex conjugate if ``x2`` is complex and the identity if ``x2`` is real-valued.
 
     Parameters
     ----------

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -90,7 +90,7 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     The dot product is defined as
     
     .. math::
-       \sum_{i=1}^{n} = x1_i\overline{x2_i}
+       \textbf{x1} \cdot \textbf{x2} = \sum_{i=1}^{n} = x1_i\overline{x2_i}
        
     over the dimension specified by ``axis`` and where :math:`\overline{x2_i}` denotes the complex conjugate if ``x2`` is complex and the identity if ``x2`` is real-valued.
 

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -112,6 +112,7 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     out: array
         if ``x1`` and ``x2`` are both one-dimensional arrays, a zero-dimensional containing the dot product; otherwise, a non-zero-dimensional array containing the dot products and having rank ``N-1``, where ``N`` is the rank (number of dimensions) of the shape determined according to :ref:`broadcasting` along the non-contracted axes. The returned array must have a data type determined by :ref:`type-promotion`.
 
+
     **Raises**
 
     -   if provided an invalid ``axis``.

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -90,9 +90,9 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     Parameters
     ----------
     x1: array
-        first input array. Should have a real-valued data type.
+        first input array. Should have a floating-point data type.
     x2: array
-        second input array. Must be compatible with ``x1`` for all non-contracted axes (see :ref:`broadcasting`). The size of the axis over which to compute the dot product must be the same size as the respective axis in ``x1``. Should have a real-valued data type.
+        second input array. Must be compatible with ``x1`` for all non-contracted axes (see :ref:`broadcasting`). The size of the axis over which to compute the dot product must be the same size as the respective axis in ``x1``. Should have a floating-point data type.
 
         .. note::
            The contracted axis (dimension) must not be broadcasted.
@@ -104,6 +104,8 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     -------
     out: array
         if ``x1`` and ``x2`` are both one-dimensional arrays, a zero-dimensional containing the dot product; otherwise, a non-zero-dimensional array containing the dot products and having rank ``N-1``, where ``N`` is the rank (number of dimensions) of the shape determined according to :ref:`broadcasting` along the non-contracted axes. The returned array must have a data type determined by :ref:`type-promotion`.
+
+        For complex-valued input arrays, this function computes :math:`x_1^H \cdot x_2`.
 
 
     **Raises**

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -90,7 +90,7 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     Let ``x1`` equal :math:`a` and ``x2`` equal :math:`b`. The dot product is defined as
     
     .. math::
-       \mathbf{a} \cdot \mathbf{b} = \sum_{i=0}^{n-1} = a_i\overline{b_i}
+       \mathbf{a} \cdot \mathbf{b} = \sum_{i=0}^{n-1} a_i\overline{b_i}
        
     over the dimension specified by ``axis`` and where :math:`n` is the dimension size and :math:`\overline{b_i}` denotes the complex conjugate if :math:`b_i` is complex and the identity if :math:`b_i` is real-valued.
 

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -86,6 +86,13 @@ def tensordot(x1: array, x2: array, /, *, axes: Union[int, Tuple[Sequence[int], 
 def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     """
     Computes the (vector) dot product of two arrays.
+    
+    The dot product is defined as
+    
+    .. math::
+       \sum_{i=1}^{n} = \overline{x1_i}x2_i
+       
+    over the dimension specified by ``axis`` and where :math:`\overline{x1_i}` denotes the complex conjugate if ``x1`` is complex and the identity if ``x1`` is real-valued.
 
     Parameters
     ----------

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -87,12 +87,12 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     """
     Computes the (vector) dot product of two arrays.
     
-    The dot product is defined as
+    Let ``x1`` equal :math:`a` and ``x2`` equal :math:`b`. The dot product is defined as
     
     .. math::
-       \textbf{x1} \cdot \textbf{x2} = \sum_{i=0}^{n-1} = x1_i\overline{x2_i}
+       \mathbf{a} \cdot \mathbf{b} = \sum_{i=0}^{n-1} = a_i\overline{b_i}
        
-    over the dimension specified by ``axis`` and where :math:`n` is the dimension size and :math:`\overline{x2_i}` denotes the complex conjugate if ``x2`` is complex and the identity if ``x2`` is real-valued.
+    over the dimension specified by ``axis`` and where :math:`n` is the dimension size and :math:`\overline{b_i}` denotes the complex conjugate if :math:`b_i` is complex and the identity if :math:`b_i` is real-valued.
 
     Parameters
     ----------

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -90,9 +90,9 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     The dot product is defined as
     
     .. math::
-       \sum_{i=1}^{n} = \overline{x1_i}x2_i
+       \sum_{i=1}^{n} = x1_i\overline{x2_i}
        
-    over the dimension specified by ``axis`` and where :math:`\overline{x1_i}` denotes the complex conjugate if ``x1`` is complex and the identity if ``x1`` is real-valued.
+    over the dimension specified by ``axis`` and where :math:`\overline{x2_i}` denotes the complex conjugate if ``x2`` is complex and the identity if ``x2`` is real-valued.
 
     Parameters
     ----------

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -112,9 +112,6 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     out: array
         if ``x1`` and ``x2`` are both one-dimensional arrays, a zero-dimensional containing the dot product; otherwise, a non-zero-dimensional array containing the dot products and having rank ``N-1``, where ``N`` is the rank (number of dimensions) of the shape determined according to :ref:`broadcasting` along the non-contracted axes. The returned array must have a data type determined by :ref:`type-promotion`.
 
-        For complex-valued input arrays, this function computes :math:`x_1^H \cdot x_2`.
-
-
     **Raises**
 
     -   if provided an invalid ``axis``.


### PR DESCRIPTION
Closes gh-356 (where the definition `x1^H x2` was decided).