### PR TITLE
Add complex number support to `linalg.pinv`

### DIFF
--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -301,7 +301,7 @@ def pinv(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> array:
     r"""
     Returns the (Moore-Penrose) pseudo-inverse of a matrix (or a stack of matrices) ``x``.
 
-    The pseudo-inverse of a matrix :math:`A`, denoted :math:`A^{+}`, is defined as the matrix that "solves" the least-squares problem :math:`Ax = b` (i.e., if :math:`\hbar{x}` is a solution, then :math:`A^{+}` is the matrix such that :math:`\hbar{x} = A^{+}b`).
+    The pseudo-inverse of a matrix :math:`A`, denoted :math:`A^{+}`, is defined as the matrix that "solves" the least-squares problem :math:`Ax = b` (i.e., if :math:`\overline{x}` is a solution, then :math:`A^{+}` is the matrix such that :math:`\overline{x} = A^{+}b`).
 
     While the pseudo-inverse can be defined algebraically, one can understand the pseudo-inverse via singular value decomposition (SVD). Namely, if
 

--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -298,20 +298,36 @@ def outer(x1: array, x2: array, /) -> array:
     """
 
 def pinv(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> array:
-    """
+    r"""
     Returns the (Moore-Penrose) pseudo-inverse of a matrix (or a stack of matrices) ``x``.
+
+    The pseudo-inverse of a matrix :math:`A`, denoted :math:`A^{+}`, is defined as the matrix that "solves" the least-squares problem :math:`Ax = b` (i.e., if :math:`\hbar{x}` is a solution, then :math:`A^{+}` is the matrix such that :math:`\hbar{x} = A^{+}b`).
+
+    While the pseudo-inverse can be defined algebraically, one can understand the pseudo-inverse via singular value decomposition (SVD). Namely, if
+
+    .. math::
+       A = U \Sigma V^H
+
+    is a singular decomposition of :math:`A`, then
+
+    .. math::
+       A^{+} = U \Sigma^{+} V^H
+
+    where :math:`U` and :math:`V^H` are orthogonal matrices, :math:`\Sigma` is a diagonal matrix consisting of :math:`A`'s singular values, and :math:`\Sigma^{+}` is then a diagonal matrix consisting of the reciprocals of :math:`A`'s singular values, leaving zeros in place. During numerical computation, only elements larger than a small tolerance are considered nonzero, and all others replaced by zeros.
+
+    When ``x`` is a stack of matrices, the function must compute the pseudo-inverse for each matrix in the stack.
 
     Parameters
     ----------
     x: array
-        input array having shape ``(..., M, N)`` and whose innermost two dimensions form ``MxN`` matrices. Should have a real-valued floating-point data type.
+        input array having shape ``(..., M, N)`` and whose innermost two dimensions form ``MxN`` matrices. Should have a floating-point data type.
     rtol: Optional[Union[float, array]]
         relative tolerance for small singular values. Singular values approximately less than or equal to ``rtol * largest_singular_value`` are set to zero. If a ``float``, the value is equivalent to a zero-dimensional array having a real-valued floating-point data type determined by :ref:`type-promotion` (as applied to ``x``) and must be broadcast against each matrix. If an ``array``, must have a real-valued floating-point data type and must be compatible with ``shape(x)[:-2]`` (see :ref:`broadcasting`). If ``None``, the default value is ``max(M, N) * eps``, where ``eps`` must be the machine epsilon associated with the real-valued floating-point data type determined by :ref:`type-promotion` (as applied to ``x``). Default: ``None``.
 
     Returns
     -------
     out: array
-        an array containing the pseudo-inverses. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion` and must have shape ``(..., N, M)`` (i.e., must have the same shape as ``x``, except the innermost two dimensions must be transposed).
+        an array containing the pseudo-inverse(s). The returned array must have a floating-point data type determined by :ref:`type-promotion` and must have shape ``(..., N, M)`` (i.e., must have the same shape as ``x``, except the innermost two dimensions must be transposed).
     """
 
 def qr(x: array, /, *, mode: Literal['reduced', 'complete'] = 'reduced') -> Tuple[array, array]:


### PR DESCRIPTION
This PR

-   adds complex number support to `linalg.pinv`.
-   updates the allowed input data type from real-valued floating-point to any floating-point data type.
-   makes explicit that, for matrix stacks, the pseudo-inverse must be computed for each matrix in the stack.
-   adds an extended description helping contextualize the use `rtol`.
-   (in practice) depends on <https://github.com/data-apis/array-api/pull/561>.