### PR TITLE
Add complex number support to `linalg.slogdet`

### DIFF
--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -361,6 +361,8 @@ def slogdet(x: array, /) -> Tuple[array, array]:
 
     where :math:`|\det x|` is the absolute value of :math:`\det x`.
 
+    When ``x`` is a stack of matrices, the function must compute the sign and natural logarithm of the absolute value of the determinant for each matrix in the stack.
+
     **Special Cases**
 
     For real-valued floating-point operands,

--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -367,11 +367,11 @@ def slogdet(x: array, /) -> Tuple[array, array]:
 
     For real-valued floating-point operands,
 
-    - If the determinant is zero, the corresponding ``sign`` should be ``0`` and ``logabsdet`` should be ``-infinity``.
+    - If the determinant is zero, the ``sign`` should be ``0`` and ``logabsdet`` should be ``-infinity``.
 
     For complex floating-point operands,
 
-    - If the determinant is ``0 + 0j``, the corresponding ``sign`` should be ``0 + 0j`` and ``logabsdet`` should be ``-infinity + 0j``.
+    - If the determinant is ``0 + 0j``, the ``sign`` should be ``0 + 0j`` and ``logabsdet`` should be ``-infinity + 0j``.
 
     .. note::
        Depending on the underlying algorithm, when the determinant is zero, the returned result may differ from ``-infinity`` (or ``-infinity + 0j``). In all cases, the determinant should be equal to ``sign * exp(logabsdet)`` (although, again, the result may be subject to numerical precision errors).

--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -355,8 +355,8 @@ def slogdet(x: array, /) -> Tuple[array, array]:
 
     .. math::
        \operatorname{sign}(\det x) = \begin{cases}
-       0 & \textrm{if } \det x = 0 &&
-       \frac{\det x}{|\det x|}
+       0 & \textrm{if } \det x = 0 \\
+       \frac{\det x}{|\det x|} & \textrm{otherwise}
        \end{cases}
 
     where :math:`|\det x|` is the absolute value of :math:`\det x`.

--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -387,7 +387,7 @@ def slogdet(x: array, /) -> Tuple[array, array]:
         a namedtuple (``sign``, ``logabsdet``) whose
 
         -   first element must have the field name ``sign`` and must be an array containing a number representing the sign of the determinant for each square matrix. Must have the same data type as ``x``.
-        -   second element must have the field name ``logabsdet`` and must be an array containing the natural logarithm of the absolute value of the determinant for each square matrix. If ``x`` is real-valued, the returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`. If ``x`` is complex`, the returned array must have a real-valued floating-point data type having the same precision as ``x`` (e.g., if ``x`` is ``complex64``, ``logabsdet`` must have a ``float32`` data type).
+        -   second element must have the field name ``logabsdet`` and must be an array containing the natural logarithm of the absolute value of the determinant for each square matrix. If ``x`` is real-valued, the returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`. If ``x`` is complex, the returned array must have a real-valued floating-point data type having the same precision as ``x`` (e.g., if ``x`` is ``complex64``, ``logabsdet`` must have a ``float32`` data type).
 
         Each returned array must have shape ``shape(x)[:-2]``.
     """

--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -359,7 +359,7 @@ def slogdet(x: array, /) -> Tuple[array, array]:
        \frac{\det x}{|\det x|} & \textrm{otherwise}
        \end{cases}
 
-    where :math:`|\det x|` is the absolute value of :math:`\det x`.
+    where :math:`|\det x|` is the absolute value of the determinant of ``x``.
 
     When ``x`` is a stack of matrices, the function must compute the sign and natural logarithm of the absolute value of the determinant for each matrix in the stack.
 

--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -345,31 +345,49 @@ def qr(x: array, /, *, mode: Literal['reduced', 'complete'] = 'reduced') -> Tupl
     """
 
 def slogdet(x: array, /) -> Tuple[array, array]:
-    """
+    r"""
     Returns the sign and the natural logarithm of the absolute value of the determinant of a square matrix (or a stack of square matrices) ``x``.
 
     .. note::
        The purpose of this function is to calculate the determinant more accurately when the determinant is either very small or very large, as calling ``det`` may overflow or underflow.
 
+    The sign of the determinant is given by
+
+    .. math::
+       \operatorname{sign}(\det x) = \begin{cases}
+       0 & \textrm{if } \det x = 0 &&
+       \frac{\det x}{|\det x|}
+       \end{cases}
+
+    where :math:`|\det x|` is the absolute value of :math:`\det x`.
+
+    **Special Cases**
+
+    For real-valued floating-point operands,
+
+    - If the determinant is zero, the corresponding ``sign`` should be ``0`` and ``logabsdet`` should be ``-infinity``.
+
+    For complex floating-point operands,
+
+    - If the determinant is ``0 + 0j``, the corresponding ``sign`` should be ``0 + 0j`` and ``logabsdet`` should be ``-infinity + 0j``.
+
+    .. note::
+       Depending on the underlying algorithm, when the determinant is zero, the returned result may differ from ``-infinity`` (or ``-infinity + 0j``). In all cases, the determinant should be equal to ``sign * exp(logabsdet)`` (although, again, the result may be subject to numerical precision errors).
+
     Parameters
     ----------
     x: array
-        input array having shape ``(..., M, M)`` and whose innermost two dimensions form square matrices. Should have a real-valued floating-point data type.
+        input array having shape ``(..., M, M)`` and whose innermost two dimensions form square matrices. Should have a floating-point data type.
 
     Returns
     -------
     out: Tuple[array, array]
         a namedtuple (``sign``, ``logabsdet``) whose
 
-        -   first element must have the field name ``sign`` and must be an array containing a number representing the sign of the determinant for each square matrix.
-        -   second element must have the field name ``logabsdet`` and must be an array containing the determinant for each square matrix.
+        -   first element must have the field name ``sign`` and must be an array containing a number representing the sign of the determinant for each square matrix. Must have the same data type as ``x``.
+        -   second element must have the field name ``logabsdet`` and must be an array containing the natural logarithm of the absolute value of the determinant for each square matrix. If ``x`` is real-valued, the returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`. If ``x`` is complex`, the returned array must have a real-valued floating-point data type having the same precision as ``x`` (e.g., if ``x`` is ``complex64``, ``logabsdet`` must have a ``float32`` data type).
 
-        For a real matrix, the sign of the determinant must be either ``1``, ``0``, or ``-1``.
-
-        Each returned array must have shape ``shape(x)[:-2]`` and a real-valued floating-point data type determined by :ref:`type-promotion`.
-
-        .. note::
-           If a determinant is zero, then the corresponding ``sign`` should be ``0`` and ``logabsdet`` should be ``-infinity``; however, depending on the underlying algorithm, the returned result may differ. In all cases, the determinant should be equal to ``sign * exp(logsabsdet)`` (although, again, the result may be subject to numerical precision errors).
+        Each returned array must have shape ``shape(x)[:-2]``.
     """
 
 def solve(x1: array, x2: array, /) -> array:


### PR DESCRIPTION
This PR

-   adds complex number support to `linalg.slogdet`.
-   defines the sign of the determinant in agreement with <https://github.com/data-apis/array-api/pull/556>. In contrast to its `sign` function, NumPy uses the definition $\operatorname{sign}(\det x) = \frac{\det x}{|\det x|}$ to compute the sign of the determinant. At the time of this PR, [PyTorch](https://github.com/pytorch/pytorch/pull/56265/files#diff-316ce439a56491298e2d98deeca82606c52e5bde2f1ceb16c534ec03386c817eR224) refers to the "sign" as the angle (which I take to mean the argument of the determinant); however, I don't believe this is correct, as, via polar decomposition, $\det A = |\det A| e^{\theta j}$. Given the expected equality that $\det A = \operatorname{sign}(\det A) \cdot e^{\ln |\det A|} =  |\det A| \operatorname{sign}(\det A)$, we see that what should be returned is $e^{\theta j}$, not simply the argument $\theta$. While the PyTorch docs state that the angle is returned, what is actually returned is $\frac{\det x}{|\det x|}$.
-   updates the allowed data types from real-valued floating-point to any floating-point data type.
-   requires that the `sign` array be the same data type as the input array and `logabsdet` be unconditionally real-valued.
-   adds an extended description describing the operation.
-   makes explicit that, for matrix stacks, a solution must be computed for each matrix in the stack.