### PR TITLE
Add complex number support to `square`

### DIFF
--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1713,13 +1713,22 @@ def sinh(x: array, /) -> array:
     """
 
 def square(x: array, /) -> array:
-    """
-    Squares (``x_i * x_i``) each element ``x_i`` of the input array ``x``.
+    r"""
+    Squares each element ``x_i`` of the input array ``x``.
+
+    The square of a number ``x_i`` is defined as
+
+    .. math::
+       x_i^2 = x_i \cdot x_i
+
+    **Special cases**
+
+    For floating-point operands, special cases must be handled as if the operation is implemented as ``x * x`` (see :func:`~array_api.multiply`).
 
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------


### PR DESCRIPTION
This PR

-   adds complex number support to `square`. As `square` is shorthand for `multiply(x, x)`, special cases should match that of `multiply` for both real- and complex-valued floating-point operands. 
-   updates the input and output array data types to be any numeric data type, not just real-valued data types.
-   depends on <https://github.com/data-apis/array-api/pull/551>.