### PR TITLE
Add design document on complex number ordering

### DIFF
--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -427,6 +427,9 @@ class _array():
         """
         Computes the truth value of ``self_i >= other_i`` for each element of an array instance with the respective element of the array ``other``.
 
+        .. note::
+           Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+
         Parameters
         ----------
         self: array
@@ -464,6 +467,9 @@ class _array():
     def __gt__(self: array, other: Union[int, float, array], /) -> array:
         """
         Computes the truth value of ``self_i > other_i`` for each element of an array instance with the respective element of the array ``other``.
+
+        .. note::
+           Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
         Parameters
         ----------
@@ -538,6 +544,9 @@ class _array():
         """
         Computes the truth value of ``self_i <= other_i`` for each element of an array instance with the respective element of the array ``other``.
 
+        .. note::
+           Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+
         Parameters
         ----------
         self: array
@@ -579,6 +588,9 @@ class _array():
     def __lt__(self: array, other: Union[int, float, array], /) -> array:
         """
         Computes the truth value of ``self_i < other_i`` for each element of an array instance with the respective element of the array ``other``.
+
+        .. note::
+           Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
         Parameters
         ----------

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -428,7 +428,7 @@ class _array():
         Computes the truth value of ``self_i >= other_i`` for each element of an array instance with the respective element of the array ``other``.
 
         .. note::
-           Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+           For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
         Parameters
         ----------
@@ -469,7 +469,7 @@ class _array():
         Computes the truth value of ``self_i > other_i`` for each element of an array instance with the respective element of the array ``other``.
 
         .. note::
-           Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+           For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
         Parameters
         ----------
@@ -545,7 +545,7 @@ class _array():
         Computes the truth value of ``self_i <= other_i`` for each element of an array instance with the respective element of the array ``other``.
 
         .. note::
-           Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+           For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
         Parameters
         ----------
@@ -590,7 +590,7 @@ class _array():
         Computes the truth value of ``self_i < other_i`` for each element of an array instance with the respective element of the array ``other``.
 
         .. note::
-           Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+           For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
         Parameters
         ----------

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -780,7 +780,7 @@ def greater(x1: array, x2: array, /) -> array:
     Computes the truth value of ``x1_i > x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
 
     .. note::
-       Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
     Parameters
     ----------
@@ -800,7 +800,7 @@ def greater_equal(x1: array, x2: array, /) -> array:
     Computes the truth value of ``x1_i >= x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
 
     .. note::
-       Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
     Parameters
     ----------
@@ -880,7 +880,7 @@ def less(x1: array, x2: array, /) -> array:
     Computes the truth value of ``x1_i < x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
 
     .. note::
-       Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
     Parameters
     ----------
@@ -900,7 +900,7 @@ def less_equal(x1: array, x2: array, /) -> array:
     Computes the truth value of ``x1_i <= x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
 
     .. note::
-       Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
     Parameters
     ----------

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -779,6 +779,9 @@ def greater(x1: array, x2: array, /) -> array:
     """
     Computes the truth value of ``x1_i > x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
 
+    .. note::
+       Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+
     Parameters
     ----------
     x1: array
@@ -795,6 +798,9 @@ def greater(x1: array, x2: array, /) -> array:
 def greater_equal(x1: array, x2: array, /) -> array:
     """
     Computes the truth value of ``x1_i >= x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
+
+    .. note::
+       Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
     Parameters
     ----------
@@ -873,6 +879,9 @@ def less(x1: array, x2: array, /) -> array:
     """
     Computes the truth value of ``x1_i < x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
 
+    .. note::
+       Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+
     Parameters
     ----------
     x1: array
@@ -889,6 +898,9 @@ def less(x1: array, x2: array, /) -> array:
 def less_equal(x1: array, x2: array, /) -> array:
     """
     Computes the truth value of ``x1_i <= x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
+
+    .. note::
+       Inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
     Parameters
     ----------

--- a/spec/API_specification/array_api/searching_functions.py
+++ b/spec/API_specification/array_api/searching_functions.py
@@ -2,7 +2,12 @@ from ._types import Optional, Tuple, array
 
 def argmax(x: array, /, *, axis: Optional[int] = None, keepdims: bool = False) -> array:
     """
-    Returns the indices of the maximum values along a specified axis. When the maximum value occurs multiple times, only the indices corresponding to the first occurrence are returned.
+    Returns the indices of the maximum values along a specified axis.
+
+    When the maximum value occurs multiple times, only the indices corresponding to the first occurrence are returned.
+
+    .. note::
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
     Parameters
     ----------
@@ -21,7 +26,12 @@ def argmax(x: array, /, *, axis: Optional[int] = None, keepdims: bool = False) -
 
 def argmin(x: array, /, *, axis: Optional[int] = None, keepdims: bool = False) -> array:
     """
-    Returns the indices of the minimum values along a specified axis. When the minimum value occurs multiple times, only the indices corresponding to the first occurrence are returned.
+    Returns the indices of the minimum values along a specified axis.
+
+    When the minimum value occurs multiple times, only the indices corresponding to the first occurrence are returned.
+
+    .. note::
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
     Parameters
     ----------

--- a/spec/API_specification/array_api/sorting_functions.py
+++ b/spec/API_specification/array_api/sorting_functions.py
@@ -4,10 +4,13 @@ def argsort(x: array, /, *, axis: int = -1, descending: bool = False, stable: bo
     """
     Returns the indices that sort an array ``x`` along a specified axis.
 
+    .. note::
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+
     Parameters
     ----------
     x : array
-        input array.
+        input array. Should have a real-valued data type.
     axis: int
         axis along which to sort. If set to ``-1``, the function must sort along the last axis. Default: ``-1``.
     descending: bool
@@ -25,10 +28,13 @@ def sort(x: array, /, *, axis: int = -1, descending: bool = False, stable: bool 
     """
     Returns a sorted copy of an input array ``x``.
 
+    .. note::
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+
     Parameters
     ----------
     x: array
-        input array.
+        input array. Should have a real-valued data type.
     axis: int
         axis along which to sort. If set to ``-1``, the function must sort along the last axis. Default: ``-1``.
     descending: bool

--- a/spec/API_specification/array_api/statistical_functions.py
+++ b/spec/API_specification/array_api/statistical_functions.py
@@ -7,6 +7,9 @@ def max(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keep
     .. note::
        When the number of elements over which to compute the maximum value is zero, the maximum value is implementation-defined. Specification-compliant libraries may choose to raise an error, return a sentinel value (e.g., if ``x`` is a floating-point input array, return ``NaN``), or return the minimum possible value for the input array ``x`` data type (e.g., if ``x`` is a floating-point array, return ``-infinity``).
 
+    .. note::
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+
     **Special Cases**
 
     For floating-point operands,
@@ -63,6 +66,9 @@ def min(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keep
 
     .. note::
        When the number of elements over which to compute the minimum value is zero, the minimum value is implementation-defined. Specification-compliant libraries may choose to raise an error, return a sentinel value (e.g., if ``x`` is a floating-point input array, return ``NaN``), or return the maximum possible value for the input array ``x`` data type (e.g., if ``x`` is a floating-point array, return ``+infinity``).
+
+    .. note::
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
     **Special Cases**
 

--- a/spec/design_topics/complex_number_ordering.rst
+++ b/spec/design_topics/complex_number_ordering.rst
@@ -5,12 +5,12 @@ Complex Number Ordering
 
 Given a set :math:`\{a_1, \ldots, a_n\}`, an order relation must satisfy the following properties:
 
-1. For any :math:`a` in the set, :math:`a \leq a` (i.e., *reflexive*).
-2. For any :math:`a`, :math:`b`, and :math:`c` in the set, if :math:`a \leq b` and :math:`b \leq c`, then :math:`a \leq c` (i.e., *transitive*).
-3. For any :math:`a` and :math:`b` in the set, if :math:`a \leq b` and :math:`b \leq a`, then :math:`a = b` (i.e., *antisymmetric*).
-4. For any :math:`a` and :math:`b` in the set, either :math:`a \leq b` or :math:`b \leq a` (or both) (i.e., in addition to a *partial order* established by 1-3, satisfies a *total order*).
-5. For all :math:`a`, :math:`b`, and :math:`c` in the set, if :math:`a \leq b`, then :math:`a + c \leq b + c` (i.e., compatible with addition).
-6. For all :math:`a`, :math:`b`, and :math:`c` in the set, if :math:`a \leq b` and :math:`0 \leq c`, then :math:`ac \leq bc` (i.e., compatible with multiplication).
+1. **Reflexive**: for any :math:`a` in the set, :math:`a \leq a`.
+2. **Transitive**: for any :math:`a`, :math:`b`, and :math:`c` in the set, if :math:`a \leq b` and :math:`b \leq c`, then :math:`a \leq c`.
+3. **Antisymmetric**: for any :math:`a` and :math:`b` in the set, if :math:`a \leq b` and :math:`b \leq a`, then :math:`a = b`.
+4. **Total Order**: in addition to the *partial order* established by 1-3, for any :math:`a` and :math:`b` in the set, either :math:`a \leq b` or :math:`b \leq a` (or both).
+5. **Compatible with Addition**: for all :math:`a`, :math:`b`, and :math:`c` in the set, if :math:`a \leq b`, then :math:`a + c \leq b + c`.
+6. **Compatible with Multiplication**: for all :math:`a`, :math:`b`, and :math:`c` in the set, if :math:`a \leq b` and :math:`0 \leq c`, then :math:`ac \leq bc`.
 
 Defining an order relation for complex numbers which satisfies all six properties defined above is not possible. Accordingly, this specification does not require that a conforming implementation of the array API standard adopt any specific complex number order relation.
 

--- a/spec/design_topics/complex_number_ordering.rst
+++ b/spec/design_topics/complex_number_ordering.rst
@@ -1,0 +1,17 @@
+.. _complex-number-ordering:
+
+Complex Number Ordering
+=======================
+
+Given a set :math:`{a_1, \ldots, a_n}`, an order relation must satisfy the following properties:
+
+1. For any :math:`a` in the set, :math:`a \leq a` (i.e., *reflexive*).
+2. For any :math:`a`, :math:`b`, and :math:`c` in the set, if :math:`a \leq b` and :math:`b \leq c`, then :math:`a \leq c` (i.e., *transitive*).
+3. For any :math:`a` and :math:`b` in the set, if :math:`a \leq b` and :math:`b \leq a`, then :math:`a = b` (i.e., *antisymmetric*).
+4. For any :math:`a` and :math:`b` in the set, either :math:`a \leq b` or :math:`b \leq a` (or both) (i.e., in addition to a *partial order* established by 1-3, satisfies a *total order*).
+5. For all :math:`a`, :math:`b`, and :math:`c` in the set, if :math:`a \leq b`, then :math:`a + c \leq b + c` (i.e., compatible with addition).
+6. For all :math:`a`, :math:`b`, and :math:`c` in the set, if :math:`a \leq b` and :math:`0 \leq c`, then :math:`ac \leq bc` (i.e., compatible with multiplication).
+
+Defining an order relation for complex numbers which satisfies all six properties defined above is not possible. Accordingly, this specification does not require that a conforming implementation of the array API standard adopt any specific complex number order relation.
+
+In order to satisfy backward compatibility guarantees, conforming implementations of the array API standard may choose to define an order relation for complex numbers (e.g., lexicographic); however, consumers of the array API standard should **not** assume that complex number ordering is consistent between implementations or even supported.

--- a/spec/design_topics/complex_number_ordering.rst
+++ b/spec/design_topics/complex_number_ordering.rst
@@ -14,4 +14,4 @@ Given a set :math:`\{a_1, \ldots, a_n\}`, an order relation must satisfy the fol
 
 Defining an order relation for complex numbers which satisfies all six properties defined above is not possible. Accordingly, this specification does not require that a conforming implementation of the array API standard adopt any specific complex number order relation.
 
-In order to satisfy backward compatibility guarantees, conforming implementations of the array API standard may choose to define an order relation for complex numbers (e.g., lexicographic); however, consumers of the array API standard should **not** assume that complex number ordering is consistent between implementations or even supported.
+In order to satisfy backward compatibility guarantees, conforming implementations of the array API standard may choose to define an ordering for complex numbers (e.g., lexicographic); however, consumers of the array API standard should **not** assume that complex number ordering is consistent between implementations or even supported.

--- a/spec/design_topics/complex_number_ordering.rst
+++ b/spec/design_topics/complex_number_ordering.rst
@@ -3,7 +3,7 @@
 Complex Number Ordering
 =======================
 
-Given a set :math:`{a_1, \ldots, a_n}`, an order relation must satisfy the following properties:
+Given a set :math:`\{a_1, \ldots, a_n\}`, an order relation must satisfy the following properties:
 
 1. For any :math:`a` in the set, :math:`a \leq a` (i.e., *reflexive*).
 2. For any :math:`a`, :math:`b`, and :math:`c` in the set, if :math:`a \leq b` and :math:`b \leq c`, then :math:`a \leq c` (i.e., *transitive*).

--- a/spec/design_topics/index.rst
+++ b/spec/design_topics/index.rst
@@ -12,5 +12,6 @@ Design topics & constraints
    static_typing
    accuracy
    branch_cuts
+   complex_number_ordering
    C_API
    parallelism


### PR DESCRIPTION
This PR

- adds a design document on complex number ordering. As complex numbers have no natural order, the specification does not require that conforming implementations adopt any particular ordering convention. While ordering APIs are restricted to real-valued data types, conforming implementations are permitted to implement an ordering for reasons of backward compatibility; however, ordering is not guaranteed to be portable across implementations. 
- adds notes to ordering APIs (`less`, `less_equal`, `greater`, `greater_equal`, `argmin`, `argmax`,  `argsort`, `sort`, `min`, `max`) documenting that inequality comparison of complex numbers is unspecified and thus implementation-dependent.
- specifies that `argsort` and `sort` should only accept real-valued data types. The current specification does not restrict the input data types for `argsort` and `sort`, but does restrict `argmin` and `argmax` to real-valued data types. This PR updates `argsort` and `sort` to align with `argmin` and `argmax`, as boolean values have no natural ordering. The divergence was likely an oversight.

## Prior Art

In general, because complex numbers have no natural ordering, ordering APIs supporting complex numbers inevitably lead to unintuitive results, as documented on the NumPy issue tracker. The general gist there is that ordering complex numbers should be deprecated, with only specialized support (with support for customized sort order) for complex number ordering when wanting to sort a complex number array.

- NumPy has an open PR for deprecating complex number ordering: <https://github.com/numpy/numpy/pull/17030>
  - Related issue: <https://github.com/numpy/numpy/issues/15981>
- Confusion arising from NumPy diverging from Python behavior: <https://github.com/numpy/numpy/issues/17361>
- Confusion concerning complex ordering in `np.argmax`: <https://github.com/numpy/numpy/issues/10469>
- Confusion concerning complex ordering in `np.median`: <https://github.com/numpy/numpy/issues/12943>
- Confusion concerning complex ordering in `np.quantile`: <https://github.com/numpy/numpy/issues/22652>
