### PR TITLE
Add imag to elementwise functions table of contents

### DIFF
--- a/spec/2022.12/API_specification/elementwise_functions.rst
+++ b/spec/2022.12/API_specification/elementwise_functions.rst
@@ -44,6 +44,7 @@ Objects in API
    floor_divide
    greater
    greater_equal
+   imag
    isfinite
    isinf
    isnan

--- a/spec/draft/API_specification/elementwise_functions.rst
+++ b/spec/draft/API_specification/elementwise_functions.rst
@@ -44,6 +44,7 @@ Objects in API
    floor_divide
    greater
    greater_equal
+   imag
    isfinite
    isinf
    isnan


### PR DESCRIPTION
This PR Fixes #600,

Adds `imag` to elementwise functions table of contents in,

- [x] Draft
- [x] 2022v

