### PR TITLE
Add complex number support to `linalg.det`

### DIFF
--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -78,7 +78,7 @@ def det(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array having shape ``(..., M, M)`` and whose innermost two dimensions form square matrices. Should have a real-valued floating-point data type.
+        input array having shape ``(..., M, M)`` and whose innermost two dimensions form square matrices. Should have a floating-point data type.
 
     Returns
     -------


### PR DESCRIPTION
This PR

-   adds support for complex numbers to `linalg.det`.
-   updates the input and output array data types to be any floating-point data type, not just real-valued floating-point data types. In certain circumstances, the determinant of a complex matrix can be real-valued; however, this is not generally true. In which case, the guidance remains that the output data type be required to have the same data type as the input array `x`.

