### PR TITLE
Add complex number support to `linalg.matrix_power`

### DIFF
--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -248,14 +248,14 @@ def matrix_power(x: array, n: int, /) -> array:
     Parameters
     ----------
     x: array
-        input array having shape ``(..., M, M)`` and whose innermost two dimensions form square matrices. Should have a real-valued floating-point data type.
+        input array having shape ``(..., M, M)`` and whose innermost two dimensions form square matrices. Should have a floating-point data type.
     n: int
         integer exponent.
 
     Returns
     -------
     out: array
-        if ``n`` is equal to zero, an array containing the identity matrix for each square matrix. If ``n`` is less than zero, an array containing the inverse of each square matrix raised to the absolute value of ``n``, provided that each square matrix is invertible. If ``n`` is greater than zero, an array containing the result of raising each square matrix to the power ``n``. The returned array must have the same shape as ``x`` and a real-valued floating-point data type determined by :ref:`type-promotion`.
+        if ``n`` is equal to zero, an array containing the identity matrix for each square matrix. If ``n`` is less than zero, an array containing the inverse of each square matrix raised to the absolute value of ``n``, provided that each square matrix is invertible. If ``n`` is greater than zero, an array containing the result of raising each square matrix to the power ``n``. The returned array must have the same shape as ``x`` and a floating-point data type determined by :ref:`type-promotion`.
     """
 
 def matrix_rank(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> array:


### PR DESCRIPTION
This PR

-   adds complex number support to `linalg.matrix_power`. The main substantive change is updating the input and output data types.
-   depends on <https://github.com/data-apis/array-api/pull/547>, which adds complex number support for matrix inversion.