### PR TITLE
Add complex number support for multiplication

### DIFF
--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -717,7 +717,7 @@ class _array():
         +------------+----------------+-----------------+--------------------------+
         | **bj**     | (b*c)j         | -(b*d)          | -(b*d) + (b*c)j          |
         +------------+----------------+-----------------+--------------------------+
-        | **a + bj** | (a*c) + (b*c)j | -(b*d) + (a*d)j | implementation-dependent |
+        | **a + bj** | (a*c) + (b*c)j | -(b*d) + (a*d)j | special rules            |
         +------------+----------------+-----------------+--------------------------+
 
         In general, for complex floating-point operands, real-valued floating-point special cases must independently apply to the real and imaginary component operations involving real numbers as described in the above table.

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -689,12 +689,14 @@ class _array():
         """
 
     def __mul__(self: array, other: Union[int, float, array], /) -> array:
-        """
+        r"""
         Calculates the product for each element of an array instance with the respective element of the array ``other``.
 
         **Special cases**
 
-        For floating-point operands, let ``self`` equal ``x1`` and ``other`` equal ``x2``.
+        Let ``self`` equal ``x1`` and ``other`` equal ``x2``.
+
+        For real-valued floating-point operands,
 
         -   If either ``x1_i`` or ``x2_i`` is ``NaN``, the result is ``NaN``.
         -   If ``x1_i`` is either ``+infinity`` or ``-infinity`` and ``x2_i`` is either ``+0`` or ``-0``, the result is ``NaN``.
@@ -706,6 +708,32 @@ class _array():
         -   If ``x1_i`` is a nonzero finite number and ``x2_i`` is either ``+infinity`` or ``-infinity``, the result is a signed infinity with the mathematical sign determined by the rule already stated above.
         -   In the remaining cases, where neither ``infinity`` nor `NaN` is involved, the product must be computed and rounded to the nearest representable value according to IEEE 754-2019 and a supported rounding mode. If the magnitude is too large to represent, the result is an ``infinity`` of appropriate mathematical sign. If the magnitude is too small to represent, the result is a zero of appropriate mathematical sign.
 
+        For complex floating-point operands, multiplication is defined according to the following table. For real components ``a`` and ``c`` and imaginary components ``b`` and ``d``,
+
+        +------------+----------------+-----------------+--------------------------+
+        |            | c              | dj              | c + dj                   |
+        +============+================+=================+==========================+
+        | **a**      | a * c          | (a*d)j          | (a*c) + (a*d)j           |
+        +------------+----------------+-----------------+--------------------------+
+        | **bj**     | (b*c)j         | -(b*d)          | -(b*d) + (b*c)j          |
+        +------------+----------------+-----------------+--------------------------+
+        | **a + bj** | (a*c) + (b*c)j | -(b*d) + (a*d)j | implementation-dependent |
+        +------------+----------------+-----------------+--------------------------+
+
+        In general, for complex floating-point operands, real-valued floating-point special cases must independently apply to the real and imaginary component operations involving real numbers as described in the above table.
+
+        When ``a``, ``b``, ``c``, or ``d`` are all finite numbers (i.e., a value other than ``NaN``, ``+infinity``, or ``-infinity``), multiplication of complex floating-point operands should be computed as if calculated according to the textbook formula for complex number multiplication
+
+        .. math::
+           (a + bj) \cdot (c + dj) = (ac - bd) + (bc + ad)j
+
+        When at least one of ``a``, ``b``, ``c``, or ``d`` is ``NaN``, ``+infinity``, or ``-infinity``,
+
+        - If ``a``, ``b``, ``c``, and ``d`` are all ``NaN``, the result is ``NaN + NaN j``.
+        - In the remaining cases, the result is implementation dependent.
+
+        .. note::
+           For complex floating-point operands, the results of special cases may be implementation dependent depending on how an implementation chooses to model complex numbers and complex infinity (e.g., complex plane versus Riemann sphere). For those implementations following C99 and its one-infinity model, when at least one component is infinite, even if the other component is ``NaN``, the complex value is infinite, and the usual arithmetic rules do not apply to complex-complex multiplication. In the interest of performance, other implementations may want to avoid the complex branching logic necessary to implement the one-infinity model and choose to implement all complex-complex multiplication according to the textbook formula. Accordingly, special case behavior is unlikely to be consistent across implementations.
 
         .. note::
            Floating-point multiplication is not always associative due to finite precision.
@@ -713,9 +741,9 @@ class _array():
         Parameters
         ----------
         self: array
-            array instance. Should have a real-valued data type.
+            array instance. Should have a numeric data type.
         other: Union[int, float, array]
-            other array. Must be compatible with ``self`` (see :ref:`broadcasting`). Should have a real-valued data type.
+            other array. Must be compatible with ``self`` (see :ref:`broadcasting`). Should have a numeric data type.
 
         Returns
         -------

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1111,12 +1111,12 @@ def logical_xor(x1: array, x2: array, /) -> array:
     """
 
 def multiply(x1: array, x2: array, /) -> array:
-    """
+    r"""
     Calculates the product for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
 
     **Special cases**
 
-    For floating-point operands,
+    For real-valued floating-point operands,
 
     - If either ``x1_i`` or ``x2_i`` is ``NaN``, the result is ``NaN``.
     - If ``x1_i`` is either ``+infinity`` or ``-infinity`` and ``x2_i`` is either ``+0`` or ``-0``, the result is ``NaN``.
@@ -1128,15 +1128,42 @@ def multiply(x1: array, x2: array, /) -> array:
     - If ``x1_i`` is a nonzero finite number and ``x2_i`` is either ``+infinity`` or ``-infinity``, the result is a signed infinity with the mathematical sign determined by the rule already stated above.
     - In the remaining cases, where neither ``infinity`` nor ``NaN`` is involved, the product must be computed and rounded to the nearest representable value according to IEEE 754-2019 and a supported rounding mode. If the magnitude is too large to represent, the result is an `infinity` of appropriate mathematical sign. If the magnitude is too small to represent, the result is a zero of appropriate mathematical sign.
 
+    For complex floating-point operands, multiplication is defined according to the following table. For real components ``a`` and ``c`` and imaginary components ``b`` and ``d``,
+
+    +------------+----------------+-----------------+--------------------------+
+    |            | c              | dj              | c + dj                   |
+    +============+================+=================+==========================+
+    | **a**      | a * c          | (a*d)j          | (a*c) + (a*d)j           |
+    +------------+----------------+-----------------+--------------------------+
+    | **bj**     | (b*c)j         | -(b*d)          | -(b*d) + (b*c)j          |
+    +------------+----------------+-----------------+--------------------------+
+    | **a + bj** | (a*c) + (b*c)j | -(b*d) + (a*d)j | implementation-dependent |
+    +------------+----------------+-----------------+--------------------------+
+
+    In general, for complex floating-point operands, real-valued floating-point special cases must independently apply to the real and imaginary component operations involving real numbers as described in the above table.
+
+    When ``a``, ``b``, ``c``, or ``d`` are all finite numbers (i.e., a value other than ``NaN``, ``+infinity``, or ``-infinity``), multiplication of complex floating-point operands should be computed as if calculated according to the textbook formula for complex number multiplication
+
+    .. math::
+       (a + bj) \cdot (c + dj) = (ac - bd) + (bc + ad)j
+
+    When at least one of ``a``, ``b``, ``c``, or ``d`` is ``NaN``, ``+infinity``, or ``-infinity``,
+
+    - If ``a``, ``b``, ``c``, and ``d`` are all ``NaN``, the result is ``NaN + NaN j``.
+    - In the remaining cases, the result is implementation dependent.
+
+    .. note::
+       For complex floating-point operands, the results of special cases may be implementation dependent depending on how an implementation chooses to model complex numbers and complex infinity (e.g., complex plane versus Riemann sphere). For those implementations following C99 and its one-infinity model, when at least one component is infinite, even if the other component is ``NaN``, the complex value is infinite, and the usual arithmetic rules do not apply to complex-complex multiplication. In the interest of performance, other implementations may want to avoid the complex branching logic necessary to implement the one-infinity model and choose to implement all complex-complex multiplication according to the textbook formula. Accordingly, special case behavior is unlikely to be consistent across implementations.
+
     .. note::
        Floating-point multiplication is not always associative due to finite precision.
 
     Parameters
     ----------
     x1: array
-        first input array. Should have a real-valued data type.
+        first input array. Should have a numeric data type.
     x2: array
-        second input array. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have a real-valued data type.
+        second input array. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have a numeric data type.
 
     Returns
     -------

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1137,7 +1137,7 @@ def multiply(x1: array, x2: array, /) -> array:
     +------------+----------------+-----------------+--------------------------+
     | **bj**     | (b*c)j         | -(b*d)          | -(b*d) + (b*c)j          |
     +------------+----------------+-----------------+--------------------------+
-    | **a + bj** | (a*c) + (b*c)j | -(b*d) + (a*d)j | implementation-dependent |
+    | **a + bj** | (a*c) + (b*c)j | -(b*d) + (a*d)j | special rules            |
     +------------+----------------+-----------------+--------------------------+
 
     In general, for complex floating-point operands, real-valued floating-point special cases must independently apply to the real and imaginary component operations involving real numbers as described in the above table.


### PR DESCRIPTION
This PR

-   adds support for complex number multiplication. For finite components, complex number multiplication is well-defined, where `(a + bj) x (c + dj) = (ac - bd) + (bc + ad)j`. However, for complex numbers having infinite or `NaN` components, results may diverge depending on how one chooses to model complex infinities. In C99 with its one-infinity model, a complex value is infinite, even if the other component is `NaN`. In order to maintain a single point at infinity, C99 suspends the normal rules of arithmetic floating-point operations and requires branching logic within implementations in order to accurately handle special cases. Such branching logic is undesirable when performance is paramount (e.g., in certain accelerator libraries), and, thus, special cases involving `NaNs` and infinities is specified as implementation-dependent.
-   Specifies that, in general, the special cases described for real-valued floating-point operands apply to the component operations separately. Meaning, operations involving real-valued components (i.e., `a`, `b`, `c`, `d`) must abide by real-valued floating-point special cases. 
-   updates the input and output array data types to be any numeric data type, not just real-valued data types.