### PR TITLE
Add complex number support to `linalg.cross`

### DIFF
--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -48,9 +48,9 @@ def cross(x1: array, x2: array, /, *, axis: int = -1) -> array:
     Parameters
     ----------
     x1: array
-        first input array. Should have a real-valued data type.
+        first input array. Must have a numeric data type.
     x2: array
-        second input array. Must be compatible with ``x1`` for all non-compute axes (see :ref:`broadcasting`). The size of the axis over which to compute the cross product must be the same size as the respective axis in ``x1``. Should have a real-valued data type.
+        second input array. Must be compatible with ``x1`` for all non-compute axes (see :ref:`broadcasting`). The size of the axis over which to compute the cross product must be the same size as the respective axis in ``x1``. Must have a numeric data type.
 
         .. note::
            The compute axis (dimension) must not be broadcasted.


### PR DESCRIPTION
This PR

-   adds complex number support to `linalg.cross`. No special considerations are required to accommodate complex numbers.
-   updates the input and output array data types to be any numeric data type, not just real-valued data types.
-   updates guidance to **require** a numeric data type. Previously, it said "should", but this was likely an oversight, as computing the cross product for non-numeric data types does not make sense.