### PR TITLE
Run `black` on `.py` files (with git-blame-ignore-revs)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate code style to Black
+162034b12711dad54589c5dc9e75942695a7957f

--- a/spec/API_specification/array_api/__init__.py
+++ b/spec/API_specification/array_api/__init__.py
@@ -1,3 +1,5 @@
+"""Function stubs and API documentation for the array API standard."""
+
 from .array_object import *
 from .constants import *
 from .creation_functions import *

--- a/spec/API_specification/array_api/_types.py
+++ b/spec/API_specification/array_api/_types.py
@@ -7,18 +7,29 @@ library, e.g., for NumPy TypeVar('array') would be replaced with ndarray.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, List, Literal, Optional, Sequence, Tuple, TypeVar, Union, Protocol
+from typing import (
+    Any,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    Protocol,
+)
 from enum import Enum
 
-array = TypeVar('array')
-device = TypeVar('device')
-dtype = TypeVar('dtype')
-SupportsDLPack = TypeVar('SupportsDLPack')
-SupportsBufferProtocol = TypeVar('SupportsBufferProtocol')
-PyCapsule = TypeVar('PyCapsule')
+array = TypeVar("array")
+device = TypeVar("device")
+dtype = TypeVar("dtype")
+SupportsDLPack = TypeVar("SupportsDLPack")
+SupportsBufferProtocol = TypeVar("SupportsBufferProtocol")
+PyCapsule = TypeVar("PyCapsule")
 # ellipsis cannot actually be imported from anywhere, so include a dummy here
 # to keep pyflakes happy. https://github.com/python/typeshed/issues/3556
-ellipsis = TypeVar('ellipsis')
+ellipsis = TypeVar("ellipsis")
+
 
 @dataclass
 class finfo_object:
@@ -27,6 +38,7 @@ class finfo_object:
     max: float
     min: float
     smallest_normal: float
+
 
 @dataclass
 class iinfo_object:
@@ -37,11 +49,32 @@ class iinfo_object:
 
 _T_co = TypeVar("_T_co", covariant=True)
 
+
 class NestedSequence(Protocol[_T_co]):
-    def __getitem__(self, key: int, /) -> Union[_T_co, NestedSequence[_T_co]]: ...
-    def __len__(self, /) -> int: ...
+    def __getitem__(self, key: int, /) -> Union[_T_co, NestedSequence[_T_co]]:
+        ...
+
+    def __len__(self, /) -> int:
+        ...
 
 
-__all__ = ['Any', 'List', 'Literal', 'NestedSequence', 'Optional',
-'PyCapsule', 'SupportsBufferProtocol', 'SupportsDLPack', 'Tuple', 'Union', 'Sequence',
-'array', 'device', 'dtype', 'ellipsis', 'finfo_object', 'iinfo_object', 'Enum']
+__all__ = [
+    "Any",
+    "List",
+    "Literal",
+    "NestedSequence",
+    "Optional",
+    "PyCapsule",
+    "SupportsBufferProtocol",
+    "SupportsDLPack",
+    "Tuple",
+    "Union",
+    "Sequence",
+    "array",
+    "device",
+    "dtype",
+    "ellipsis",
+    "finfo_object",
+    "iinfo_object",
+    "Enum",
+]

--- a/spec/API_specification/array_api/_types.py
+++ b/spec/API_specification/array_api/_types.py
@@ -1,5 +1,5 @@
 """
-This file defines the types for type annotations.
+Types for type annotations used in the array API standard.
 
 The type variables should be replaced with the actual types for a given
 library, e.g., for NumPy TypeVar('array') would be replaced with ndarray.
@@ -33,6 +33,7 @@ ellipsis = TypeVar("ellipsis")
 
 @dataclass
 class finfo_object:
+    """Dataclass returned by `finfo`."""
     bits: int
     eps: float
     max: float
@@ -42,6 +43,7 @@ class finfo_object:
 
 @dataclass
 class iinfo_object:
+    """Dataclass returned by `iinfo`."""
     bits: int
     max: int
     min: int

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -16,9 +16,7 @@ from ._types import (
 
 class _array:
     def __init__(self: array) -> None:
-        """
-        Initialize the attributes for the array object class.
-        """
+        """Initialize the attributes for the array object class."""
 
     @property
     def dtype(self: array) -> Dtype:

--- a/spec/API_specification/array_api/array_object.py
+++ b/spec/API_specification/array_api/array_object.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
-from ._types import (array, dtype as Dtype, device as Device, Optional, Tuple,
-                     Union, Any, PyCapsule, Enum, ellipsis)
+from ._types import (
+    array,
+    dtype as Dtype,
+    device as Device,
+    Optional,
+    Tuple,
+    Union,
+    Any,
+    PyCapsule,
+    Enum,
+    ellipsis,
+)
 
-class _array():
+
+class _array:
     def __init__(self: array) -> None:
         """
         Initialize the attributes for the array object class.
@@ -246,7 +257,9 @@ class _array():
            Element-wise results must equal the results returned by the equivalent element-wise function :func:`~array_api.bitwise_and`.
         """
 
-    def __array_namespace__(self: array, /, *, api_version: Optional[str] = None) -> Any:
+    def __array_namespace__(
+        self: array, /, *, api_version: Optional[str] = None
+    ) -> Any:
         """
         Returns an object that has all the array API functions on it.
 
@@ -298,9 +311,9 @@ class _array():
 
         - If ``self`` is ``True``, the result is ``1+0j``.
         - If ``self`` is ``False``, the result is ``0+0j``.
-        
+
         For real-valued floating-point operands,
-        
+
         - If ``self`` is ``NaN``, the result is ``NaN + NaN j``.
         - If ``self`` is ``+infinity``, the result is ``+infinity + 0j``.
         - If ``self`` is ``-infinity``, the result is ``-infinity + 0j``.
@@ -317,7 +330,9 @@ class _array():
             a Python ``complex`` object representing the single element of the array instance.
         """
 
-    def __dlpack__(self: array, /, *, stream: Optional[Union[int, Any]] = None) -> PyCapsule:
+    def __dlpack__(
+        self: array, /, *, stream: Optional[Union[int, Any]] = None
+    ) -> PyCapsule:
         """
         Exports the array for consumption by :func:`~array_api.from_dlpack` as a DLPack capsule.
 
@@ -559,7 +574,13 @@ class _array():
            Element-wise results must equal the results returned by the equivalent element-wise function :func:`~array_api.greater_equal`.
         """
 
-    def __getitem__(self: array, key: Union[int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], array], /) -> array:
+    def __getitem__(
+        self: array,
+        key: Union[
+            int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], array
+        ],
+        /,
+    ) -> array:
         """
         Returns ``self[key]``.
 
@@ -1099,7 +1120,14 @@ class _array():
            Element-wise results must equal the results returned by the equivalent element-wise function :func:`~array_api.bitwise_right_shift`.
         """
 
-    def __setitem__(self: array, key: Union[int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], array], value: Union[int, float, bool, array], /) -> None:
+    def __setitem__(
+        self: array,
+        key: Union[
+            int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], array
+        ],
+        value: Union[int, float, bool, array],
+        /,
+    ) -> None:
         """
         Sets ``self[key]`` to ``value``.
 
@@ -1196,17 +1224,17 @@ class _array():
         +------------+----------------+-----------------+--------------------------+
 
         In general, for complex floating-point operands, real-valued floating-point special cases must independently apply to the real and imaginary component operations involving real numbers as described in the above table.
-        
+
         When ``a``, ``b``, ``c``, or ``d`` are all finite numbers (i.e., a value other than ``NaN``, ``+infinity``, or ``-infinity``), division of complex floating-point operands should be computed as if calculated according to the textbook formula for complex number division
-       
+
         .. math::
            \frac{a + bj}{c + dj} = \frac{(ac + bd) + (bc - ad)j}{c^2 + d^2}
-        
+
         When at least one of ``a``, ``b``, ``c``, or ``d`` is ``NaN``, ``+infinity``, or ``-infinity``,
-        
+
         - If ``a``, ``b``, ``c``, and ``d`` are all ``NaN``, the result is ``NaN + NaN j``.
         - In the remaining cases, the result is implementation dependent.
-        
+
         .. note::
            For complex floating-point operands, the results of special cases may be implementation dependent depending on how an implementation chooses to model complex numbers and complex infinity (e.g., complex plane versus Riemann sphere). For those implementations following C99 and its one-infinity model, when at least one component is infinite, even if the other component is ``NaN``, the complex value is infinite, and the usual arithmetic rules do not apply to complex-complex division. In the interest of performance, other implementations may want to avoid the complex branching logic necessary to implement the one-infinity model and choose to implement all complex-complex division according to the textbook formula. Accordingly, special case behavior is unlikely to be consistent across implementations.
 
@@ -1248,7 +1276,9 @@ class _array():
            Element-wise results must equal the results returned by the equivalent element-wise function :func:`~array_api.bitwise_xor`.
         """
 
-    def to_device(self: array, device: Device, /, *, stream: Optional[Union[int, Any]] = None) -> array:
+    def to_device(
+        self: array, device: Device, /, *, stream: Optional[Union[int, Any]] = None
+    ) -> array:
         """
         Copy the array from the device on which it currently resides to the specified ``device``.
 
@@ -1271,6 +1301,7 @@ class _array():
            If ``stream`` is given, the copy operation should be enqueued on the provided ``stream``; otherwise, the copy operation should be enqueued on the default stream/queue. Whether the copy is performed synchronously or asynchronously is implementation-dependent. Accordingly, if synchronization is required to guarantee data safety, this must be clearly explained in a conforming library's documentation.
         """
 
+
 array = _array
 
-__all__ = ['array']
+__all__ = ["array"]

--- a/spec/API_specification/array_api/constants.py
+++ b/spec/API_specification/array_api/constants.py
@@ -5,12 +5,12 @@ IEEE 754 floating-point representation of Euler's constant.
 ``e = 2.71828182845904523536028747135266249775724709369995...``
 """
 
-inf = float('inf')
+inf = float("inf")
 """
 IEEE 754 floating-point representation of (positive) infinity.
 """
 
-nan = float('nan')
+nan = float("nan")
 """
 IEEE 754 floating-point representation of Not a Number (``NaN``).
 """
@@ -27,4 +27,4 @@ IEEE 754 floating-point representation of the mathematical constant ``π``.
 ``pi = 3.1415926535897932384626433...``
 """
 
-__all__ = ['e', 'inf', 'nan', 'newaxis', 'pi']
+__all__ = ["e", "inf", "nan", "newaxis", "pi"]

--- a/spec/API_specification/array_api/creation_functions.py
+++ b/spec/API_specification/array_api/creation_functions.py
@@ -156,7 +156,7 @@ def eye(
     dtype: Optional[dtype] = None,
     device: Optional[device] = None,
 ) -> array:
-    """
+    r"""
     Returns a two-dimensional array with ones on the ``k``\th diagonal and zeros elsewhere.
 
     .. note::

--- a/spec/API_specification/array_api/creation_functions.py
+++ b/spec/API_specification/array_api/creation_functions.py
@@ -1,7 +1,25 @@
-from ._types import (List, NestedSequence, Optional, SupportsBufferProtocol, Tuple, Union, array,
-                     device, dtype)
+from ._types import (
+    List,
+    NestedSequence,
+    Optional,
+    SupportsBufferProtocol,
+    Tuple,
+    Union,
+    array,
+    device,
+    dtype,
+)
 
-def arange(start: Union[int, float], /, stop: Optional[Union[int, float]] = None, step: Union[int, float] = 1, *, dtype: Optional[dtype] = None, device: Optional[device] = None) -> array:
+
+def arange(
+    start: Union[int, float],
+    /,
+    stop: Optional[Union[int, float]] = None,
+    step: Union[int, float] = 1,
+    *,
+    dtype: Optional[dtype] = None,
+    device: Optional[device] = None,
+) -> array:
     """
     Returns evenly spaced values within the half-open interval ``[start, stop)`` as a one-dimensional array.
 
@@ -28,7 +46,17 @@ def arange(start: Union[int, float], /, stop: Optional[Union[int, float]] = None
         a one-dimensional array containing evenly spaced values. The length of the output array must be ``ceil((stop-start)/step)`` if ``stop - start`` and ``step`` have the same sign, and length ``0`` otherwise.
     """
 
-def asarray(obj: Union[array, bool, int, float, complex, NestedSequence, SupportsBufferProtocol], /, *, dtype: Optional[dtype] = None, device: Optional[device] = None, copy: Optional[bool] = None) -> array:
+
+def asarray(
+    obj: Union[
+        array, bool, int, float, complex, NestedSequence, SupportsBufferProtocol
+    ],
+    /,
+    *,
+    dtype: Optional[dtype] = None,
+    device: Optional[device] = None,
+    copy: Optional[bool] = None,
+) -> array:
     r"""
     Convert the input to an array.
 
@@ -71,7 +99,13 @@ def asarray(obj: Union[array, bool, int, float, complex, NestedSequence, Support
         an array containing the data from ``obj``.
     """
 
-def empty(shape: Union[int, Tuple[int, ...]], *, dtype: Optional[dtype] = None, device: Optional[device] = None) -> array:
+
+def empty(
+    shape: Union[int, Tuple[int, ...]],
+    *,
+    dtype: Optional[dtype] = None,
+    device: Optional[device] = None,
+) -> array:
     """
     Returns an uninitialized array having a specified `shape`.
 
@@ -90,7 +124,10 @@ def empty(shape: Union[int, Tuple[int, ...]], *, dtype: Optional[dtype] = None, 
         an array containing uninitialized data.
     """
 
-def empty_like(x: array, /, *, dtype: Optional[dtype] = None, device: Optional[device] = None) -> array:
+
+def empty_like(
+    x: array, /, *, dtype: Optional[dtype] = None, device: Optional[device] = None
+) -> array:
     """
     Returns an uninitialized array with the same ``shape`` as an input array ``x``.
 
@@ -109,12 +146,21 @@ def empty_like(x: array, /, *, dtype: Optional[dtype] = None, device: Optional[d
         an array having the same shape as ``x`` and containing uninitialized data.
     """
 
-def eye(n_rows: int, n_cols: Optional[int] = None, /, *, k: int = 0, dtype: Optional[dtype] = None, device: Optional[device] = None) -> array:
+
+def eye(
+    n_rows: int,
+    n_cols: Optional[int] = None,
+    /,
+    *,
+    k: int = 0,
+    dtype: Optional[dtype] = None,
+    device: Optional[device] = None,
+) -> array:
     """
     Returns a two-dimensional array with ones on the ``k``\th diagonal and zeros elsewhere.
 
     .. note::
-       An output array having a complex floating-point data type must have the value ``1 + 0j`` along the ``k``\th diagonal and ``0 + 0j`` elsewhere. 
+       An output array having a complex floating-point data type must have the value ``1 + 0j`` along the ``k``\th diagonal and ``0 + 0j`` elsewhere.
 
     Parameters
     ----------
@@ -134,6 +180,7 @@ def eye(n_rows: int, n_cols: Optional[int] = None, /, *, k: int = 0, dtype: Opti
     out: array
         an array where all elements are equal to zero, except for the ``k``\th diagonal, whose values are equal to one.
     """
+
 
 def from_dlpack(x: object, /) -> array:
     """
@@ -155,7 +202,14 @@ def from_dlpack(x: object, /) -> array:
            The returned array may be either a copy or a view. See :ref:`data-interchange` for details.
     """
 
-def full(shape: Union[int, Tuple[int, ...]], fill_value: Union[bool, int, float, complex], *, dtype: Optional[dtype] = None, device: Optional[device] = None) -> array:
+
+def full(
+    shape: Union[int, Tuple[int, ...]],
+    fill_value: Union[bool, int, float, complex],
+    *,
+    dtype: Optional[dtype] = None,
+    device: Optional[device] = None,
+) -> array:
     """
     Returns a new array having a specified ``shape`` and filled with ``fill_value``.
 
@@ -185,7 +239,15 @@ def full(shape: Union[int, Tuple[int, ...]], fill_value: Union[bool, int, float,
         an array where every element is equal to ``fill_value``.
     """
 
-def full_like(x: array, /, fill_value: Union[bool, int, float, complex], *, dtype: Optional[dtype] = None, device: Optional[device] = None) -> array:
+
+def full_like(
+    x: array,
+    /,
+    fill_value: Union[bool, int, float, complex],
+    *,
+    dtype: Optional[dtype] = None,
+    device: Optional[device] = None,
+) -> array:
     """
     Returns a new array filled with ``fill_value`` and having the same ``shape`` as an input array ``x``.
 
@@ -213,7 +275,17 @@ def full_like(x: array, /, fill_value: Union[bool, int, float, complex], *, dtyp
         an array having the same shape as ``x`` and where every element is equal to ``fill_value``.
     """
 
-def linspace(start: Union[int, float, complex], stop: Union[int, float, complex], /, num: int, *, dtype: Optional[dtype] = None, device: Optional[device] = None, endpoint: bool = True) -> array:
+
+def linspace(
+    start: Union[int, float, complex],
+    stop: Union[int, float, complex],
+    /,
+    num: int,
+    *,
+    dtype: Optional[dtype] = None,
+    device: Optional[device] = None,
+    endpoint: bool = True,
+) -> array:
     r"""
     Returns evenly spaced numbers over a specified interval.
 
@@ -270,7 +342,8 @@ def linspace(start: Union[int, float, complex], stop: Union[int, float, complex]
        As mixed data type promotion is implementation-defined, behavior when ``start`` or ``stop`` exceeds the maximum safe integer of an output floating-point data type is implementation-defined. An implementation may choose to overflow or raise an exception.
     """
 
-def meshgrid(*arrays: array, indexing: str = 'xy') -> List[array]:
+
+def meshgrid(*arrays: array, indexing: str = "xy") -> List[array]:
     """
     Returns coordinate matrices from coordinate vectors.
 
@@ -296,12 +369,18 @@ def meshgrid(*arrays: array, indexing: str = 'xy') -> List[array]:
         Each returned array should have the same data type as the input arrays.
     """
 
-def ones(shape: Union[int, Tuple[int, ...]], *, dtype: Optional[dtype] = None, device: Optional[device] = None) -> array:
+
+def ones(
+    shape: Union[int, Tuple[int, ...]],
+    *,
+    dtype: Optional[dtype] = None,
+    device: Optional[device] = None,
+) -> array:
     """
     Returns a new array having a specified ``shape`` and filled with ones.
 
     .. note::
-       An output array having a complex floating-point data type must contain complex numbers having a real component equal to one and an imaginary component equal to zero (i.e., ``1 + 0j``).  
+       An output array having a complex floating-point data type must contain complex numbers having a real component equal to one and an imaginary component equal to zero (i.e., ``1 + 0j``).
 
     Parameters
     ----------
@@ -318,12 +397,15 @@ def ones(shape: Union[int, Tuple[int, ...]], *, dtype: Optional[dtype] = None, d
         an array containing ones.
     """
 
-def ones_like(x: array, /, *, dtype: Optional[dtype] = None, device: Optional[device] = None) -> array:
+
+def ones_like(
+    x: array, /, *, dtype: Optional[dtype] = None, device: Optional[device] = None
+) -> array:
     """
     Returns a new array filled with ones and having the same ``shape`` as an input array ``x``.
 
     .. note::
-       An output array having a complex floating-point data type must contain complex numbers having a real component equal to one and an imaginary component equal to zero (i.e., ``1 + 0j``).  
+       An output array having a complex floating-point data type must contain complex numbers having a real component equal to one and an imaginary component equal to zero (i.e., ``1 + 0j``).
 
     Parameters
     ----------
@@ -339,6 +421,7 @@ def ones_like(x: array, /, *, dtype: Optional[dtype] = None, device: Optional[de
     out: array
         an array having the same shape as ``x`` and filled with ones.
     """
+
 
 def tril(x: array, /, *, k: int = 0) -> array:
     """
@@ -363,6 +446,7 @@ def tril(x: array, /, *, k: int = 0) -> array:
         an array containing the lower triangular part(s). The returned array must have the same shape and data type as ``x``. All elements above the specified diagonal ``k`` must be zeroed. The returned array should be allocated on the same device as ``x``.
     """
 
+
 def triu(x: array, /, *, k: int = 0) -> array:
     """
     Returns the upper triangular part of a matrix (or a stack of matrices) ``x``.
@@ -386,7 +470,13 @@ def triu(x: array, /, *, k: int = 0) -> array:
         an array containing the upper triangular part(s). The returned array must have the same shape and data type as ``x``. All elements below the specified diagonal ``k`` must be zeroed. The returned array should be allocated on the same device as ``x``.
     """
 
-def zeros(shape: Union[int, Tuple[int, ...]], *, dtype: Optional[dtype] = None, device: Optional[device] = None) -> array:
+
+def zeros(
+    shape: Union[int, Tuple[int, ...]],
+    *,
+    dtype: Optional[dtype] = None,
+    device: Optional[device] = None,
+) -> array:
     """
     Returns a new array having a specified ``shape`` and filled with zeros.
 
@@ -405,7 +495,10 @@ def zeros(shape: Union[int, Tuple[int, ...]], *, dtype: Optional[dtype] = None, 
         an array containing zeros.
     """
 
-def zeros_like(x: array, /, *, dtype: Optional[dtype] = None, device: Optional[device] = None) -> array:
+
+def zeros_like(
+    x: array, /, *, dtype: Optional[dtype] = None, device: Optional[device] = None
+) -> array:
     """
     Returns a new array filled with zeros and having the same ``shape`` as an input array ``x``.
 
@@ -424,4 +517,22 @@ def zeros_like(x: array, /, *, dtype: Optional[dtype] = None, device: Optional[d
         an array having the same shape as ``x`` and filled with zeros.
     """
 
-__all__ = ['arange', 'asarray', 'empty', 'empty_like', 'eye', 'from_dlpack', 'full', 'full_like', 'linspace', 'meshgrid', 'ones', 'ones_like', 'tril', 'triu', 'zeros', 'zeros_like']
+
+__all__ = [
+    "arange",
+    "asarray",
+    "empty",
+    "empty_like",
+    "eye",
+    "from_dlpack",
+    "full",
+    "full_like",
+    "linspace",
+    "meshgrid",
+    "ones",
+    "ones_like",
+    "tril",
+    "triu",
+    "zeros",
+    "zeros_like",
+]

--- a/spec/API_specification/array_api/data_type_functions.py
+++ b/spec/API_specification/array_api/data_type_functions.py
@@ -1,5 +1,6 @@
 from ._types import Union, Tuple, array, dtype, finfo_object, iinfo_object
 
+
 def astype(x: array, dtype: dtype, /, *, copy: bool = True) -> array:
     """
     Copies an array to a specified data type irrespective of :ref:`type-promotion` rules.
@@ -37,6 +38,7 @@ def astype(x: array, dtype: dtype, /, *, copy: bool = True) -> array:
         an array having the specified data type. The returned array must have the same shape as ``x``.
     """
 
+
 def can_cast(from_: Union[dtype, array], to: dtype, /) -> bool:
     """
     Determines if one data type can be cast to another data type according :ref:`type-promotion` rules.
@@ -53,6 +55,7 @@ def can_cast(from_: Union[dtype, array], to: dtype, /) -> bool:
     out: bool
         ``True`` if the cast can occur according to :ref:`type-promotion` rules; otherwise, ``False``.
     """
+
 
 def finfo(type: Union[dtype, array], /) -> finfo_object:
     """
@@ -96,6 +99,7 @@ def finfo(type: Union[dtype, array], /) -> finfo_object:
           real-valued floating-point data type.
     """
 
+
 def iinfo(type: Union[dtype, array], /) -> iinfo_object:
     """
     Machine limits for integer data types.
@@ -127,7 +131,10 @@ def iinfo(type: Union[dtype, array], /) -> iinfo_object:
           integer data type.
     """
 
-def isdtype(dtype: dtype, kind: Union[dtype, str, Tuple[Union[dtype, str], ...]]) -> bool:
+
+def isdtype(
+    dtype: dtype, kind: Union[dtype, str, Tuple[Union[dtype, str], ...]]
+) -> bool:
     """
     Returns a boolean indicating whether a provided dtype is of a specified data type "kind".
 
@@ -142,7 +149,7 @@ def isdtype(dtype: dtype, kind: Union[dtype, str, Tuple[Union[dtype, str], ...]]
         -   If ``kind`` is a string, the function must return a boolean indicating whether the input ``dtype`` is of a specified data type kind. The following dtype kinds must be supported:
 
             -   **bool**: boolean data types (e.g., ``bool``).
-            -   **signed integer**: signed integer data types (e.g., ``int8``, ``int16``, ``int32``, ``int64``). 
+            -   **signed integer**: signed integer data types (e.g., ``int8``, ``int16``, ``int32``, ``int64``).
             -   **unsigned integer**: unsigned integer data types (e.g., ``uint8``, ``uint16``, ``uint32``, ``uint64``).
             -   **integral**: integer data types. Shorthand for ``('signed integer', 'unsigned integer')``.
             -   **real floating**: real-valued floating-point data types (e.g., ``float32``, ``float64``).
@@ -162,6 +169,7 @@ def isdtype(dtype: dtype, kind: Union[dtype, str, Tuple[Union[dtype, str], ...]]
         boolean indicating whether a provided dtype is of a specified data type kind.
     """
 
+
 def result_type(*arrays_and_dtypes: Union[array, dtype]) -> dtype:
     """
     Returns the dtype that results from applying the type promotion rules (see :ref:`type-promotion`) to the arguments.
@@ -180,4 +188,5 @@ def result_type(*arrays_and_dtypes: Union[array, dtype]) -> dtype:
         the dtype resulting from an operation involving the input arrays and dtypes.
     """
 
-__all__ = ['astype', 'can_cast', 'finfo', 'iinfo', 'isdtype', 'result_type']
+
+__all__ = ["astype", "can_cast", "finfo", "iinfo", "isdtype", "result_type"]

--- a/spec/API_specification/array_api/data_types.py
+++ b/spec/API_specification/array_api/data_types.py
@@ -1,5 +1,6 @@
 from ._types import dtype
 
+
 def __eq__(self: dtype, other: dtype, /) -> bool:
     """
     Computes the truth value of ``self == other`` in order to test for data type object equality.
@@ -17,4 +18,5 @@ def __eq__(self: dtype, other: dtype, /) -> bool:
         a boolean indicating whether the data type objects are equal.
     """
 
-__all__ = ['__eq__']
+
+__all__ = ["__eq__"]

--- a/spec/API_specification/array_api/elementwise_functions.py
+++ b/spec/API_specification/array_api/elementwise_functions.py
@@ -1,5 +1,6 @@
 from ._types import array
 
+
 def abs(x: array, /) -> array:
     r"""
     Calculates the absolute value for each element ``x_i`` of the input array ``x``.
@@ -50,6 +51,7 @@ def abs(x: array, /) -> array:
         an array containing the absolute value of each element in ``x``. If ``x`` has a real-valued data type, the returned array must have the same data type as ``x``. If ``x`` has a complex floating-point data type, the returned arrayed must have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then the returned array must have a ``float64`` data type).
     """
 
+
 def acos(x: array, /) -> array:
     r"""
     Calculates an implementation-dependent approximation of the principal value of the inverse cosine for each element ``x_i`` of the input array ``x``.
@@ -81,7 +83,7 @@ def acos(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
 
     .. note::
-       The principal value of the arc cosine of a complex number :math:`z` is 
+       The principal value of the arc cosine of a complex number :math:`z` is
 
        .. math::
           \operatorname{acos}(z) = \frac{1}{2}\pi + j\ \ln(zj + \sqrt{1-z^2})
@@ -99,7 +101,7 @@ def acos(x: array, /) -> array:
 
        Accordingly, for complex arguments, the function returns the inverse cosine in the range of a strip unbounded along the imaginary axis and in the interval :math:`[0, \pi]` along the real axis.
 
-       *Note: branch cuts have provisional status* (see :ref:`branch-cuts`). 
+       *Note: branch cuts have provisional status* (see :ref:`branch-cuts`).
 
     Parameters
     ----------
@@ -111,6 +113,7 @@ def acos(x: array, /) -> array:
     out: array
         an array containing the inverse cosine of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def acosh(x: array, /) -> array:
     r"""
@@ -179,6 +182,7 @@ def acosh(x: array, /) -> array:
         an array containing the inverse hyperbolic cosine of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def add(x1: array, x2: array, /) -> array:
     """
     Calculates the sum for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
@@ -240,6 +244,7 @@ def add(x1: array, x2: array, /) -> array:
         an array containing the element-wise sums. The returned array must have a data type determined by :ref:`type-promotion`.
     """
 
+
 def asin(x: array, /) -> array:
     r"""
     Calculates an implementation-dependent approximation of the principal value of the inverse sine for each element ``x_i`` of the input array ``x``.
@@ -267,7 +272,7 @@ def asin(x: array, /) -> array:
        For any :math:`z`,
 
        .. math::
-          \operatorname{asin}(z) = \operatorname{acos}(-z) - \frac{\pi}{2} 
+          \operatorname{asin}(z) = \operatorname{acos}(-z) - \frac{\pi}{2}
 
     .. note::
        For complex floating-point operands, ``asin(conj(x))`` must equal ``conj(asin(x))``.
@@ -277,7 +282,7 @@ def asin(x: array, /) -> array:
 
        Accordingly, for complex arguments, the function returns the inverse sine in the range of a strip unbounded along the imaginary axis and in the interval :math:`[-\pi/2, +\pi/2]` along the real axis.
 
-       *Note: branch cuts have provisional status* (see :ref:`branch-cuts`). 
+       *Note: branch cuts have provisional status* (see :ref:`branch-cuts`).
 
     Parameters
     ----------
@@ -289,6 +294,7 @@ def asin(x: array, /) -> array:
     out: array
         an array containing the inverse sine of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def asinh(x: array, /) -> array:
     r"""
@@ -348,6 +354,7 @@ def asinh(x: array, /) -> array:
         an array containing the inverse hyperbolic sine of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def atan(x: array, /) -> array:
     r"""
     Calculates an implementation-dependent approximation of the principal value of the inverse tangent for each element ``x_i`` of the input array ``x``.
@@ -392,6 +399,7 @@ def atan(x: array, /) -> array:
     out: array
         an array containing the inverse tangent of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def atan2(x1: array, x2: array, /) -> array:
     """
@@ -445,6 +453,7 @@ def atan2(x1: array, x2: array, /) -> array:
         an array containing the inverse tangent of the quotient ``x1/x2``. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`.
 
     """
+
 
 def atanh(x: array, /) -> array:
     r"""
@@ -508,6 +517,7 @@ def atanh(x: array, /) -> array:
         an array containing the inverse hyperbolic tangent of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def bitwise_and(x1: array, x2: array, /) -> array:
     """
     Computes the bitwise AND of the underlying binary representation of each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
@@ -524,6 +534,7 @@ def bitwise_and(x1: array, x2: array, /) -> array:
     out: array
         an array containing the element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
     """
+
 
 def bitwise_left_shift(x1: array, x2: array, /) -> array:
     """
@@ -542,6 +553,7 @@ def bitwise_left_shift(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
     """
 
+
 def bitwise_invert(x: array, /) -> array:
     """
     Inverts (flips) each bit for each element ``x_i`` of the input array ``x``.
@@ -556,6 +568,7 @@ def bitwise_invert(x: array, /) -> array:
     out: array
         an array containing the element-wise results. The returned array must have the same data type as ``x``.
     """
+
 
 def bitwise_or(x1: array, x2: array, /) -> array:
     """
@@ -573,6 +586,7 @@ def bitwise_or(x1: array, x2: array, /) -> array:
     out: array
         an array containing the element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
     """
+
 
 def bitwise_right_shift(x1: array, x2: array, /) -> array:
     """
@@ -594,6 +608,7 @@ def bitwise_right_shift(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
     """
 
+
 def bitwise_xor(x1: array, x2: array, /) -> array:
     """
     Computes the bitwise XOR of the underlying binary representation of each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
@@ -610,6 +625,7 @@ def bitwise_xor(x1: array, x2: array, /) -> array:
     out: array
         an array containing the element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
     """
+
 
 def ceil(x: array, /) -> array:
     """
@@ -637,6 +653,7 @@ def ceil(x: array, /) -> array:
     out: array
         an array containing the rounded result for each element in ``x``. The returned array must have the same data type as ``x``.
     """
+
 
 def conj(x: array, /) -> array:
     """
@@ -706,6 +723,7 @@ def cos(x: array, /) -> array:
         an array containing the cosine of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def cosh(x: array, /) -> array:
     r"""
     Calculates an implementation-dependent approximation to the hyperbolic cosine for each element ``x_i`` in the input array ``x``.
@@ -762,6 +780,7 @@ def cosh(x: array, /) -> array:
         an array containing the hyperbolic cosine of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def divide(x1: array, x2: array, /) -> array:
     r"""
     Calculates the division of each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
@@ -811,17 +830,17 @@ def divide(x1: array, x2: array, /) -> array:
     +------------+----------------+-----------------+--------------------------+
 
     In general, for complex floating-point operands, real-valued floating-point special cases must independently apply to the real and imaginary component operations involving real numbers as described in the above table.
-    
+
     When ``a``, ``b``, ``c``, or ``d`` are all finite numbers (i.e., a value other than ``NaN``, ``+infinity``, or ``-infinity``), division of complex floating-point operands should be computed as if calculated according to the textbook formula for complex number division
-   
+
     .. math::
        \frac{a + bj}{c + dj} = \frac{(ac + bd) + (bc - ad)j}{c^2 + d^2}
-    
+
     When at least one of ``a``, ``b``, ``c``, or ``d`` is ``NaN``, ``+infinity``, or ``-infinity``,
-    
+
     - If ``a``, ``b``, ``c``, and ``d`` are all ``NaN``, the result is ``NaN + NaN j``.
     - In the remaining cases, the result is implementation dependent.
-    
+
     .. note::
        For complex floating-point operands, the results of special cases may be implementation dependent depending on how an implementation chooses to model complex numbers and complex infinity (e.g., complex plane versus Riemann sphere). For those implementations following C99 and its one-infinity model, when at least one component is infinite, even if the other component is ``NaN``, the complex value is infinite, and the usual arithmetic rules do not apply to complex-complex division. In the interest of performance, other implementations may want to avoid the complex branching logic necessary to implement the one-infinity model and choose to implement all complex-complex division according to the textbook formula. Accordingly, special case behavior is unlikely to be consistent across implementations.
 
@@ -837,6 +856,7 @@ def divide(x1: array, x2: array, /) -> array:
     out: array
         an array containing the element-wise results. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def equal(x1: array, x2: array, /) -> array:
     r"""
@@ -874,6 +894,7 @@ def equal(x1: array, x2: array, /) -> array:
     out: array
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
     """
+
 
 def exp(x: array, /) -> array:
     """
@@ -923,6 +944,7 @@ def exp(x: array, /) -> array:
     out: array
         an array containing the evaluated exponential function result for each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def expm1(x: array, /) -> array:
     """
@@ -976,6 +998,7 @@ def expm1(x: array, /) -> array:
         an array containing the evaluated result for each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def floor(x: array, /) -> array:
     """
     Rounds each element ``x_i`` of the input array ``x`` to the greatest (i.e., closest to ``+infinity``) integer-valued number that is not greater than ``x_i``.
@@ -1002,6 +1025,7 @@ def floor(x: array, /) -> array:
     out: array
         an array containing the rounded result for each element in ``x``. The returned array must have the same data type as ``x``.
     """
+
 
 def floor_divide(x1: array, x2: array, /) -> array:
     r"""
@@ -1059,6 +1083,7 @@ def floor_divide(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
     """
 
+
 def greater(x1: array, x2: array, /) -> array:
     """
     Computes the truth value of ``x1_i > x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
@@ -1078,6 +1103,7 @@ def greater(x1: array, x2: array, /) -> array:
     out: array
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
     """
+
 
 def greater_equal(x1: array, x2: array, /) -> array:
     """
@@ -1099,6 +1125,7 @@ def greater_equal(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
     """
 
+
 def imag(x: array, /) -> array:
     """
     Returns the imaginary component of a complex number for each element ``x_i`` of the input array ``x``.
@@ -1111,8 +1138,9 @@ def imag(x: array, /) -> array:
     Returns
     -------
     out: array
-        an array containing the element-wise results. The returned array must have a floating-point data type with the same floating-point precision as ``x`` (e.g., if ``x`` is ``complex64``, the returned array must have the floating-point data type ``float32``). 
+        an array containing the element-wise results. The returned array must have a floating-point data type with the same floating-point precision as ``x`` (e.g., if ``x`` is ``complex64``, the returned array must have the floating-point data type ``float32``).
     """
+
 
 def isfinite(x: array, /) -> array:
     """
@@ -1144,6 +1172,7 @@ def isfinite(x: array, /) -> array:
         an array containing test results. The returned array must have a data type of ``bool``.
     """
 
+
 def isinf(x: array, /) -> array:
     """
     Tests each element ``x_i`` of the input array ``x`` to determine if equal to positive or negative infinity.
@@ -1172,6 +1201,7 @@ def isinf(x: array, /) -> array:
         an array containing test results. The returned array must have a data type of ``bool``.
     """
 
+
 def isnan(x: array, /) -> array:
     """
     Tests each element ``x_i`` of the input array ``x`` to determine whether the element is ``NaN``.
@@ -1199,6 +1229,7 @@ def isnan(x: array, /) -> array:
         an array containing test results. The returned array should have a data type of ``bool``.
     """
 
+
 def less(x1: array, x2: array, /) -> array:
     """
     Computes the truth value of ``x1_i < x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
@@ -1219,6 +1250,7 @@ def less(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
     """
 
+
 def less_equal(x1: array, x2: array, /) -> array:
     """
     Computes the truth value of ``x1_i <= x2_i`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
@@ -1238,6 +1270,7 @@ def less_equal(x1: array, x2: array, /) -> array:
     out: array
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
     """
+
 
 def log(x: array, /) -> array:
     r"""
@@ -1281,7 +1314,7 @@ def log(x: array, /) -> array:
 
        Accordingly, for complex arguments, the function returns the natural logarithm in the range of a strip in the interval :math:`[-\pi j, +\pi j]` along the imaginary axis and mathematically unbounded along the real axis.
 
-       *Note: branch cuts have provisional status* (see :ref:`branch-cuts`). 
+       *Note: branch cuts have provisional status* (see :ref:`branch-cuts`).
 
     Parameters
     ----------
@@ -1293,6 +1326,7 @@ def log(x: array, /) -> array:
     out: array
         an array containing the evaluated natural logarithm for each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def log1p(x: array, /) -> array:
     r"""
@@ -1328,7 +1362,7 @@ def log1p(x: array, /) -> array:
 
     .. note::
        For complex floating-point operands, ``log1p(conj(x))`` must equal ``conj(log1p(x))``.
-    
+
     .. note::
        By convention, the branch cut of the natural logarithm is the negative real axis :math:`(-\infty, 0)`.
 
@@ -1348,6 +1382,7 @@ def log1p(x: array, /) -> array:
     out: array
         an array containing the evaluated result for each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def log2(x: array, /) -> array:
     r"""
@@ -1384,6 +1419,7 @@ def log2(x: array, /) -> array:
         an array containing the evaluated base ``2`` logarithm for each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def log10(x: array, /) -> array:
     r"""
     Calculates an implementation-dependent approximation to the base ``10`` logarithm for each element ``x_i`` of the input array ``x``.
@@ -1419,6 +1455,7 @@ def log10(x: array, /) -> array:
         an array containing the evaluated base ``10`` logarithm for each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def logaddexp(x1: array, x2: array, /) -> array:
     """
     Calculates the logarithm of the sum of exponentiations ``log(exp(x1) + exp(x2))`` for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
@@ -1444,6 +1481,7 @@ def logaddexp(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def logical_and(x1: array, x2: array, /) -> array:
     """
     Computes the logical AND for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
@@ -1464,6 +1502,7 @@ def logical_and(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. The returned array must have a data type of `bool`.
     """
 
+
 def logical_not(x: array, /) -> array:
     """
     Computes the logical NOT for each element ``x_i`` of the input array ``x``.
@@ -1481,6 +1520,7 @@ def logical_not(x: array, /) -> array:
     out: array
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
     """
+
 
 def logical_or(x1: array, x2: array, /) -> array:
     """
@@ -1502,6 +1542,7 @@ def logical_or(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
     """
 
+
 def logical_xor(x1: array, x2: array, /) -> array:
     """
     Computes the logical XOR for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
@@ -1521,6 +1562,7 @@ def logical_xor(x1: array, x2: array, /) -> array:
     out: array
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
     """
+
 
 def multiply(x1: array, x2: array, /) -> array:
     r"""
@@ -1583,6 +1625,7 @@ def multiply(x1: array, x2: array, /) -> array:
         an array containing the element-wise products. The returned array must have a data type determined by :ref:`type-promotion`.
     """
 
+
 def negative(x: array, /) -> array:
     """
     Computes the numerical negative of each element ``x_i`` (i.e., ``y_i = -x_i``) of the input array ``x``.
@@ -1603,6 +1646,7 @@ def negative(x: array, /) -> array:
     out: array
         an array containing the evaluated result for each element in ``x``. The returned array must have a data type determined by :ref:`type-promotion`.
     """
+
 
 def not_equal(x1: array, x2: array, /) -> array:
     """
@@ -1639,6 +1683,7 @@ def not_equal(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
     """
 
+
 def positive(x: array, /) -> array:
     """
     Computes the numerical positive of each element ``x_i`` (i.e., ``y_i = +x_i``) of the input array ``x``.
@@ -1653,6 +1698,7 @@ def positive(x: array, /) -> array:
     out: array
         an array containing the evaluated result for each element in ``x``. The returned array must have the same data type as ``x``.
     """
+
 
 def pow(x1: array, x2: array, /) -> array:
     r"""
@@ -1717,6 +1763,7 @@ def pow(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
     """
 
+
 def real(x: array, /) -> array:
     """
     Returns the real component of a complex number for each element ``x_i`` of the input array ``x``.
@@ -1729,8 +1776,9 @@ def real(x: array, /) -> array:
     Returns
     -------
     out: array
-        an array containing the element-wise results. The returned array must have a floating-point data type with the same floating-point precision as ``x`` (e.g., if ``x`` is ``complex64``, the returned array must have the floating-point data type ``float32``). 
+        an array containing the element-wise results. The returned array must have a floating-point data type with the same floating-point precision as ``x`` (e.g., if ``x`` is ``complex64``, the returned array must have the floating-point data type ``float32``).
     """
+
 
 def remainder(x1: array, x2: array, /) -> array:
     """
@@ -1783,13 +1831,14 @@ def remainder(x1: array, x2: array, /) -> array:
         an array containing the element-wise results. Each element-wise result must have the same sign as the respective element ``x2_i``. The returned array must have a data type determined by :ref:`type-promotion`.
     """
 
+
 def round(x: array, /) -> array:
     """
     Rounds each element ``x_i`` of the input array ``x`` to the nearest integer-valued number.
 
     .. note::
        For complex floating-point operands, real and imaginary components must be independently rounded to the nearest integer-valued number.
-    
+
        Rounded real and imaginary components must be equal to their equivalent rounded real-valued floating-point counterparts (i.e., for complex-valued ``x``, ``real(round(x))`` must equal ``round(real(x)))`` and ``imag(round(x))`` must equal ``round(imag(x))``).
 
     **Special cases**
@@ -1818,6 +1867,7 @@ def round(x: array, /) -> array:
     out: array
         an array containing the rounded result for each element in ``x``. The returned array must have the same data type as ``x``.
     """
+
 
 def sign(x: array, /) -> array:
     r"""
@@ -1859,6 +1909,7 @@ def sign(x: array, /) -> array:
         an array containing the evaluated result for each element in ``x``. The returned array must have the same data type as ``x``.
     """
 
+
 def sin(x: array, /) -> array:
     r"""
     Calculates an implementation-dependent approximation to the sine for each element ``x_i`` of the input array ``x``.
@@ -1897,6 +1948,7 @@ def sin(x: array, /) -> array:
     out: array
         an array containing the sine of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def sinh(x: array, /) -> array:
     r"""
@@ -1954,6 +2006,7 @@ def sinh(x: array, /) -> array:
         an array containing the hyperbolic sine of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def square(x: array, /) -> array:
     r"""
     Squares each element ``x_i`` of the input array ``x``.
@@ -1977,6 +2030,7 @@ def square(x: array, /) -> array:
     out: array
         an array containing the evaluated result for each element in ``x``. The returned array must have a data type determined by :ref:`type-promotion`.
     """
+
 
 def sqrt(x: array, /) -> array:
     r"""
@@ -2018,7 +2072,7 @@ def sqrt(x: array, /) -> array:
        Accordingly, for complex arguments, the function returns the square root in the range of the right half-plane, including the imaginary axis (i.e., the plane defined by :math:`[0, +\infty)` along the real axis and :math:`(-\infty, +\infty)` along the imaginary axis).
 
        *Note: branch cuts have provisional status* (see :ref:`branch-cuts`).
-    
+
     Parameters
     ----------
     x: array
@@ -2029,6 +2083,7 @@ def sqrt(x: array, /) -> array:
     out: array
         an array containing the square root of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def subtract(x1: array, x2: array, /) -> array:
     """
@@ -2048,6 +2103,7 @@ def subtract(x1: array, x2: array, /) -> array:
     out: array
         an array containing the element-wise differences. The returned array must have a data type determined by :ref:`type-promotion`.
     """
+
 
 def tan(x: array, /) -> array:
     r"""
@@ -2087,6 +2143,7 @@ def tan(x: array, /) -> array:
     out: array
         an array containing the tangent of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def tanh(x: array, /) -> array:
     r"""
@@ -2148,6 +2205,7 @@ def tanh(x: array, /) -> array:
         an array containing the hyperbolic tangent of each element in ``x``. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def trunc(x: array, /) -> array:
     """
     Rounds each element ``x_i`` of the input array ``x`` to the nearest integer-valued number that is closer to zero than ``x_i``.
@@ -2175,4 +2233,65 @@ def trunc(x: array, /) -> array:
         an array containing the rounded result for each element in ``x``. The returned array must have the same data type as ``x``.
     """
 
-__all__ = ['abs', 'acos', 'acosh', 'add', 'asin', 'asinh', 'atan', 'atan2', 'atanh', 'bitwise_and', 'bitwise_left_shift', 'bitwise_invert', 'bitwise_or', 'bitwise_right_shift', 'bitwise_xor', 'ceil', 'conj', 'cos', 'cosh', 'divide', 'equal', 'exp', 'expm1', 'floor', 'floor_divide', 'greater', 'greater_equal', 'imag', 'isfinite', 'isinf', 'isnan', 'less', 'less_equal', 'log', 'log1p', 'log2', 'log10', 'logaddexp', 'logical_and', 'logical_not', 'logical_or', 'logical_xor', 'multiply', 'negative', 'not_equal', 'positive', 'pow', 'real', 'remainder', 'round', 'sign', 'sin', 'sinh', 'square', 'sqrt', 'subtract', 'tan', 'tanh', 'trunc']
+
+__all__ = [
+    "abs",
+    "acos",
+    "acosh",
+    "add",
+    "asin",
+    "asinh",
+    "atan",
+    "atan2",
+    "atanh",
+    "bitwise_and",
+    "bitwise_left_shift",
+    "bitwise_invert",
+    "bitwise_or",
+    "bitwise_right_shift",
+    "bitwise_xor",
+    "ceil",
+    "conj",
+    "cos",
+    "cosh",
+    "divide",
+    "equal",
+    "exp",
+    "expm1",
+    "floor",
+    "floor_divide",
+    "greater",
+    "greater_equal",
+    "imag",
+    "isfinite",
+    "isinf",
+    "isnan",
+    "less",
+    "less_equal",
+    "log",
+    "log1p",
+    "log2",
+    "log10",
+    "logaddexp",
+    "logical_and",
+    "logical_not",
+    "logical_or",
+    "logical_xor",
+    "multiply",
+    "negative",
+    "not_equal",
+    "positive",
+    "pow",
+    "real",
+    "remainder",
+    "round",
+    "sign",
+    "sin",
+    "sinh",
+    "square",
+    "sqrt",
+    "subtract",
+    "tan",
+    "tanh",
+    "trunc",
+]

--- a/spec/API_specification/array_api/fft.py
+++ b/spec/API_specification/array_api/fft.py
@@ -1,7 +1,14 @@
 from ._types import Tuple, Union, Sequence, array, Optional, Literal, device
 
 
-def fft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal['backward', 'ortho', 'forward'] = 'backward') -> array:
+def fft(
+    x: array,
+    /,
+    *,
+    n: Optional[int] = None,
+    axis: int = -1,
+    norm: Literal["backward", "ortho", "forward"] = "backward",
+) -> array:
     """
     Computes the one-dimensional discrete Fourier transform.
 
@@ -40,7 +47,14 @@ def fft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal['
     """
 
 
-def ifft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal['backward', 'ortho', 'forward'] = 'backward') -> array:
+def ifft(
+    x: array,
+    /,
+    *,
+    n: Optional[int] = None,
+    axis: int = -1,
+    norm: Literal["backward", "ortho", "forward"] = "backward",
+) -> array:
     """
     Computes the one-dimensional inverse discrete Fourier transform.
 
@@ -79,7 +93,14 @@ def ifft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal[
     """
 
 
-def fftn(x: array, /, *, s: Sequence[int] = None, axes: Sequence[int] = None, norm: Literal['backward', 'ortho', 'forward'] = 'backward') -> array:
+def fftn(
+    x: array,
+    /,
+    *,
+    s: Sequence[int] = None,
+    axes: Sequence[int] = None,
+    norm: Literal["backward", "ortho", "forward"] = "backward",
+) -> array:
     """
     Computes the n-dimensional discrete Fourier transform.
 
@@ -125,7 +146,14 @@ def fftn(x: array, /, *, s: Sequence[int] = None, axes: Sequence[int] = None, no
     """
 
 
-def ifftn(x: array, /, *, s: Sequence[int] = None, axes: Sequence[int] = None, norm: Literal['backward', 'ortho', 'forward'] = 'backward') -> array:
+def ifftn(
+    x: array,
+    /,
+    *,
+    s: Sequence[int] = None,
+    axes: Sequence[int] = None,
+    norm: Literal["backward", "ortho", "forward"] = "backward",
+) -> array:
     """
     Computes the n-dimensional inverse discrete Fourier transform.
 
@@ -171,7 +199,14 @@ def ifftn(x: array, /, *, s: Sequence[int] = None, axes: Sequence[int] = None, n
     """
 
 
-def rfft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal['backward', 'ortho', 'forward'] = 'backward') -> array:
+def rfft(
+    x: array,
+    /,
+    *,
+    n: Optional[int] = None,
+    axis: int = -1,
+    norm: Literal["backward", "ortho", "forward"] = "backward",
+) -> array:
     """
     Computes the one-dimensional discrete Fourier transform for real-valued input.
 
@@ -210,7 +245,14 @@ def rfft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal[
     """
 
 
-def irfft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal['backward', 'ortho', 'forward'] = 'backward') -> array:
+def irfft(
+    x: array,
+    /,
+    *,
+    n: Optional[int] = None,
+    axis: int = -1,
+    norm: Literal["backward", "ortho", "forward"] = "backward",
+) -> array:
     """
     Computes the one-dimensional inverse of ``rfft`` for complex-valued input.
 
@@ -249,7 +291,14 @@ def irfft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal
     """
 
 
-def rfftn(x: array, /, *, s: Sequence[int] = None, axes: Sequence[int] = None, norm: Literal['backward', 'ortho', 'forward'] = 'backward') -> array:
+def rfftn(
+    x: array,
+    /,
+    *,
+    s: Sequence[int] = None,
+    axes: Sequence[int] = None,
+    norm: Literal["backward", "ortho", "forward"] = "backward",
+) -> array:
     """
     Computes the n-dimensional discrete Fourier transform for real-valued input.
 
@@ -295,7 +344,14 @@ def rfftn(x: array, /, *, s: Sequence[int] = None, axes: Sequence[int] = None, n
     """
 
 
-def irfftn(x: array, /, *, s: Sequence[int] = None, axes: Sequence[int] = None, norm: Literal['backward', 'ortho', 'forward'] = 'backward') -> array:
+def irfftn(
+    x: array,
+    /,
+    *,
+    s: Sequence[int] = None,
+    axes: Sequence[int] = None,
+    norm: Literal["backward", "ortho", "forward"] = "backward",
+) -> array:
     """
     Computes the n-dimensional inverse of ``rfftn`` for complex-valued input.
 
@@ -341,7 +397,14 @@ def irfftn(x: array, /, *, s: Sequence[int] = None, axes: Sequence[int] = None, 
     """
 
 
-def hfft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal['backward', 'ortho', 'forward'] = 'backward') -> array:
+def hfft(
+    x: array,
+    /,
+    *,
+    n: Optional[int] = None,
+    axis: int = -1,
+    norm: Literal["backward", "ortho", "forward"] = "backward",
+) -> array:
     """
     Computes the one-dimensional discrete Fourier transform of a signal with Hermitian symmetry.
 
@@ -377,7 +440,14 @@ def hfft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal[
     """
 
 
-def ihfft(x: array, /, *, n: Optional[int] = None, axis: int = -1, norm: Literal['backward', 'ortho', 'forward'] = 'backward') -> array:
+def ihfft(
+    x: array,
+    /,
+    *,
+    n: Optional[int] = None,
+    axis: int = -1,
+    norm: Literal["backward", "ortho", "forward"] = "backward",
+) -> array:
     """
     Computes the one-dimensional inverse discrete Fourier transform of a signal with Hermitian symmetry.
 
@@ -513,4 +583,19 @@ def ifftshift(x: array, /, *, axes: Union[int, Sequence[int]] = None) -> array:
     """
 
 
-__all__ = ['fft','ifft','fftn','ifftn','rfft','irfft','rfftn','irfftn','hfft','ihfft','fftfreq','rfftfreq','fftshift','ifftshift']
+__all__ = [
+    "fft",
+    "ifft",
+    "fftn",
+    "ifftn",
+    "rfft",
+    "irfft",
+    "rfftn",
+    "irfftn",
+    "hfft",
+    "ihfft",
+    "fftfreq",
+    "rfftfreq",
+    "fftshift",
+    "ifftshift",
+]

--- a/spec/API_specification/array_api/indexing_functions.py
+++ b/spec/API_specification/array_api/indexing_functions.py
@@ -1,5 +1,6 @@
 from ._types import Union, array
 
+
 def take(x: array, indices: array, /, *, axis: int) -> array:
     """
     Returns elements of an array along an axis.
@@ -24,4 +25,5 @@ def take(x: array, indices: array, /, *, axis: int) -> array:
         an array having the same data type as ``x``. The output array must have the same rank (i.e., number of dimensions) as ``x`` and must have the same shape as ``x``, except for the axis specified by ``axis`` whose size must equal the number of elements in ``indices``.
     """
 
-__all__ = ['take']
+
+__all__ = ["take"]

--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -228,9 +228,7 @@ def inv(x: array, /) -> array:
 
 
 def matmul(x1: array, x2: array, /) -> array:
-    """
-    Alias for :func:`~array_api.matmul`.
-    """
+    """Alias for :func:`~array_api.matmul`."""
 
 
 def matrix_norm(
@@ -332,9 +330,7 @@ def matrix_rank(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> a
 
 
 def matrix_transpose(x: array, /) -> array:
-    """
-    Alias for :func:`~array_api.matrix_transpose`.
-    """
+    """Alias for :func:`~array_api.matrix_transpose`."""
 
 
 def outer(x1: array, x2: array, /) -> array:
@@ -603,9 +599,7 @@ def tensordot(
     *,
     axes: Union[int, Tuple[Sequence[int], Sequence[int]]] = 2,
 ) -> array:
-    """
-    Alias for :func:`~array_api.tensordot`.
-    """
+    """Alias for :func:`~array_api.tensordot`."""
 
 
 def trace(x: array, /, *, offset: int = 0, dtype: Optional[dtype] = None) -> array:
@@ -660,9 +654,7 @@ def trace(x: array, /, *, offset: int = 0, dtype: Optional[dtype] = None) -> arr
 
 
 def vecdot(x1: array, x2: array, /, *, axis: int = None) -> array:
-    """
-    Alias for :func:`~array_api.vecdot`.
-    """
+    """Alias for :func:`~array_api.vecdot`."""
 
 
 def vector_norm(

--- a/spec/API_specification/array_api/linalg.py
+++ b/spec/API_specification/array_api/linalg.py
@@ -1,6 +1,7 @@
 from ._types import Literal, Optional, Tuple, Union, Sequence, array, dtype
 from .constants import inf
 
+
 def cholesky(x: array, /, *, upper: bool = False) -> array:
     r"""
     Returns the lower (upper) Cholesky decomposition of a complex Hermitian or real symmetric positive-definite matrix ``x``.
@@ -39,6 +40,7 @@ def cholesky(x: array, /, *, upper: bool = False) -> array:
         an array containing the Cholesky factors for each square matrix. If ``upper`` is ``False``, the returned array must contain lower-triangular matrices; otherwise, the returned array must contain upper-triangular matrices. The returned array must have a floating-point data type determined by :ref:`type-promotion` and must have the same shape as ``x``.
     """
 
+
 def cross(x1: array, x2: array, /, *, axis: int = -1) -> array:
     """
     Returns the cross product of 3-element vectors.
@@ -71,6 +73,7 @@ def cross(x1: array, x2: array, /, *, axis: int = -1) -> array:
     -   if the size of the axis over which to compute the cross product is not the same (before broadcasting) for both ``x1`` and ``x2``.
     """
 
+
 def det(x: array, /) -> array:
     """
     Returns the determinant of a square matrix (or a stack of square matrices) ``x``.
@@ -85,6 +88,7 @@ def det(x: array, /) -> array:
     out: array
         if ``x`` is a two-dimensional array, a zero-dimensional array containing the determinant; otherwise, a non-zero dimensional array containing the determinant for each square matrix. The returned array must have the same data type as ``x``.
     """
+
 
 def diagonal(x: array, /, *, offset: int = 0) -> array:
     """
@@ -108,6 +112,7 @@ def diagonal(x: array, /, *, offset: int = 0) -> array:
     out: array
         an array containing the diagonals and whose shape is determined by removing the last two dimensions and appending a dimension equal to the size of the resulting diagonals. The returned array must have the same data type as ``x``.
     """
+
 
 def eigh(x: array, /) -> Tuple[array]:
     r"""
@@ -154,6 +159,7 @@ def eigh(x: array, /) -> Tuple[array]:
        Eigenvalue sort order is left unspecified and is thus implementation-dependent.
     """
 
+
 def eigvalsh(x: array, /) -> array:
     r"""
     Returns the eigenvalues of a complex Hermitian or real symmetric matrix (or a stack of matrices) ``x``.
@@ -191,6 +197,7 @@ def eigvalsh(x: array, /) -> array:
        Eigenvalue sort order is left unspecified and is thus implementation-dependent.
     """
 
+
 def inv(x: array, /) -> array:
     r"""
     Returns the multiplicative inverse of a square matrix (or a stack of square matrices) ``x``.
@@ -219,12 +226,20 @@ def inv(x: array, /) -> array:
         an array containing the multiplicative inverses. The returned array must have a floating-point data type determined by :ref:`type-promotion` and must have the same shape as ``x``.
     """
 
+
 def matmul(x1: array, x2: array, /) -> array:
     """
     Alias for :func:`~array_api.matmul`.
     """
 
-def matrix_norm(x: array, /, *, keepdims: bool = False, ord: Optional[Union[int, float, Literal[inf, -inf, 'fro', 'nuc']]] = 'fro') -> array:
+
+def matrix_norm(
+    x: array,
+    /,
+    *,
+    keepdims: bool = False,
+    ord: Optional[Union[int, float, Literal[inf, -inf, "fro", "nuc"]]] = "fro",
+) -> array:
     """
     Computes the matrix norm of a matrix (or a stack of matrices) ``x``.
 
@@ -277,6 +292,7 @@ def matrix_norm(x: array, /, *, keepdims: bool = False, ord: Optional[Union[int,
         an array containing the norms for each ``MxN`` matrix. If ``keepdims`` is ``False``, the returned array must have a rank which is two less than the rank of ``x``. If ``x`` has a real-valued data type, the returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`. If ``x`` has a complex-valued data type, the returned array must have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then the returned array must have a ``float64`` data type).
     """
 
+
 def matrix_power(x: array, n: int, /) -> array:
     """
     Raises a square matrix (or a stack of square matrices) ``x`` to an integer power ``n``.
@@ -293,6 +309,7 @@ def matrix_power(x: array, n: int, /) -> array:
     out: array
         if ``n`` is equal to zero, an array containing the identity matrix for each square matrix. If ``n`` is less than zero, an array containing the inverse of each square matrix raised to the absolute value of ``n``, provided that each square matrix is invertible. If ``n`` is greater than zero, an array containing the result of raising each square matrix to the power ``n``. The returned array must have the same shape as ``x`` and a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def matrix_rank(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> array:
     """
@@ -313,10 +330,12 @@ def matrix_rank(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> a
         an array containing the ranks. The returned array must have the default integer data type and must have shape ``(...)`` (i.e., must have a shape equal to ``shape(x)[:-2]``).
     """
 
+
 def matrix_transpose(x: array, /) -> array:
     """
     Alias for :func:`~array_api.matrix_transpose`.
     """
+
 
 def outer(x1: array, x2: array, /) -> array:
     """
@@ -334,6 +353,7 @@ def outer(x1: array, x2: array, /) -> array:
     out: array
         a two-dimensional array containing the outer product and whose shape is ``(N, M)``. The returned array must have a data type determined by :ref:`type-promotion`.
     """
+
 
 def pinv(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> array:
     r"""
@@ -368,7 +388,10 @@ def pinv(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> array:
         an array containing the pseudo-inverse(s). The returned array must have a floating-point data type determined by :ref:`type-promotion` and must have shape ``(..., N, M)`` (i.e., must have the same shape as ``x``, except the innermost two dimensions must be transposed).
     """
 
-def qr(x: array, /, *, mode: Literal['reduced', 'complete'] = 'reduced') -> Tuple[array, array]:
+
+def qr(
+    x: array, /, *, mode: Literal["reduced", "complete"] = "reduced"
+) -> Tuple[array, array]:
     r"""
     Returns the QR decomposition of a full column rank matrix (or a stack of matrices).
 
@@ -424,6 +447,7 @@ def qr(x: array, /, *, mode: Literal['reduced', 'complete'] = 'reduced') -> Tupl
         Each returned array must have a floating-point data type determined by :ref:`type-promotion`.
     """
 
+
 def slogdet(x: array, /) -> Tuple[array, array]:
     r"""
     Returns the sign and the natural logarithm of the absolute value of the determinant of a square matrix (or a stack of square matrices) ``x``.
@@ -472,6 +496,7 @@ def slogdet(x: array, /) -> Tuple[array, array]:
         Each returned array must have shape ``shape(x)[:-2]``.
     """
 
+
 def solve(x1: array, x2: array, /) -> array:
     r"""
     Returns the solution of a square system of linear equations with a unique solution.
@@ -502,6 +527,7 @@ def solve(x1: array, x2: array, /) -> array:
     out: array
         an array containing the solution to the system ``AX = B`` for each square matrix. The returned array must have the same shape as ``x2`` (i.e., the array corresponding to ``B``) and must have a floating-point data type determined by :ref:`type-promotion`.
     """
+
 
 def svd(x: array, /, *, full_matrices: bool = True) -> Union[array, Tuple[array, ...]]:
     r"""
@@ -551,6 +577,7 @@ def svd(x: array, /, *, full_matrices: bool = True) -> Union[array, Tuple[array,
         -   third element must have the field name ``Vh`` and must be an array whose shape depends on the value of ``full_matrices`` and contain orthonormal rows (i.e., the rows are the right singular vectors and the array is the adjoint). If ``full_matrices`` is ``True``, the array must have shape ``(..., N, N)``. If ``full_matrices`` is ``False``, the array must have shape ``(..., K, N)`` where ``K = min(M, N)``. The first ``x.ndim-2`` dimensions must have the same shape as those of the input ``x``. Must have the same data type as ``x``.
     """
 
+
 def svdvals(x: array, /) -> array:
     """
     Returns the singular values of a matrix (or a stack of matrices) ``x``.
@@ -568,10 +595,18 @@ def svdvals(x: array, /) -> array:
         an array with shape ``(..., K)`` that contains the vector(s) of singular values of length ``K``, where ``K = min(M, N)``. For each vector, the singular values must be sorted in descending order by magnitude, such that ``s[..., 0]`` is the largest value, ``s[..., 1]`` is the second largest value, et cetera. The first ``x.ndim-2`` dimensions must have the same shape as those of the input ``x``. The returned array must have a real-valued floating-point data type having the same precision as ``x`` (e.g., if ``x`` is ``complex64``, the returned array must have a ``float32`` data type).
     """
 
-def tensordot(x1: array, x2: array, /, *, axes: Union[int, Tuple[Sequence[int], Sequence[int]]] = 2) -> array:
+
+def tensordot(
+    x1: array,
+    x2: array,
+    /,
+    *,
+    axes: Union[int, Tuple[Sequence[int], Sequence[int]]] = 2,
+) -> array:
     """
     Alias for :func:`~array_api.tensordot`.
     """
+
 
 def trace(x: array, /, *, offset: int = 0, dtype: Optional[dtype] = None) -> array:
     """
@@ -623,12 +658,21 @@ def trace(x: array, /, *, offset: int = 0, dtype: Optional[dtype] = None) -> arr
         The returned array must have a data type as described by the ``dtype`` parameter above.
     """
 
+
 def vecdot(x1: array, x2: array, /, *, axis: int = None) -> array:
     """
     Alias for :func:`~array_api.vecdot`.
     """
 
-def vector_norm(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False, ord: Union[int, float, Literal[inf, -inf]] = 2) -> array:
+
+def vector_norm(
+    x: array,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    keepdims: bool = False,
+    ord: Union[int, float, Literal[inf, -inf]] = 2,
+) -> array:
     r"""
     Computes the vector norm of a vector (or batch of vectors) ``x``.
 
@@ -679,4 +723,29 @@ def vector_norm(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = No
         an array containing the vector norms. If ``axis`` is ``None``, the returned array must be a zero-dimensional array containing a vector norm. If ``axis`` is a scalar value (``int`` or ``float``), the returned array must have a rank which is one less than the rank of ``x``. If ``axis`` is a ``n``-tuple, the returned array must have a rank which is ``n`` less than the rank of ``x``. If ``x`` has a real-valued data type, the returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`. If ``x`` has a complex-valued data type, the returned array must have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then the returned array must have a ``float64`` data type).
     """
 
-__all__ = ['cholesky', 'cross', 'det', 'diagonal', 'eigh', 'eigvalsh', 'inv', 'matmul', 'matrix_norm', 'matrix_power', 'matrix_rank', 'matrix_transpose', 'outer', 'pinv', 'qr', 'slogdet', 'solve', 'svd', 'svdvals', 'tensordot', 'trace', 'vecdot', 'vector_norm']
+
+__all__ = [
+    "cholesky",
+    "cross",
+    "det",
+    "diagonal",
+    "eigh",
+    "eigvalsh",
+    "inv",
+    "matmul",
+    "matrix_norm",
+    "matrix_power",
+    "matrix_rank",
+    "matrix_transpose",
+    "outer",
+    "pinv",
+    "qr",
+    "slogdet",
+    "solve",
+    "svd",
+    "svdvals",
+    "tensordot",
+    "trace",
+    "vecdot",
+    "vector_norm",
+]

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -1,5 +1,6 @@
 from ._types import Tuple, Union, Sequence, array
 
+
 def matmul(x1: array, x2: array, /) -> array:
     """
     Computes the matrix product.
@@ -41,6 +42,7 @@ def matmul(x1: array, x2: array, /) -> array:
     -   if ``x1`` is an array having shape ``(..., M, K)``, ``x2`` is an array having shape ``(..., L, N)``, and ``K != L``.
     """
 
+
 def matrix_transpose(x: array, /) -> array:
     """
     Transposes a matrix (or a stack of matrices) ``x``.
@@ -56,7 +58,14 @@ def matrix_transpose(x: array, /) -> array:
         an array containing the transpose for each matrix and having shape ``(..., N, M)``. The returned array must have the same data type as ``x``.
     """
 
-def tensordot(x1: array, x2: array, /, *, axes: Union[int, Tuple[Sequence[int], Sequence[int]]] = 2) -> array:
+
+def tensordot(
+    x1: array,
+    x2: array,
+    /,
+    *,
+    axes: Union[int, Tuple[Sequence[int], Sequence[int]]] = 2,
+) -> array:
     """
     Returns a tensor contraction of ``x1`` and ``x2`` over specific axes.
 
@@ -94,15 +103,16 @@ def tensordot(x1: array, x2: array, /, *, axes: Union[int, Tuple[Sequence[int], 
         an array containing the tensor contraction whose shape consists of the non-contracted axes (dimensions) of the first array ``x1``, followed by the non-contracted axes (dimensions) of the second array ``x2``. The returned array must have a data type determined by :ref:`type-promotion`.
     """
 
+
 def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     """
     Computes the (vector) dot product of two arrays.
-    
+
     Let :math:`\mathbf{a}` be a vector in ``x1`` and :math:`\mathbf{b}` be a corresponding vector in ``x2``. The dot product is defined as
-    
+
     .. math::
        \mathbf{a} \cdot \mathbf{b} = \sum_{i=0}^{n-1} a_i\overline{b_i}
-       
+
     over the dimension specified by ``axis`` and where :math:`n` is the dimension size and :math:`\overline{b_i}` denotes the complex conjugate if :math:`b_i` is complex and the identity if :math:`b_i` is real-valued.
 
     Parameters
@@ -130,4 +140,5 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     -   if the size of the axis over which to compute the dot product is not the same (before broadcasting) for both ``x1`` and ``x2``.
     """
 
-__all__ = ['matmul', 'matrix_transpose', 'tensordot', 'vecdot']
+
+__all__ = ["matmul", "matrix_transpose", "tensordot", "vecdot"]

--- a/spec/API_specification/array_api/linear_algebra_functions.py
+++ b/spec/API_specification/array_api/linear_algebra_functions.py
@@ -105,7 +105,7 @@ def tensordot(
 
 
 def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
-    """
+    r"""
     Computes the (vector) dot product of two arrays.
 
     Let :math:`\mathbf{a}` be a vector in ``x1`` and :math:`\mathbf{b}` be a corresponding vector in ``x2``. The dot product is defined as

--- a/spec/API_specification/array_api/manipulation_functions.py
+++ b/spec/API_specification/array_api/manipulation_functions.py
@@ -190,7 +190,7 @@ def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) ->
         axis along which the arrays will be joined. Providing an ``axis`` specifies the index of the new axis in the dimensions of the result. For example, if ``axis`` is ``0``, the new axis will be the first dimension and the output array will have shape ``(N, A, B, C)``; if ``axis`` is ``1``, the new axis will be the second dimension and the output array will have shape ``(A, N, B, C)``; and, if ``axis`` is ``-1``, the new axis will be the last dimension and the output array will have shape ``(A, B, C, N)``. A valid ``axis`` must be on the interval ``[-N, N)``, where ``N`` is the rank (number of dimensions) of ``x``. If provided an ``axis`` outside of the required interval, the function must raise an exception. Default: ``0``.
 
     Returns
-    --------
+    -------
     out: array
         an output array having rank ``N+1``, where ``N`` is the rank (number of dimensions) of ``x``. If the input arrays have different data types, normal :ref:`type-promotion` must apply. If the input arrays have the same data type, the output array must have the same data type as the input arrays.
 

--- a/spec/API_specification/array_api/manipulation_functions.py
+++ b/spec/API_specification/array_api/manipulation_functions.py
@@ -1,5 +1,6 @@
 from ._types import List, Optional, Tuple, Union, array
 
+
 def broadcast_arrays(*arrays: array) -> List[array]:
     """
     Broadcasts one or more arrays against one another.
@@ -14,6 +15,7 @@ def broadcast_arrays(*arrays: array) -> List[array]:
     out: List[array]
         a list of broadcasted arrays. Each array must have the same shape. Each array must have the same dtype as its corresponding input array.
     """
+
 
 def broadcast_to(x: array, /, shape: Tuple[int, ...]) -> array:
     """
@@ -32,7 +34,10 @@ def broadcast_to(x: array, /, shape: Tuple[int, ...]) -> array:
         an array having a specified shape. Must have the same data type as ``x``.
     """
 
-def concat(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: Optional[int] = 0) -> array:
+
+def concat(
+    arrays: Union[Tuple[array, ...], List[array]], /, *, axis: Optional[int] = 0
+) -> array:
     """
     Joins a sequence of arrays along an existing axis.
 
@@ -52,6 +57,7 @@ def concat(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: Optional[i
            This specification leaves type promotion between data type families (i.e., ``intxx`` and ``floatxx``) unspecified.
     """
 
+
 def expand_dims(x: array, /, *, axis: int = 0) -> array:
     """
     Expands the shape of an array by inserting a new axis (dimension) of size one at the position specified by ``axis``.
@@ -68,6 +74,7 @@ def expand_dims(x: array, /, *, axis: int = 0) -> array:
     out: array
         an expanded output array having the same data type as ``x``.
     """
+
 
 def flip(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> array:
     """
@@ -86,6 +93,7 @@ def flip(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> 
         an output array having the same data type and shape as ``x`` and whose elements, relative to ``x``, are reordered.
     """
 
+
 def permute_dims(x: array, /, axes: Tuple[int, ...]) -> array:
     """
     Permutes the axes (dimensions) of an array ``x``.
@@ -103,7 +111,10 @@ def permute_dims(x: array, /, axes: Tuple[int, ...]) -> array:
         an array containing the axes permutation. The returned array must have the same data type as ``x``.
     """
 
-def reshape(x: array, /, shape: Tuple[int, ...], *, copy: Optional[bool] = None) -> array:
+
+def reshape(
+    x: array, /, shape: Tuple[int, ...], *, copy: Optional[bool] = None
+) -> array:
     """
     Reshapes an array without changing its data.
 
@@ -122,7 +133,14 @@ def reshape(x: array, /, shape: Tuple[int, ...], *, copy: Optional[bool] = None)
         an output array having the same data type and elements as ``x``.
     """
 
-def roll(x: array, /, shift: Union[int, Tuple[int, ...]], *, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> array:
+
+def roll(
+    x: array,
+    /,
+    shift: Union[int, Tuple[int, ...]],
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+) -> array:
     """
     Rolls array elements along a specified axis. Array elements that roll beyond the last position are re-introduced at the first position. Array elements that roll beyond the first position are re-introduced at the last position.
 
@@ -141,6 +159,7 @@ def roll(x: array, /, shift: Union[int, Tuple[int, ...]], *, axis: Optional[Unio
         an output array having the same data type as ``x`` and whose elements, relative to ``x``, are shifted.
     """
 
+
 def squeeze(x: array, /, axis: Union[int, Tuple[int, ...]]) -> array:
     """
     Removes singleton dimensions (axes) from ``x``.
@@ -157,6 +176,7 @@ def squeeze(x: array, /, axis: Union[int, Tuple[int, ...]]) -> array:
     out: array
         an output array having the same data type and elements as ``x``.
     """
+
 
 def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) -> array:
     """
@@ -178,4 +198,16 @@ def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) ->
            This specification leaves type promotion between data type families (i.e., ``intxx`` and ``floatxx``) unspecified.
     """
 
-__all__ = [ 'broadcast_arrays', 'broadcast_to', 'concat', 'expand_dims', 'flip', 'permute_dims', 'reshape', 'roll', 'squeeze', 'stack']
+
+__all__ = [
+    "broadcast_arrays",
+    "broadcast_to",
+    "concat",
+    "expand_dims",
+    "flip",
+    "permute_dims",
+    "reshape",
+    "roll",
+    "squeeze",
+    "stack",
+]

--- a/spec/API_specification/array_api/searching_functions.py
+++ b/spec/API_specification/array_api/searching_functions.py
@@ -1,5 +1,6 @@
 from ._types import Optional, Tuple, array
 
+
 def argmax(x: array, /, *, axis: Optional[int] = None, keepdims: bool = False) -> array:
     """
     Returns the indices of the maximum values along a specified axis.
@@ -24,6 +25,7 @@ def argmax(x: array, /, *, axis: Optional[int] = None, keepdims: bool = False) -
         if ``axis`` is ``None``, a zero-dimensional array containing the index of the first occurrence of the maximum value; otherwise, a non-zero-dimensional array containing the indices of the maximum values. The returned array must have be the default array index data type.
     """
 
+
 def argmin(x: array, /, *, axis: Optional[int] = None, keepdims: bool = False) -> array:
     """
     Returns the indices of the minimum values along a specified axis.
@@ -47,6 +49,7 @@ def argmin(x: array, /, *, axis: Optional[int] = None, keepdims: bool = False) -
     out: array
         if ``axis`` is ``None``, a zero-dimensional array containing the index of the first occurrence of the minimum value; otherwise, a non-zero-dimensional array containing the indices of the minimum values. The returned array must have the default array index data type.
     """
+
 
 def nonzero(x: array, /) -> Tuple[array, ...]:
     """
@@ -74,6 +77,7 @@ def nonzero(x: array, /) -> Tuple[array, ...]:
         a tuple of ``k`` arrays, one for each dimension of ``x`` and each of size ``n`` (where ``n`` is the total number of non-zero elements), containing the indices of the non-zero elements in that dimension. The indices must be returned in row-major, C-style order. The returned array must have the default array index data type.
     """
 
+
 def where(condition: array, x1: array, x2: array, /) -> array:
     """
     Returns elements chosen from ``x1`` or ``x2`` depending on ``condition``.
@@ -93,4 +97,5 @@ def where(condition: array, x1: array, x2: array, /) -> array:
         an array with elements from ``x1`` where ``condition`` is ``True``, and elements from ``x2`` elsewhere. The returned array must have a data type determined by :ref:`type-promotion` rules with the arrays ``x1`` and ``x2``.
     """
 
-__all__ = ['argmax', 'argmin', 'nonzero', 'where']
+
+__all__ = ["argmax", "argmin", "nonzero", "where"]

--- a/spec/API_specification/array_api/set_functions.py
+++ b/spec/API_specification/array_api/set_functions.py
@@ -1,5 +1,6 @@
 from ._types import Tuple, array
 
+
 def unique_all(x: array, /) -> Tuple[array, array, array, array]:
     """
     Returns the unique elements of an input array ``x``, the first occurring indices for each unique element in ``x``, the indices from the set of unique elements that reconstruct ``x``, and the corresponding counts for each unique element in ``x``.
@@ -39,6 +40,7 @@ def unique_all(x: array, /) -> Tuple[array, array, array, array]:
            The order of unique elements is not specified and may vary between implementations.
     """
 
+
 def unique_counts(x: array, /) -> Tuple[array, array]:
     """
     Returns the unique elements of an input array ``x`` and the corresponding counts for each unique element in ``x``.
@@ -73,6 +75,7 @@ def unique_counts(x: array, /) -> Tuple[array, array]:
         .. note::
            The order of unique elements is not specified and may vary between implementations.
     """
+
 
 def unique_inverse(x: array, /) -> Tuple[array, array]:
     """
@@ -109,6 +112,7 @@ def unique_inverse(x: array, /) -> Tuple[array, array]:
            The order of unique elements is not specified and may vary between implementations.
     """
 
+
 def unique_values(x: array, /) -> array:
     """
     Returns the unique elements of an input array ``x``.
@@ -139,4 +143,5 @@ def unique_values(x: array, /) -> array:
            The order of unique elements is not specified and may vary between implementations.
     """
 
-__all__ = ['unique_all', 'unique_counts', 'unique_inverse', 'unique_values']
+
+__all__ = ["unique_all", "unique_counts", "unique_inverse", "unique_values"]

--- a/spec/API_specification/array_api/sorting_functions.py
+++ b/spec/API_specification/array_api/sorting_functions.py
@@ -1,6 +1,9 @@
 from ._types import array
 
-def argsort(x: array, /, *, axis: int = -1, descending: bool = False, stable: bool = True) -> array:
+
+def argsort(
+    x: array, /, *, axis: int = -1, descending: bool = False, stable: bool = True
+) -> array:
     """
     Returns the indices that sort an array ``x`` along a specified axis.
 
@@ -24,7 +27,10 @@ def argsort(x: array, /, *, axis: int = -1, descending: bool = False, stable: bo
         an array of indices. The returned array must have the same shape as ``x``. The returned array must have the default array index data type.
     """
 
-def sort(x: array, /, *, axis: int = -1, descending: bool = False, stable: bool = True) -> array:
+
+def sort(
+    x: array, /, *, axis: int = -1, descending: bool = False, stable: bool = True
+) -> array:
     """
     Returns a sorted copy of an input array ``x``.
 
@@ -48,4 +54,5 @@ def sort(x: array, /, *, axis: int = -1, descending: bool = False, stable: bool 
         a sorted array. The returned array must have the same data type and shape as ``x``.
     """
 
-__all__ = ['argsort', 'sort']
+
+__all__ = ["argsort", "sort"]

--- a/spec/API_specification/array_api/statistical_functions.py
+++ b/spec/API_specification/array_api/statistical_functions.py
@@ -1,6 +1,13 @@
 from ._types import Optional, Tuple, Union, array, dtype
 
-def max(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> array:
+
+def max(
+    x: array,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    keepdims: bool = False,
+) -> array:
     """
     Calculates the maximum value of the input array ``x``.
 
@@ -31,7 +38,14 @@ def max(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keep
         if the maximum value was computed over the entire array, a zero-dimensional array containing the maximum value; otherwise, a non-zero-dimensional array containing the maximum values. The returned array must have the same data type as ``x``.
     """
 
-def mean(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> array:
+
+def mean(
+    x: array,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    keepdims: bool = False,
+) -> array:
     """
     Calculates the arithmetic mean of the input array ``x``.
 
@@ -60,7 +74,14 @@ def mean(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, kee
            While this specification recommends that this function only accept input arrays having a real-valued floating-point data type, specification-compliant array libraries may choose to accept input arrays having an integer data type. While mixed data type promotion is implementation-defined, if the input array ``x`` has an integer data type, the returned array must have the default real-valued floating-point data type.
     """
 
-def min(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> array:
+
+def min(
+    x: array,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    keepdims: bool = False,
+) -> array:
     """
     Calculates the minimum value of the input array ``x``.
 
@@ -91,7 +112,15 @@ def min(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keep
         if the minimum value was computed over the entire array, a zero-dimensional array containing the minimum value; otherwise, a non-zero-dimensional array containing the minimum values. The returned array must have the same data type as ``x``.
     """
 
-def prod(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, dtype: Optional[dtype] = None, keepdims: bool = False) -> array:
+
+def prod(
+    x: array,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    dtype: Optional[dtype] = None,
+    keepdims: bool = False,
+) -> array:
     """
     Calculates the product of input array ``x`` elements.
 
@@ -132,7 +161,15 @@ def prod(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, dty
         if the product was computed over the entire array, a zero-dimensional array containing the product; otherwise, a non-zero-dimensional array containing the products. The returned array must have a data type as described by the ``dtype`` parameter above.
     """
 
-def std(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, correction: Union[int, float] = 0.0, keepdims: bool = False) -> array:
+
+def std(
+    x: array,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    correction: Union[int, float] = 0.0,
+    keepdims: bool = False,
+) -> array:
     """
     Calculates the standard deviation of the input array ``x``.
 
@@ -163,7 +200,15 @@ def std(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, corr
            While this specification recommends that this function only accept input arrays having a real-valued floating-point data type, specification-compliant array libraries may choose to accept input arrays having an integer data type. While mixed data type promotion is implementation-defined, if the input array ``x`` has an integer data type, the returned array must have the default real-valued floating-point data type.
     """
 
-def sum(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, dtype: Optional[dtype] = None, keepdims: bool = False) -> array:
+
+def sum(
+    x: array,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    dtype: Optional[dtype] = None,
+    keepdims: bool = False,
+) -> array:
     """
     Calculates the sum of the input array ``x``.
 
@@ -204,7 +249,15 @@ def sum(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, dtyp
         if the sum was computed over the entire array, a zero-dimensional array containing the sum; otherwise, an array containing the sums. The returned array must have a data type as described by the ``dtype`` parameter above.
     """
 
-def var(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, correction: Union[int, float] = 0.0, keepdims: bool = False) -> array:
+
+def var(
+    x: array,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    correction: Union[int, float] = 0.0,
+    keepdims: bool = False,
+) -> array:
     """
     Calculates the variance of the input array ``x``.
 
@@ -236,4 +289,5 @@ def var(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, corr
        While this specification recommends that this function only accept input arrays having a real-valued floating-point data type, specification-compliant array libraries may choose to accept input arrays having an integer data type. While mixed data type promotion is implementation-defined, if the input array ``x`` has an integer data type, the returned array must have the default real-valued floating-point data type.
     """
 
-__all__ = ['max', 'mean', 'min', 'prod', 'std', 'sum', 'var']
+
+__all__ = ["max", "mean", "min", "prod", "std", "sum", "var"]

--- a/spec/API_specification/array_api/utility_functions.py
+++ b/spec/API_specification/array_api/utility_functions.py
@@ -1,6 +1,13 @@
 from ._types import Optional, Tuple, Union, array
 
-def all(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> array:
+
+def all(
+    x: array,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    keepdims: bool = False,
+) -> array:
     """
     Tests whether all input array elements evaluate to ``True`` along a specified axis.
 
@@ -28,7 +35,14 @@ def all(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keep
         if a logical AND reduction was performed over the entire array, the returned array must be a zero-dimensional array containing the test result; otherwise, the returned array must be a non-zero-dimensional array containing the test results. The returned array must have a data type of ``bool``.
     """
 
-def any(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False) -> array:
+
+def any(
+    x: array,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    keepdims: bool = False,
+) -> array:
     """
     Tests whether any input array element evaluates to ``True`` along a specified axis.
 
@@ -56,4 +70,5 @@ def any(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keep
         if a logical OR reduction was performed over the entire array, the returned array must be a zero-dimensional array containing the test result; otherwise, the returned array must be a non-zero-dimensional array containing the test results. The returned array must have a data type of ``bool``.
     """
 
-__all__ = ['all', 'any']
+
+__all__ = ["all", "any"]


### PR DESCRIPTION
This makes `black` happy, and `git blame` won't be cluttered by the commit with `black` changes. This works in the GitHub UI out of the box, and locally after running `git config blame.ignoreRevsFile .git-blame-ignore-revs` once.

This PR also fixes some minor issues identified by `pydocstyle`. There is no good automated formatter for docstrings (`black` doesn't touch them, and `docformatter` touches only summary lines and descriptions, which is a small fraction of content). So in anticipation of adding CI in the future, this makes the following check pass:
```
pydocstyle . --ignore=D401,D212,D413,D100 --match='(?!_types.py).*\.py'
```

This is all that can be done with automated tooling. xref gh-533 for context.