### PR TITLE
Update dtype guidance for `eigh` and `eigvalsh`

### DIFF
--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -139,7 +139,7 @@ def eigh(x: array, /) -> Tuple[array]:
     Parameters
     ----------
     x: array
-        input array having shape ``(..., M, M)`` and whose innermost two dimensions form square matrices. Must have a floating-point data type.
+        input array having shape ``(..., M, M)`` and whose innermost two dimensions form square matrices. Should have a floating-point data type.
 
     Returns
     -------
@@ -179,7 +179,7 @@ def eigvalsh(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array having shape ``(..., M, M)`` and whose innermost two dimensions form square matrices. Must have a floating-point data type.
+        input array having shape ``(..., M, M)`` and whose innermost two dimensions form square matrices. Should have a floating-point data type.
 
     Returns
     -------


### PR DESCRIPTION
This PR

- updates the data type guidance for `eigh` and `eigvalsh` to be aligned with other `linalg` APIs. Currently, the specification says the input dtypes for these two APIs "must" be floating-point; however, all other similar `linalg` APIs state that the input dtypes "should" be floating-point. This PR corrects this discrepancy.