### PR TITLE
Add complex number support to `isnan`

### DIFF
--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -858,15 +858,27 @@ def isnan(x: array, /) -> array:
     """
     Tests each element ``x_i`` of the input array ``x`` to determine whether the element is ``NaN``.
 
+    **Special Cases**
+
+    For real-valued floating-point operands,
+
+    - If ``x_i`` is ``NaN``, the result is ``True``.
+    - In the remaining cases, the result is ``False``.
+
+    For complex floating-point operands, let ``a = real(x_i)``, ``b = imag(x_i)``, and
+
+    - If ``a`` or ``b`` is ``NaN``, the result is ``True``.
+    - In the remaining cases, the result is ``False``.
+
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------
     out: array
-        an array containing test results. An element ``out_i`` is ``True`` if ``x_i`` is ``NaN`` and ``False`` otherwise. The returned array should have a data type of ``bool``.
+        an array containing test results. The returned array should have a data type of ``bool``.
     """
 
 def less(x1: array, x2: array, /) -> array:


### PR DESCRIPTION
This PR

-   adds complex number support to `isnan` by documenting special cases. Namely, if either component is `NaN`, the result should be `True`; otherwise, the result should be `False`. This follows Python, Julia, and NumPy.
-   updates the input and output array data types to be any numeric data type, not just real-valued data types.

## Notes

-   Based on the guidance included in this PR, when applied in conjunction with #530, a complex number can be both infinite and "NaN". This may not be intuitive for users accustomed to real-valued tests, where a real value is either infinite or NaN, but not both at the same time. Accordingly, users cannot rely on simply using `isnan` and `isinf` to identify special results involving complex numbers in a mutually exclusive fashion (something which is commonly done when branching based on IEEE 754 floats).

## Reference

```python
>>> z
(inf+nanj)
>>> cmath.isnan(z)
True
```

```python
>>> import numpy as np
>>> z
(inf+nanj)
>>> np.isnan(np.array([z]))
array([ True])
```

```julia
julia> z
inf + NaN*im

julia> isnan(z)
true
```