### PR TITLE
Add complex number support to `sum`

### DIFF
--- a/spec/API_specification/array_api/statistical_functions.py
+++ b/spec/API_specification/array_api/statistical_functions.py
@@ -168,7 +168,7 @@ def sum(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, dtyp
 
     -   If ``N`` is ``0``, the sum is ``0`` (i.e., the empty sum).
 
-    For both real-valued and complex floating-point operands, special cases must be handled as if the operation is implemented by successive evaluation of :func:`~array_api.add`.
+    For both real-valued and complex floating-point operands, special cases must be handled as if the operation is implemented by successive application of :func:`~array_api.add`.
 
     Parameters
     ----------

--- a/spec/API_specification/array_api/statistical_functions.py
+++ b/spec/API_specification/array_api/statistical_functions.py
@@ -168,21 +168,20 @@ def sum(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, dtyp
 
     -   If ``N`` is ``0``, the sum is ``0`` (i.e., the empty sum).
 
-    For floating-point operands,
-
-    -   If ``x_i`` is ``NaN``, the sum is ``NaN`` (i.e., ``NaN`` values propagate).
+    For both real-valued and complex floating-point operands, special cases must be handled as if the operation is implemented by successive evaluation of :func:`~array_api.add`.
 
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued data type.
+        input array. Should have a numeric data type.
     axis: Optional[Union[int, Tuple[int, ...]]]
         axis or axes along which sums must be computed. By default, the sum must be computed over the entire array. If a tuple of integers, sums must be computed over multiple axes. Default: ``None``.
     dtype: Optional[dtype]
         data type of the returned array. If ``None``,
 
-        -   if the default data type corresponding to the data type "kind" (integer or floating-point) of ``x`` has a smaller range of values than the data type of ``x`` (e.g., ``x`` has data type ``int64`` and the default data type is ``int32``, or ``x`` has data type ``uint64`` and the default data type is ``int64``), the returned array must have the same data type as ``x``.
+        -   if the default data type corresponding to the data type "kind" (integer, real-valued floating-point, or complex floating-point) of ``x`` has a smaller range of values than the data type of ``x`` (e.g., ``x`` has data type ``int64`` and the default data type is ``int32``, or ``x`` has data type ``uint64`` and the default data type is ``int64``), the returned array must have the same data type as ``x``.
         -   if ``x`` has a real-valued floating-point data type, the returned array must have the default real-valued floating-point data type.
+        -   if ``x`` has a complex floating-point data type, the returned array must have the default complex floating-point data type.
         -   if ``x`` has a signed integer data type (e.g., ``int16``), the returned array must have the default integer data type.
         -   if ``x`` has an unsigned integer data type (e.g., ``uint16``), the returned array must have an unsigned integer data type having the same number of bits as the default integer data type (e.g., if the default integer data type is ``int32``, the returned array must have a ``uint32`` data type).
 


### PR DESCRIPTION
This PR

-   adds support for complex number summation. As described in <https://github.com/data-apis/array-api/pull/525>, complex number addition is well-defined, where `(a + bj) + (c + dj) = (a+c) + (c+d)j`.
-   specifies that special cases be derived **as if** the operation was implemented as a reduction over `add`.
-   requires that, if `x` is a complex floating-point data type and `dtype` is `None`, the function must return an array having the default complex floating-point data type.
-   updates the input and output array data types to be any numeric data type, not just real-valued data types.
-   depends on <https://github.com/data-apis/array-api/pull/525>.

