### PR TITLE
Add `unstack`

### DIFF
--- a/spec/draft/API_specification/manipulation_functions.rst
+++ b/spec/draft/API_specification/manipulation_functions.rst
@@ -28,3 +28,4 @@ Objects in API
    roll
    squeeze
    stack
+   unstack

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -199,7 +199,7 @@ def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) ->
     """
 
 
-def unstack(array: array, /, *, axis: int = 0) -> List[array]:
+def unstack(array: array, /, *, axis: int = 0) -> Tuple[array]:
     """
     Splits an array in a sequence of arrays along the given axis.
 

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -199,7 +199,7 @@ def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) ->
     """
 
 
-def unstack(x: Tuple[array, ...], /, *, axis: int = 0) -> Tuple[array]:
+def unstack(x: array, /, *, axis: int = 0) -> Tuple[array, ...]:
     """
     Splits an array in a sequence of arrays along the given axis.
 
@@ -212,7 +212,7 @@ def unstack(x: Tuple[array, ...], /, *, axis: int = 0) -> Tuple[array]:
 
     Returns
     -------
-    out: Tuple[array]
+    out: Tuple[array, ...]
         tuple of slices along the given dimension. All the arrays have the same shape.
     """
 

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -199,21 +199,21 @@ def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) ->
     """
 
 
-def unstack(array: array, /, *, axis: int = 0) -> Tuple[array]:
+def unstack(x: Tuple[array, ...], /, *, axis: int = 0) -> Tuple[array]:
     """
     Splits an array in a sequence of arrays along the given axis.
 
     Parameters
     ----------
-    array: array
+    x: array
         input array.
     axis: int
         axis along which the array will be split. A valid ``axis`` must be on the interval ``[-N, N)``, where ``N`` is the rank (number of dimensions) of ``x``. If provided an ``axis`` outside of the required interval, the function must raise an exception. Default: ``0``.
 
     Returns
     -------
-    out: List[array]
-        list of slices along the given dimension. All the arrays have the same shape.
+    out: Tuple[array]
+        tuple of slices along the given dimension. All the arrays have the same shape.
     """
 
 

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -199,6 +199,24 @@ def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) ->
     """
 
 
+def unstack(array: array, /, *, axis: int = 0) -> List[array]:
+    """
+    Splits an array in a sequence of arrays along the given axis.
+
+    Parameters
+    ----------
+    array: array
+        input array.
+    axis: int
+        axis along which the array will be split. A valid ``axis`` must be on the interval ``[-N, N)``, where ``N`` is the rank (number of dimensions) of ``x``. If provided an ``axis`` outside of the required interval, the function must raise an exception. Default: ``0``.
+
+    Returns
+    -------
+    out: List[array]
+        list of slices along the given dimension. All the arrays have the same shape.
+    """
+
+
 __all__ = [
     "broadcast_arrays",
     "broadcast_to",
@@ -210,4 +228,5 @@ __all__ = [
     "roll",
     "squeeze",
     "stack",
+    "unstack",
 ]


### PR DESCRIPTION
This PR adds `unstack` to the specification, fixes #487.

- [x] Adds the signature inside the manipulation functions
- [x] Adds the reference in the table of contents 