### PR TITLE
Add complex number support to `sign`

### DIFF
--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1356,14 +1356,20 @@ def sign(x: array, /) -> array:
 
     **Special cases**
 
+    For real-valued operands,
+
     - If ``x_i`` is less than ``0``, the result is ``-1``.
     - If ``x_i`` is either ``-0`` or ``+0``, the result is ``0``.
     - If ``x_i`` is greater than ``0``, the result is ``+1``.
 
+    For complex floating-point operands,
+
+    TODO
+
     Parameters
     ----------
     x: array
-        input array. Should have a real-valued data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1351,8 +1351,18 @@ def round(x: array, /) -> array:
     """
 
 def sign(x: array, /) -> array:
-    """
+    r"""
     Returns an indication of the sign of a number for each element ``x_i`` of the input array ``x``.
+
+    The sign function (also known as the **signum function**) of a number :math:`x_i` is defined as
+
+    .. math::
+       \operatorname{sign}(x_i) = \begin{cases}
+       0 & \textrm{if } x_i = 0 \\
+       \frac{x}{|x|} & \textrm{otherwise}
+       \end{cases}
+
+    where :math:`|x_i|` is the absolute value of :math:`x_i`.
 
     **Special cases**
 
@@ -1361,10 +1371,13 @@ def sign(x: array, /) -> array:
     - If ``x_i`` is less than ``0``, the result is ``-1``.
     - If ``x_i`` is either ``-0`` or ``+0``, the result is ``0``.
     - If ``x_i`` is greater than ``0``, the result is ``+1``.
+    - If ``x_i`` is ``NaN``, the result is ``NaN``.
 
-    For complex floating-point operands,
+    For complex floating-point operands, let ``a = real(x_i)``, ``b = imag(x_i)``, and
 
-    TODO
+    - If ``a`` is either ``-0`` or ``+0`` and ``b`` is either ``-0`` or ``+0``, the result is ``0 + 0j``.
+    - If ``a`` is ``NaN`` or ``b`` is ``NaN``, the result is ``NaN + NaN j``.
+    - In the remaining cases, special cases must be handled according to the rules of complex number division (see :func:`~array_api.divide`).
 
     Parameters
     ----------


### PR DESCRIPTION
This PR

-   adds complex number support to `sign`.
-   defines the sign to be `x/|x|` ensuring a consistent definition for real and complex data types (as discussed in <https://github.com/data-apis/array-api/issues/545>).
-   closes <https://github.com/data-apis/array-api/issues/545>.
-   requires that special cases follow the rules of complex number division. In this case, the numerator is a complex number and the denominator a real value and, thus, complex number division is well-defined.
-   updates the input array data type to be any numeric data type, not just real-valued data types.
-   adds a special case for real-valued inputs in that `NaN` should be returned if `x_i` is `NaN`.
-   depends on <https://github.com/data-apis/array-api/pull/554>.