### PR TITLE
Add complex number support to `linalg.outer`

### DIFF
--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -287,9 +287,9 @@ def outer(x1: array, x2: array, /) -> array:
     Parameters
     ----------
     x1: array
-        first one-dimensional input array of size ``N``. Should have a real-valued data type.
+        first one-dimensional input array of size ``N``. Must have a numeric data type.
     x2: array
-        second one-dimensional input array of size ``M``. Should have a real-valued data type.
+        second one-dimensional input array of size ``M``. Must have a numeric data type.
 
     Returns
     -------


### PR DESCRIPTION
This PR

-   adds complex number support to `linalg.outer`. No special considerations are required to accommodate complex numbers.
-   updates the input and output array data types to be any numeric data type, not just real-valued data types.
-   updates guidance to **require** a numeric data type. If left as "should", would imply that non-numeric data types would be permitted if a library had overriding reasons for doing so. However, for computing the outer product, non-numeric data types are not applicable.