### PR TITLE
Add complex number support to `not_equal`

### DIFF
--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -731,6 +731,26 @@ class _array():
         """
         Computes the truth value of ``self_i != other_i`` for each element of an array instance with the respective element of the array ``other``.
 
+        **Special Cases**
+
+        Let ``self`` equal ``x1`` and ``other`` equal ``x2``.
+
+        For real-valued floating-point operands,
+
+        - If ``x1_i`` is ``NaN`` or ``x2_i`` is ``NaN``, the result is ``True``.
+        - If ``x1_i`` is ``+infinity`` and ``x2_i`` is ``-infinity``, the result is ``True``.
+        - If ``x1_i`` is ``-infinity`` and ``x2_i`` is ``+infinity``, the result is ``True``.
+        - If ``x1_i`` is a finite number, ``x2_i`` is a finite number, and ``x1_i`` does not equal ``x2_i``, the result is ``True``.
+        - In the remaining cases, the result is ``False``.
+
+        For complex floating-point operands, let ``a = real(x1_i)``, ``b = imag(x1_i)``, ``c = real(x2_i)``, ``d = imag(x2_i)``, and
+
+        - If ``a``, ``b``, ``c``, or ``d`` is ``NaN``, the result is ``True``.
+        - In the remaining cases, the result is the logical OR of the equality comparison between the real values ``a`` and ``c`` (real components) and between the real values ``b`` and ``d`` (imaginary components), as described above for real-valued floating-point operands (i.e., ``a != c OR b != d``).
+
+        .. note::
+           For discussion of complex number equality, see :ref:`complex-numbers`.
+
         Parameters
         ----------
         self: array

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1169,6 +1169,24 @@ def not_equal(x1: array, x2: array, /) -> array:
     """
     Computes the truth value of ``x1_i != x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
 
+    **Special Cases**
+
+    For real-valued floating-point operands,
+
+    - If ``x1_i`` is ``NaN`` or ``x2_i`` is ``NaN``, the result is ``True``.
+    - If ``x1_i`` is ``+infinity`` and ``x2_i`` is ``-infinity``, the result is ``True``.
+    - If ``x1_i`` is ``-infinity`` and ``x2_i`` is ``+infinity``, the result is ``True``.
+    - If ``x1_i`` is a finite number, ``x2_i`` is a finite number, and ``x1_i`` does not equal ``x2_i``, the result is ``True``.
+    - In the remaining cases, the result is ``False``.
+
+    For complex floating-point operands, let ``a = real(x1_i)``, ``b = imag(x1_i)``, ``c = real(x2_i)``, ``d = imag(x2_i)``, and
+
+    - If ``a``, ``b``, ``c``, or ``d`` is ``NaN``, the result is ``True``.
+    - In the remaining cases, the result is the logical OR of the equality comparison between the real values ``a`` and ``c`` (real components) and between the real values ``b`` and ``d`` (imaginary components), as described above for real-valued floating-point operands (i.e., ``a != c OR b != d``).
+
+    .. note::
+       For discussion of complex number equality, see :ref:`complex-numbers`.
+
     Parameters
     ----------
     x1: array


### PR DESCRIPTION
This PR

-   adds complex number support to `not_equal` by documenting special cases. By convention, inequality is determined by independently comparing real and imaginary components respectively and then performing a logical OR (i.e., if `x = a + bj` and `y = c + dj`, then `x != y` iff `a != c OR b != d`.
-   follows precedent in Python, Julia, NumPy, and elsewhere.
-   does not embrace the one-infinity model in which all infinities in the complex plane map to a single infinity (see Riemann sphere), as doing so would lead to unintuitive results when casting real-valued infinities to complex infinities.
-   this PR depends on #528 which includes a design document which this PR references.