### PR TITLE
Add complex number support to `isfinite`

### DIFF
--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -826,17 +826,32 @@ def imag(x: array, /) -> array:
 
 def isfinite(x: array, /) -> array:
     """
-    Tests each element ``x_i`` of the input array ``x`` to determine if finite (i.e., not ``NaN`` and not equal to positive or negative infinity).
+    Tests each element ``x_i`` of the input array ``x`` to determine if finite.
+
+    **Special Cases**
+
+    For real-valued floating-point operands,
+
+    - If ``x_i`` is either ``+infinity`` or ``-infinity``, the result is ``False``.
+    - If ``x_i`` is ``NaN``, the result is ``False``.
+    - If ``x_i`` is a finite number, the result is ``True``.
+
+    For complex floating-point operands, let ``a = real(x_i)``, ``b = imag(x_i)``, and
+
+    - If ``a`` is ``NaN`` or ``b`` is ``NaN``, the result is ``False``.
+    - If ``a`` is either ``+infinity`` or ``-infinity`` and ``b`` is any value, the result is ``False``.
+    - If ``a`` is any value and ``b`` is either ``+infinity`` or ``-infinity``, the result is ``False``.
+    - If ``a`` is a finite number and ``b`` is a finite number, the result is ``True``.
 
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------
     out: array
-        an array containing test results. An element ``out_i`` is ``True`` if ``x_i`` is finite and ``False`` otherwise. The returned array must have a data type of ``bool``.
+        an array containing test results. The returned array must have a data type of ``bool``.
     """
 
 def isinf(x: array, /) -> array:


### PR DESCRIPTION
This PR

-   adds complex number support to `isfinite` by documenting special cases. Namely, if both the real and imaginary component are finite numbers, the result should be `True`; otherwise, if a component is either `+-infinity` or `NaN`, the result should be `False`. This follows Python, Julia, and NumPy.
-   updates the input and output array data types to be any numeric data type, not just real-valued data types.

## Notes

-   In contrast to a value which, according to convention, can be both infinite and NaN (e.g., `inf + NaN j`), a value cannot be both finite and NaN (e.g., `4.0 + NaN j`). In other words, when evaluating whether a value is infinite, we only consider components in isolation, irrespective of whether the other component is NaN; however, for the finite test, both components are considered, such that a `NaN` for either component results in `False`, irrespective of whether the other component is finite. While perhaps not surprising, one should note that we do not have uniform rules for considering whether a complex number is infinite, finite, and/or NaN.

## Reference

```python
>>> z
(4+nanj)
>>> cmath.isfinite(z)
False
```

```python
>>> import numpy as np
>>> z
(4+nanj)
>>> np.isfinite(np.array([z]))
array([ False])
```

```julia
julia> z
4.0 + NaN*im

julia> isfinite(z)
false
```