### PR TITLE
Add complex number support to `log10`

### DIFF
--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -983,12 +983,12 @@ def log2(x: array, /) -> array:
     """
 
 def log10(x: array, /) -> array:
-    """
-    Calculates an implementation-dependent approximation to the base ``10`` logarithm, having domain ``[0, +infinity]`` and codomain ``[-infinity, +infinity]``, for each element ``x_i`` of the input array ``x``.
+    r"""
+    Calculates an implementation-dependent approximation to the base ``10`` logarithm for each element ``x_i`` of the input array ``x``.
 
     **Special cases**
 
-    For floating-point operands,
+    For real-valued floating-point operands,
 
     - If ``x_i`` is ``NaN``, the result is ``NaN``.
     - If ``x_i`` is less than ``0``, the result is ``NaN``.
@@ -996,15 +996,25 @@ def log10(x: array, /) -> array:
     - If ``x_i`` is ``1``, the result is ``+0``.
     - If ``x_i`` is ``+infinity``, the result is ``+infinity``.
 
+    For complex floating-point operands, special cases must be handled as if the operation is implemented using the standard change of base formula
+
+    .. math::
+       \log_{10} x = \frac{\log_{e} x}{\log_{e} 10}
+
+    where :math:`\log_{e}` is the natural logarithm, as implemented by :func:`~array_api.log`.
+
+    .. note::
+       For complex floating-point operands, ``log10(conj(x))`` must equal ``conj(log10(x))``.
+
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued floating-point data type.
+        input array. Should have a floating-point data type.
 
     Returns
     -------
     out: array
-        an array containing the evaluated base ``10`` logarithm for each element in ``x``. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`.
+        an array containing the evaluated base ``10`` logarithm for each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
 def logaddexp(x1: array, x2: array, /) -> array:


### PR DESCRIPTION
This PR

-   adds complex number support to `log10` by documenting special cases.
-   updates the input and output array data types to be any floating-point data type, not just real-valued floating-point data types.
-   Specifies that special cases should be derived from those described in <https://github.com/data-apis/array-api/pull/514> according to the textbook change of base formula.