### PR TITLE
`make` improvments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           no_output_timeout: 25m
           command: |
             pip install .[doc]
-            make
+            make spec
       - store_artifacts:
           path: _site/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: build docs
           no_output_timeout: 25m
           command: |
-            pip install .[doc]
+            pip install -r doc-requirements.txt
             make spec
       - store_artifacts:
           path: _site/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -76,7 +76,7 @@ jobs:
       # Install dependencies:
       - name: 'Install dependencies'
         run: |
-          pip install .[doc]
+          pip install -r doc-requirements.txt
 
       # Generate the documentation:
       - name: 'Build documentation'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           # Turn warnings into errors and ensure .doctrees is not deployed:
           export SPHINXOPTS="-b html -WT --keep-going -d doctrees"
-          make
+          make spec
 
       # Configure Git:
       - name: 'Configure Git'

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,9 @@ SPHINXOPTS    ?= -W --keep-going
 SOURCEDIR     = spec
 BUILDDIR      = _site
 
-.PHONY: default install clean draft spec
+.PHONY: default clean draft spec
 
 default: clean spec
-
-install:
-	pip install -e .[doc]
 
 clean:
 	rm -rf $(BUILDDIR)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILDDIR      = _site
 
 .PHONY: default install clean draft spec
 
-default: install clean spec
+default: clean spec
 
 install:
 	pip install -e .[doc]

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,22 @@ SPHINXOPTS    ?= -W --keep-going
 SOURCEDIR     = spec
 BUILDDIR      = _site
 
-.PHONY: default clean build
+.PHONY: default install clean draft spec
 
-default: clean build
+default: install clean spec
+
+install:
+	pip install -e .[doc]
 
 clean:
-	-rm -rf $(BUILDDIR)
-	-find . -type d -name generated -exec rm -rf {} +
+	rm -rf $(BUILDDIR)
+	find . -type d -name generated -exec rm -rf {} +
 
-build:
+draft:
+	mkdir -p $(BUILDDIR)
+	sphinx-build "$(SOURCEDIR)/draft" "$(BUILDDIR)/draft" $(SPHINXOPTS)
+
+spec:
 	mkdir -p $(BUILDDIR)
 	cp "$(SOURCEDIR)/_ghpages/_gitignore.txt" "$(BUILDDIR)/.gitignore"
 	cp "$(SOURCEDIR)/_ghpages/versions.json" "$(BUILDDIR)/versions.json"

--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ this array API standard.
 
 ### Quickstart
 
-Just running `make` at the root of the repository should install the necessary
-dependencies and build the whole spec website.
+To install the local stubs and additional dependencies of the Sphinx docs, you
+can use `make install`. Then just running `make` at the root of the repository
+should build the whole spec website.
 
 ```sh
+$ make install
 $ make
 $ ls _site/
 2021.12/  draft/  index.html  latest/  versions.json
@@ -33,8 +35,7 @@ $ ls _site/
 
 The spec website is comprised of multiple Sphinx docs (one for each spec version),
 all of which exist in `spec/` and rely on the modules found in `src/` (most
-notably `array_api_stubs`). To install these modules and the additional
-dependencies of the Sphinx docs, you can use `make install`, which aliases
+notably `array_api_stubs`). `make install` aliases
 
 ```sh
 $ pip install -e .[doc]  # ensure you install the dependencies extra "doc"

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ this array API standard.
 ### Quickstart
 
 To install the local stubs and additional dependencies of the Sphinx docs, you
-can use `make install`. Then just running `make` at the root of the repository
-should build the whole spec website.
+can use `pip install -r doc-requirements.txt`. Then just running `make` at the
+root of the repository should build the whole spec website.
 
 ```sh
-$ make install
+$ pip install -r doc-requirements.txt
 $ make
 $ ls _site/
 2021.12/  draft/  index.html  latest/  versions.json
@@ -35,11 +35,9 @@ $ ls _site/
 
 The spec website is comprised of multiple Sphinx docs (one for each spec version),
 all of which exist in `spec/` and rely on the modules found in `src/` (most
-notably `array_api_stubs`). `make install` aliases
-
-```sh
-$ pip install -e .[doc]  # ensure you install the dependencies extra "doc"
-```
+notably `array_api_stubs`). For purposes of building the docs, these `src/`
+modules do not need to be installed as they are added to the `sys.path` at
+runtime.
 
 To build specific versions of the spec, run `sphinx-build` on the respective
 folder in `spec/`, e.g.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,23 @@ this array API standard.
 
 ## Building docs locally
 
+### Quickstart
+
+Just running `make` at the root of the repository should install the necessary
+dependencies and build the whole spec website.
+
+```sh
+$ make
+$ ls _site/
+2021.12/  draft/  index.html  latest/  versions.json
+```
+
+### The nitty-gritty
+
 The spec website is comprised of multiple Sphinx docs (one for each spec version),
 all of which exist in `spec/` and rely on the modules found in `src/` (most
 notably `array_api_stubs`). To install these modules and the additional
-dependencies of the Sphinx docs, you can use
+dependencies of the Sphinx docs, you can use `make install`, which aliases
 
 ```sh
 $ pip install -e .[doc]  # ensure you install the dependencies extra "doc"
@@ -31,17 +44,17 @@ To build specific versions of the spec, run `sphinx-build` on the respective
 folder in `spec/`, e.g.
 
 ```sh
+$ sphinx-build spec/2012.12/ _site/2012.12/
+```
+
+Additionally, `make draft` aliases
+
+```sh
 $ sphinx-build spec/draft/ _site/draft/
 ```
 
-To build the whole website, which includes every version of
-the spec, you can utilize the `make` commands defined in `spec/Makefile`; e.g.,
-
-```sh
-$ make
-$ ls _site/
-2021.12/  draft/  index.html  latest/  versions.json
-```
+To build the whole website, which includes every version of the spec, you can
+utilize `make spec`.
 
 
 ## Making a spec release

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,0 +1,7 @@
+sphinx==4.3.0
+sphinx-material==0.0.30
+myst-parser
+sphinx_markdown_tables
+sphinx_copybutton
+docutils<0.18
+sphinx-math-dollar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,17 +14,6 @@ Source = "https://github.com/data-apis/array-api/"
 Documentation = "https://data-apis.org/array-api/"
 Homepage = "https://data-apis.org/"
 
-[project.optional-dependencies]
-doc = [
-    "sphinx==4.3.0",
-    "sphinx-material==0.0.30",
-    "myst-parser",
-    "sphinx_markdown_tables",
-    "sphinx_copybutton",
-    "docutils<0.18",
-    "sphinx-math-dollar",
-]
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/spec/2021.12/conf.py
+++ b/spec/2021.12/conf.py
@@ -1,4 +1,6 @@
 import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 
 from array_api_stubs import _2021_12 as stubs_mod
 from _array_api_conf import *

--- a/spec/2022.12/conf.py
+++ b/spec/2022.12/conf.py
@@ -1,4 +1,6 @@
 import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 
 from array_api_stubs import _2022_12 as stubs_mod
 from _array_api_conf import *

--- a/spec/draft/conf.py
+++ b/spec/draft/conf.py
@@ -1,4 +1,6 @@
 import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 
 from array_api_stubs import _draft as stubs_mod
 from _array_api_conf import *


### PR DESCRIPTION
* `make install` now installs dependencies
* `build` command renamed to `spec`
* Introduced `draft` command aliasing `sphinx-build spec/draft/ _site/draft/`

README updated accordingly.

I'm not sure on general procedure with makefiles here: I assumed `make install` shouldn't be depended upon by the `draft` and `spec` commands.