### PR TITLE
Backport versionadded and versionchanged annotations to 2022.12 spec

### DIFF
--- a/src/array_api_stubs/_2022_12/array_object.py
+++ b/src/array_api_stubs/_2022_12/array_object.py
@@ -136,9 +136,14 @@ class _array:
         out: array
             an array containing the element-wise absolute value. If ``self`` has a real-valued data type, the returned array must have the same data type as ``self``. If ``self`` has a complex floating-point data type, the returned arrayed must have a real-valued floating-point data type whose precision matches the precision of ``self`` (e.g., if ``self`` is ``complex128``, then the returned array must have a ``float64`` data type).
 
+        Notes
+        -----
 
         .. note::
            Element-wise results, including special cases, must equal the results returned by the equivalent element-wise function :func:`~array_api.abs`.
+
+        .. versionchanged:: 2022.12
+            Added complex data type support.
         """
 
     def __add__(self: array, other: Union[int, float, array], /) -> array:
@@ -157,9 +162,14 @@ class _array:
         out: array
             an array containing the element-wise sums. The returned array must have a data type determined by :ref:`type-promotion`.
 
+        Notes
+        -----
 
         .. note::
            Element-wise results, including special cases, must equal the results returned by the equivalent element-wise function :func:`~array_api.add`.
+
+        .. versionchanged:: 2022.12
+            Added complex data type support.
         """
 
     def __and__(self: array, other: Union[int, bool, array], /) -> array:
@@ -228,6 +238,9 @@ class _array:
         - If ``self`` is either ``+0`` or ``-0``, the result is ``False``.
 
         For complex floating-point operands, special cases must be handled as if the operation is implemented as the logical AND of ``bool(real(self))`` and ``bool(imag(self))``.
+
+        .. versionchanged:: 2022.12
+            Added boolean and complex data type support.
         """
 
     def __complex__(self: array, /) -> complex:
@@ -260,6 +273,8 @@ class _array:
         - If ``self`` is ``+infinity``, the result is ``+infinity + 0j``.
         - If ``self`` is ``-infinity``, the result is ``-infinity + 0j``.
         - If ``self`` is a finite number, the result is ``self + 0j``.
+
+        .. versionadded:: 2022.12
         """
 
     def __dlpack__(
@@ -326,6 +341,11 @@ class _array:
             errors are raised when export fails for other reasons (e.g., incorrect
             arguments passed or out of memory).
 
+        Notes
+        -----
+
+        .. versionchanged:: 2022.12
+            Added BufferError.
         """
 
     def __dlpack_device__(self: array, /) -> Tuple[Enum, int]:
@@ -401,6 +421,9 @@ class _array:
 
         - If ``self`` is ``True``, the result is ``1``.
         - If ``self`` is ``False``, the result is ``0``.
+
+        .. versionchanged:: 2022.12
+            Added boolean and complex data type support.
         """
 
     def __floordiv__(self: array, other: Union[int, float, array], /) -> array:
@@ -551,6 +574,9 @@ class _array:
 
         - If ``self`` is either ``+infinity`` or ``-infinity``, raise ``OverflowError``.
         - If ``self`` is ``NaN``, raise ``ValueError``.
+
+        .. versionchanged:: 2022.12
+            Added boolean and complex data type support.
         """
 
     def __invert__(self: array, /) -> array:
@@ -671,6 +697,8 @@ class _array:
             -   if either ``self`` or ``other`` has more than two dimensions, an array having a shape determined by :ref:`broadcasting` ``shape(self)[:-2]`` against ``shape(other)[:-2]`` and containing the `conventional matrix product <https://en.wikipedia.org/wiki/Matrix_multiplication>`_ for each stacked matrix.
             -   The returned array must have a data type determined by :ref:`type-promotion`.
 
+        Notes
+        -----
 
         .. note::
            Results must equal the results returned by the equivalent function :func:`~array_api.matmul`.
@@ -682,6 +710,9 @@ class _array:
         - if ``self`` is a one-dimensional array having shape ``(K,)``, ``other`` is an array having shape ``(..., L, N)``, and ``K != L``.
         - if ``self`` is an array having shape ``(..., M, K)``, ``other`` is a one-dimensional array having shape ``(L,)``, and ``K != L``.
         - if ``self`` is an array having shape ``(..., M, K)``, ``other`` is an array having shape ``(..., L, N)``, and ``K != L``.
+
+        .. versionchanged:: 2022.12
+            Added complex data type support.
         """
 
     def __mod__(self: array, other: Union[int, float, array], /) -> array:
@@ -727,9 +758,14 @@ class _array:
         out: array
             an array containing the element-wise products. The returned array must have a data type determined by :ref:`type-promotion`.
 
+        Notes
+        -----
 
         .. note::
            Element-wise results, including special cases, must equal the results returned by the equivalent element-wise function :func:`~array_api.multiply`.
+
+        .. versionchanged:: 2022.12
+            Added complex data type support.
         """
 
     def __ne__(self: array, other: Union[int, float, bool, array], /) -> array:
@@ -748,9 +784,14 @@ class _array:
         out: array
             an array containing the element-wise results. The returned array must have a data type of ``bool`` (i.e., must be a boolean array).
 
+        Notes
+        -----
 
         .. note::
            Element-wise results, including special cases, must equal the results returned by the equivalent element-wise function :func:`~array_api.not_equal`.
+
+        .. versionchanged:: 2022.12
+            Added complex data type support.
         """
 
     def __neg__(self: array, /) -> array:
@@ -773,9 +814,14 @@ class _array:
         out: array
             an array containing the evaluated result for each element in ``self``. The returned array must have a data type determined by :ref:`type-promotion`.
 
+        Notes
+        -----
 
         .. note::
            Element-wise results must equal the results returned by the equivalent element-wise function :func:`~array_api.negative`.
+
+        .. versionchanged:: 2022.12
+            Added complex data type support.
         """
 
     def __or__(self: array, other: Union[int, bool, array], /) -> array:
@@ -794,9 +840,14 @@ class _array:
         out: array
             an array containing the element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
 
+        Notes
+        -----
 
         .. note::
            Element-wise results must equal the results returned by the equivalent element-wise function :func:`~array_api.bitwise_or`.
+
+        .. versionchanged:: 2022.12
+            Added complex data type support.
         """
 
     def __pos__(self: array, /) -> array:
@@ -839,9 +890,14 @@ class _array:
         out: array
             an array containing the element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
 
+        Notes
+        -----
 
         .. note::
            Element-wise results, including special cases, must equal the results returned by the equivalent element-wise function :func:`~array_api.pow`.
+
+        .. versionchanged:: 2022.12
+            Added complex data type support.
         """
 
     def __rshift__(self: array, other: Union[int, array], /) -> array:
@@ -913,9 +969,14 @@ class _array:
         out: array
             an array containing the element-wise differences. The returned array must have a data type determined by :ref:`type-promotion`.
 
+        Notes
+        -----
 
         .. note::
            Element-wise results must equal the results returned by the equivalent element-wise function :func:`~array_api.subtract`.
+
+        .. versionchanged:: 2022.12
+            Added complex data type support.
         """
 
     def __truediv__(self: array, other: Union[int, float, array], /) -> array:
@@ -939,9 +1000,14 @@ class _array:
         out: array
             an array containing the element-wise results. The returned array should have a floating-point data type determined by :ref:`type-promotion`.
 
+        Notes
+        -----
 
         .. note::
            Element-wise results, including special cases, must equal the results returned by the equivalent element-wise function :func:`~array_api.divide`.
+
+        .. versionchanged:: 2022.12
+            Added complex data type support.
         """
 
     def __xor__(self: array, other: Union[int, bool, array], /) -> array:

--- a/src/array_api_stubs/_2022_12/creation_functions.py
+++ b/src/array_api_stubs/_2022_12/creation_functions.py
@@ -97,6 +97,12 @@ def asarray(
     -------
     out: array
         an array containing the data from ``obj``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -179,6 +185,12 @@ def eye(
     -------
     out: array
         an array where all elements are equal to zero, except for the ``k``\th diagonal, whose values are equal to one.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -237,6 +249,12 @@ def full(
     -------
     out: array
         an array where every element is equal to ``fill_value``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -273,6 +291,12 @@ def full_like(
     -------
     out: array
         an array having the same shape as ``x`` and where every element is equal to ``fill_value``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -334,12 +358,17 @@ def linspace(
     out: array
         a one-dimensional array containing evenly spaced values.
 
+    Notes
+    -----
 
     .. note::
        While this specification recommends that this function only return arrays having a floating-point data type, specification-compliant array libraries may choose to support output arrays having an integer data type (e.g., due to backward compatibility concerns). However, function behavior when generating integer output arrays is unspecified and, thus, is implementation-defined. Accordingly, using this function to generate integer output arrays is not portable.
 
     .. note::
        As mixed data type promotion is implementation-defined, behavior when ``start`` or ``stop`` exceeds the maximum safe integer of an output floating-point data type is implementation-defined. An implementation may choose to overflow or raise an exception.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -367,6 +396,12 @@ def meshgrid(*arrays: array, indexing: str = "xy") -> List[array]:
         Similarly, for the three-dimensional case with input one-dimensional arrays of length ``M``, ``N``, and ``P``, if matrix indexing ``ij``, then each returned array must have shape ``(M, N, P)``, and, if Cartesian indexing ``xy``, then each returned array must have shape ``(N, M, P)``.
 
         Each returned array should have the same data type as the input arrays.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -395,6 +430,12 @@ def ones(
     -------
     out: array
         an array containing ones.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -420,6 +461,12 @@ def ones_like(
     -------
     out: array
         an array having the same shape as ``x`` and filled with ones.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 

--- a/src/array_api_stubs/_2022_12/data_type_functions.py
+++ b/src/array_api_stubs/_2022_12/data_type_functions.py
@@ -36,6 +36,12 @@ def astype(x: array, dtype: dtype, /, *, copy: bool = True) -> array:
     -------
     out: array
         an array having the specified data type. The returned array must have the same shape as ``x``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -97,6 +103,14 @@ def finfo(type: Union[dtype, array], /) -> finfo_object:
         - **dtype**: dtype
 
           real-valued floating-point data type.
+
+          .. versionadded:: 2022.12
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -129,6 +143,8 @@ def iinfo(type: Union[dtype, array], /) -> iinfo_object:
         - **dtype**: dtype
 
           integer data type.
+
+          .. versionadded:: 2022.12
     """
 
 
@@ -167,6 +183,11 @@ def isdtype(
     -------
     out: bool
         boolean indicating whether a provided dtype is of a specified data type kind.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 

--- a/src/array_api_stubs/_2022_12/elementwise_functions.py
+++ b/src/array_api_stubs/_2022_12/elementwise_functions.py
@@ -52,6 +52,9 @@ def abs(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is a finite number, the result is ``NaN``.
     - If ``a`` is a finite number and ``b`` is ``NaN``, the result is ``NaN``.
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -118,6 +121,9 @@ def acos(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is a finite number, the result is ``NaN + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``+infinity``, the result is ``NaN - infinity j``.
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -189,6 +195,9 @@ def acosh(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is a finite number, the result is ``NaN + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``+infinity``, the result is ``+infinity + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -254,6 +263,9 @@ def add(x1: array, x2: array, /) -> array:
     - Similarly, if ``b`` is ``+0`` and ``d`` is ``-0``, the imaginary component of the result is ``+0``.
 
     Hence, if ``z1 = a + bj = -0 + 0j`` and ``z2 = c + dj = -0 - 0j``, the result of ``z1 + z2`` is ``-0 + 0j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -308,6 +320,9 @@ def asin(x: array, /) -> array:
     - If ``x_i`` is ``-0``, the result is ``-0``.
 
     For complex floating-point operands, special cases must be handled as if the operation is implemented as ``-1j * asinh(x*1j)``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -370,6 +385,9 @@ def asinh(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is a nonzero finite number, the result is ``NaN + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``+infinity``, the result is ``±infinity + NaN j`` (sign of the real component is unspecified).
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -419,6 +437,9 @@ def atan(x: array, /) -> array:
     - If ``x_i`` is ``-infinity``, the result is an implementation-dependent approximation to ``-π/2``.
 
     For complex floating-point operands, special cases must be handled as if the operation is implemented as ``-1j * atanh(x*1j)``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -541,6 +562,9 @@ def atanh(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is a finite number, the result is ``NaN + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``+infinity``, the result is ``±0 + πj/2`` (sign of the real component is unspecified).
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -709,6 +733,8 @@ def conj(x: array, /) -> array:
     -------
     out: array
         an array containing the element-wise results. The returned array must have the same data type as ``x``.
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -753,6 +779,9 @@ def cos(x: array, /) -> array:
     - If ``x_i`` is ``-infinity``, the result is ``NaN``.
 
     For complex floating-point operands, special cases must be handled as if the operation is implemented as ``cosh(x*1j)``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -813,6 +842,9 @@ def cosh(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
 
     where ``cis(v)`` is ``cos(v) + sin(v)*1j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -893,6 +925,9 @@ def divide(x1: array, x2: array, /) -> array:
 
     .. note::
        For complex floating-point operands, the results of special cases may be implementation dependent depending on how an implementation chooses to model complex numbers and complex infinity (e.g., complex plane versus Riemann sphere). For those implementations following C99 and its one-infinity model, when at least one component is infinite, even if the other component is ``NaN``, the complex value is infinite, and the usual arithmetic rules do not apply to complex-complex division. In the interest of performance, other implementations may want to avoid the complex branching logic necessary to implement the one-infinity model and choose to implement all complex-complex division according to the textbook formula. Accordingly, special case behavior is unlikely to be consistent across implementations.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -934,6 +969,9 @@ def equal(x1: array, x2: array, /) -> array:
 
     .. note::
        For discussion of complex number equality, see :ref:`complex-numbers`.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -987,6 +1025,9 @@ def exp(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
 
     where ``cis(v)`` is ``cos(v) + sin(v)*1j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1043,6 +1084,9 @@ def expm1(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
 
     where ``cis(v)`` is ``cos(v) + sin(v)*1j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1192,6 +1236,8 @@ def imag(x: array, /) -> array:
     -------
     out: array
         an array containing the element-wise results. The returned array must have a floating-point data type with the same floating-point precision as ``x`` (e.g., if ``x`` is ``complex64``, the returned array must have the floating-point data type ``float32``).
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -1226,6 +1272,9 @@ def isfinite(x: array, /) -> array:
     - If ``a`` is either ``+infinity`` or ``-infinity`` and ``b`` is any value, the result is ``False``.
     - If ``a`` is any value and ``b`` is either ``+infinity`` or ``-infinity``, the result is ``False``.
     - If ``a`` is a finite number and ``b`` is a finite number, the result is ``True``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1258,6 +1307,9 @@ def isinf(x: array, /) -> array:
     - If ``a`` is either ``+infinity`` or ``-infinity`` and ``b`` is any value (including ``NaN``), the result is ``True``.
     - If ``a`` is either a finite number or ``NaN`` and ``b`` is either ``+infinity`` or ``-infinity``, the result is ``True``.
     - In the remaining cases, the result is ``False``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1289,6 +1341,9 @@ def isnan(x: array, /) -> array:
 
     - If ``a`` or ``b`` is ``NaN``, the result is ``True``.
     - In the remaining cases, the result is ``False``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1390,6 +1445,9 @@ def log(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is a finite number, the result is ``NaN + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``+infinity``, the result is ``+infinity + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1449,6 +1507,9 @@ def log1p(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is a finite number, the result is ``NaN + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``+infinity``, the result is ``+infinity + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1488,6 +1549,9 @@ def log2(x: array, /) -> array:
        \log_{2} x = \frac{\log_{e} x}{\log_{e} 2}
 
     where :math:`\log_{e}` is the natural logarithm, as implemented by :func:`~array_api.log`.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1527,6 +1591,9 @@ def log10(x: array, /) -> array:
        \log_{10} x = \frac{\log_{e} x}{\log_{e} 10}
 
     where :math:`\log_{e}` is the natural logarithm, as implemented by :func:`~array_api.log`.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1703,6 +1770,9 @@ def multiply(x1: array, x2: array, /) -> array:
 
     .. note::
        For complex floating-point operands, the results of special cases may be implementation dependent depending on how an implementation chooses to model complex numbers and complex infinity (e.g., complex plane versus Riemann sphere). For those implementations following C99 and its one-infinity model, when at least one component is infinite, even if the other component is ``NaN``, the complex value is infinite, and the usual arithmetic rules do not apply to complex-complex multiplication. In the interest of performance, other implementations may want to avoid the complex branching logic necessary to implement the one-infinity model and choose to implement all complex-complex multiplication according to the textbook formula. Accordingly, special case behavior is unlikely to be consistent across implementations.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1725,6 +1795,12 @@ def negative(x: array, /) -> array:
     -------
     out: array
         an array containing the evaluated result for each element in ``x``. The returned array must have a data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1764,6 +1840,9 @@ def not_equal(x1: array, x2: array, /) -> array:
 
     .. note::
        For discussion of complex number equality, see :ref:`complex-numbers`.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1780,6 +1859,12 @@ def positive(x: array, /) -> array:
     -------
     out: array
         an array containing the evaluated result for each element in ``x``. The returned array must have the same data type as ``x``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1847,6 +1932,9 @@ def pow(x1: array, x2: array, /) -> array:
 
     .. note::
        Conforming implementations are allowed to treat special cases involving complex floating-point operands more carefully than as described in this specification.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -1863,6 +1951,10 @@ def real(x: array, /) -> array:
     -------
     out: array
         an array containing the element-wise results. The returned array must have a floating-point data type with the same floating-point precision as ``x`` (e.g., if ``x`` is ``complex64``, the returned array must have the floating-point data type ``float32``).
+
+    Notes
+    -----
+    .. versionadded:: 2022.12
     """
 
 
@@ -1958,6 +2050,9 @@ def round(x: array, /) -> array:
     - If ``x_i`` is ``-0``, the result is ``-0``.
     - If ``x_i`` is ``NaN``, the result is ``NaN``.
     - If two integers are equally close to ``x_i``, the result is the even integer closest to ``x_i``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -2002,6 +2097,9 @@ def sign(x: array, /) -> array:
     - If ``a`` is either ``-0`` or ``+0`` and ``b`` is either ``-0`` or ``+0``, the result is ``0 + 0j``.
     - If ``a`` is ``NaN`` or ``b`` is ``NaN``, the result is ``NaN + NaN j``.
     - In the remaining cases, special cases must be handled according to the rules of complex number division (see :func:`~array_api.divide`).
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -2045,6 +2143,9 @@ def sin(x: array, /) -> array:
     - If ``x_i`` is either ``+infinity`` or ``-infinity``, the result is ``NaN``.
 
     For complex floating-point operands, special cases must be handled as if the operation is implemented as ``-1j * sinh(x*1j)``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -2105,6 +2206,9 @@ def sinh(x: array, /) -> array:
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
 
     where ``cis(v)`` is ``cos(v) + sin(v)*1j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -2133,6 +2237,9 @@ def square(x: array, /) -> array:
     **Special cases**
 
     For floating-point operands, special cases must be handled as if the operation is implemented as ``x * x`` (see :func:`~array_api.multiply`).
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -2189,6 +2296,9 @@ def sqrt(x: array, /) -> array:
     - If ``a`` is ``+infinity`` and ``b`` is ``NaN``, the result is ``+infinity + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is any value, the result is ``NaN + NaN j``.
     - If ``a`` is ``NaN`` and ``b`` is ``NaN``, the result is ``NaN + NaN j``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -2209,6 +2319,12 @@ def subtract(x1: array, x2: array, /) -> array:
     -------
     out: array
         an array containing the element-wise differences. The returned array must have a data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -2252,6 +2368,9 @@ def tan(x: array, /) -> array:
     - If ``x_i`` is either ``+infinity`` or ``-infinity``, the result is ``NaN``.
 
     For complex floating-point operands, special cases must be handled as if the operation is implemented as ``-1j * tanh(x*1j)``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -2316,6 +2435,9 @@ def tanh(x: array, /) -> array:
        For historical reasons stemming from the C standard, array libraries may not return the expected result when ``a`` is ``+0`` and ``b`` is either ``+infinity`` or ``NaN``. The result should be ``+0 + NaN j`` in both cases; however, for libraries compiled against older C versions, the result may be ``NaN + NaN j``.
 
        Array libraries are not required to patch these older C versions, and, thus, users are advised that results may vary across array library implementations for these special cases.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 

--- a/src/array_api_stubs/_2022_12/fft.py
+++ b/src/array_api_stubs/_2022_12/fft.py
@@ -44,6 +44,11 @@ def fft(
     -------
     out: array
         an array transformed along the axis (dimension) indicated by ``axis``. The returned array must have a complex floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -90,6 +95,11 @@ def ifft(
     -------
     out: array
         an array transformed along the axis (dimension) indicated by ``axis``. The returned array must have a complex floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -143,6 +153,11 @@ def fftn(
     -------
     out: array
         an array transformed along the axes (dimension) indicated by ``axes``. The returned array must have a complex floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -196,6 +211,11 @@ def ifftn(
     -------
     out: array
         an array transformed along the axes (dimension) indicated by ``axes``. The returned array must have a complex floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -242,6 +262,11 @@ def rfft(
     -------
     out: array
         an array transformed along the axis (dimension) indicated by ``axis``. The returned array must have a complex-valued floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -288,6 +313,11 @@ def irfft(
     -------
     out: array
         an array transformed along the axis (dimension) indicated by ``axis``. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`. The length along the transformed axis is ``n`` (if given) or ``2*(m-1)`` (otherwise).
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -341,6 +371,11 @@ def rfftn(
     -------
     out: array
         an array transformed along the axes (dimension) indicated by ``axes``. The returned array must have a complex-valued floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -394,6 +429,11 @@ def irfftn(
     -------
     out: array
         an array transformed along the axes (dimension) indicated by ``axes``. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`. The length along the last transformed axis is ``s[-1]`` (if given) or ``2*(m - 1)`` (otherwise), and all other axes ``s[i]``.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -437,6 +477,11 @@ def hfft(
     -------
     out: array
         an array transformed along the axis (dimension) indicated by ``axis``. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -480,6 +525,11 @@ def ihfft(
     -------
     out: array
         an array transformed along the axis (dimension) indicated by ``axis``. The returned array must have a complex-valued floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -507,6 +557,11 @@ def fftfreq(n: int, /, *, d: float = 1.0, device: Optional[device] = None) -> ar
     -------
     out: array
         an array of length ``n`` containing the sample frequencies. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -536,6 +591,11 @@ def rfftfreq(n: int, /, *, d: float = 1.0, device: Optional[device] = None) -> a
     -------
     out: array
         an array of length ``n//2+1`` containing the sample frequencies. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -559,6 +619,11 @@ def fftshift(x: array, /, *, axes: Union[int, Sequence[int]] = None) -> array:
     -------
     out: array
         the shifted array. The returned array must have the same data type as ``x``.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 
@@ -580,6 +645,11 @@ def ifftshift(x: array, /, *, axes: Union[int, Sequence[int]] = None) -> array:
     -------
     out: array
         the shifted array. The returned array must have the same data type as ``x``.
+
+    Notes
+    -----
+
+    .. versionadded:: 2022.12
     """
 
 

--- a/src/array_api_stubs/_2022_12/linalg.py
+++ b/src/array_api_stubs/_2022_12/linalg.py
@@ -38,6 +38,12 @@ def cholesky(x: array, /, *, upper: bool = False) -> array:
     -------
     out: array
         an array containing the Cholesky factors for each square matrix. If ``upper`` is ``False``, the returned array must contain lower-triangular matrices; otherwise, the returned array must contain upper-triangular matrices. The returned array must have a floating-point data type determined by :ref:`type-promotion` and must have the same shape as ``x``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -65,6 +71,14 @@ def cross(x1: array, x2: array, /, *, axis: int = -1) -> array:
     out: array
         an array containing the cross products. The returned array must have a data type determined by :ref:`type-promotion`.
 
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added support for broadcasting.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
 
     **Raises**
 
@@ -87,6 +101,12 @@ def det(x: array, /) -> array:
     -------
     out: array
         if ``x`` is a two-dimensional array, a zero-dimensional array containing the determinant; otherwise, a non-zero dimensional array containing the determinant for each square matrix. The returned array must have the same data type as ``x``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -154,9 +174,14 @@ def eigh(x: array, /) -> Tuple[array]:
         -   first element must have the field name ``eigenvalues`` (corresponding to :math:`\operatorname{diag}\Lambda` above) and must be an array consisting of computed eigenvalues. The array containing the eigenvalues must have shape ``(..., M)`` and must have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then ``eigenvalues`` must be ``float64``).
         -   second element have have the field name ``eigenvectors`` (corresponding to :math:`Q` above) and must be an array where the columns of the inner most matrices contain the computed eigenvectors. These matrices must be orthogonal. The array containing the eigenvectors must have shape ``(..., M, M)`` and must have the same data type as ``x``.
 
+    Notes
+    -----
 
     .. note::
        Eigenvalue sort order is left unspecified and is thus implementation-dependent.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -192,9 +217,14 @@ def eigvalsh(x: array, /) -> array:
     out: array
         an array containing the computed eigenvalues. The returned array must have shape ``(..., M)`` and have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then must have a ``float64`` data type).
 
+    Notes
+    -----
 
     .. note::
        Eigenvalue sort order is left unspecified and is thus implementation-dependent.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -224,6 +254,12 @@ def inv(x: array, /) -> array:
     -------
     out: array
         an array containing the multiplicative inverses. The returned array must have a floating-point data type determined by :ref:`type-promotion` and must have the same shape as ``x``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -288,6 +324,12 @@ def matrix_norm(
     -------
     out: array
         an array containing the norms for each ``MxN`` matrix. If ``keepdims`` is ``False``, the returned array must have a rank which is two less than the rank of ``x``. If ``x`` has a real-valued data type, the returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`. If ``x`` has a complex-valued data type, the returned array must have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then the returned array must have a ``float64`` data type).
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -306,6 +348,12 @@ def matrix_power(x: array, n: int, /) -> array:
     -------
     out: array
         if ``n`` is equal to zero, an array containing the identity matrix for each square matrix. If ``n`` is less than zero, an array containing the inverse of each square matrix raised to the absolute value of ``n``, provided that each square matrix is invertible. If ``n`` is greater than zero, an array containing the result of raising each square matrix to the power ``n``. The returned array must have the same shape as ``x`` and a floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -326,6 +374,12 @@ def matrix_rank(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> a
     -------
     out: array
         an array containing the ranks. The returned array must have the default integer data type and must have shape ``(...)`` (i.e., must have a shape equal to ``shape(x)[:-2]``).
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -348,6 +402,12 @@ def outer(x1: array, x2: array, /) -> array:
     -------
     out: array
         a two-dimensional array containing the outer product and whose shape is ``(N, M)``. The returned array must have a data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -382,6 +442,12 @@ def pinv(x: array, /, *, rtol: Optional[Union[float, array]] = None) -> array:
     -------
     out: array
         an array containing the pseudo-inverse(s). The returned array must have a floating-point data type determined by :ref:`type-promotion` and must have shape ``(..., N, M)`` (i.e., must have the same shape as ``x``, except the innermost two dimensions must be transposed).
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -441,6 +507,12 @@ def qr(
         -   second element must have the field name ``R`` and must be an array whose shape depends on the value of ``mode`` and contain upper-triangular matrices. If ``mode`` is ``'complete'``, the array must have shape ``(..., M, N)``. If ``mode`` is ``'reduced'``, the array must have shape ``(..., K, N)``, where ``K = min(M, N)``. The first ``x.ndim-2`` dimensions must have the same size as those of the input ``x``.
 
         Each returned array must have a floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -490,6 +562,12 @@ def slogdet(x: array, /) -> Tuple[array, array]:
         -   second element must have the field name ``logabsdet`` and must be an array containing the natural logarithm of the absolute value of the determinant for each square matrix. If ``x`` is real-valued, the returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`. If ``x`` is complex, the returned array must have a real-valued floating-point data type having the same precision as ``x`` (e.g., if ``x`` is ``complex64``, ``logabsdet`` must have a ``float32`` data type).
 
         Each returned array must have shape ``shape(x)[:-2]``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -522,6 +600,12 @@ def solve(x1: array, x2: array, /) -> array:
     -------
     out: array
         an array containing the solution to the system ``AX = B`` for each square matrix. The returned array must have the same shape as ``x2`` (i.e., the array corresponding to ``B``) and must have a floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -571,6 +655,12 @@ def svd(x: array, /, *, full_matrices: bool = True) -> Union[array, Tuple[array,
         -   first element must have the field name ``U`` and must be an array whose shape depends on the value of ``full_matrices`` and contain matrices with orthonormal columns (i.e., the columns are left singular vectors). If ``full_matrices`` is ``True``, the array must have shape ``(..., M, M)``. If ``full_matrices`` is ``False``, the array must have shape ``(..., M, K)``, where ``K = min(M, N)``. The first ``x.ndim-2`` dimensions must have the same shape as those of the input ``x``. Must have the same data type as ``x``.
         -   second element must have the field name ``S`` and must be an array with shape ``(..., K)`` that contains the vector(s) of singular values of length ``K``, where ``K = min(M, N)``. For each vector, the singular values must be sorted in descending order by magnitude, such that ``s[..., 0]`` is the largest value, ``s[..., 1]`` is the second largest value, et cetera. The first ``x.ndim-2`` dimensions must have the same shape as those of the input ``x``. Must have a real-valued floating-point data type having the same precision as ``x`` (e.g., if ``x`` is ``complex64``, ``S`` must have a ``float32`` data type).
         -   third element must have the field name ``Vh`` and must be an array whose shape depends on the value of ``full_matrices`` and contain orthonormal rows (i.e., the rows are the right singular vectors and the array is the adjoint). If ``full_matrices`` is ``True``, the array must have shape ``(..., N, N)``. If ``full_matrices`` is ``False``, the array must have shape ``(..., K, N)`` where ``K = min(M, N)``. The first ``x.ndim-2`` dimensions must have the same shape as those of the input ``x``. Must have the same data type as ``x``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -589,6 +679,12 @@ def svdvals(x: array, /) -> array:
     -------
     out: array
         an array with shape ``(..., K)`` that contains the vector(s) of singular values of length ``K``, where ``K = min(M, N)``. For each vector, the singular values must be sorted in descending order by magnitude, such that ``s[..., 0]`` is the largest value, ``s[..., 1]`` is the second largest value, et cetera. The first ``x.ndim-2`` dimensions must have the same shape as those of the input ``x``. The returned array must have a real-valued floating-point data type having the same precision as ``x`` (e.g., if ``x`` is ``complex64``, the returned array must have a ``float32`` data type).
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -653,6 +749,9 @@ def trace(x: array, /, *, offset: int = 0, dtype: Optional[dtype] = None) -> arr
     -   If ``N`` is ``0``, the sum is ``0`` (i.e., the empty sum).
 
     For both real-valued and complex floating-point operands, special cases must be handled as if the operation is implemented by successive application of :func:`~array_api.add`.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -716,6 +815,12 @@ def vector_norm(
     -------
     out: array
         an array containing the vector norms. If ``axis`` is ``None``, the returned array must be a zero-dimensional array containing a vector norm. If ``axis`` is a scalar value (``int`` or ``float``), the returned array must have a rank which is one less than the rank of ``x``. If ``axis`` is a ``n``-tuple, the returned array must have a rank which is ``n`` less than the rank of ``x``. If ``x`` has a real-valued data type, the returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`. If ``x`` has a complex-valued data type, the returned array must have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then the returned array must have a ``float64`` data type).
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 

--- a/src/array_api_stubs/_2022_12/linear_algebra_functions.py
+++ b/src/array_api_stubs/_2022_12/linear_algebra_functions.py
@@ -32,6 +32,11 @@ def matmul(x1: array, x2: array, /) -> array:
 
         The returned array must have a data type determined by :ref:`type-promotion`.
 
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
 
     **Raises**
 
@@ -101,6 +106,12 @@ def tensordot(
     -------
     out: array
         an array containing the tensor contraction whose shape consists of the non-contracted axes (dimensions) of the first array ``x1``, followed by the non-contracted axes (dimensions) of the second array ``x2``. The returned array must have a data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -133,6 +144,11 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     out: array
         if ``x1`` and ``x2`` are both one-dimensional arrays, a zero-dimensional containing the dot product; otherwise, a non-zero-dimensional array containing the dot products and having rank ``N-1``, where ``N`` is the rank (number of dimensions) of the shape determined according to :ref:`broadcasting` along the non-contracted axes. The returned array must have a data type determined by :ref:`type-promotion`.
 
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
 
     **Raises**
 

--- a/src/array_api_stubs/_2022_12/searching_functions.py
+++ b/src/array_api_stubs/_2022_12/searching_functions.py
@@ -75,6 +75,12 @@ def nonzero(x: array, /) -> Tuple[array, ...]:
     -------
     out: Typle[array, ...]
         a tuple of ``k`` arrays, one for each dimension of ``x`` and each of size ``n`` (where ``n`` is the total number of non-zero elements), containing the indices of the non-zero elements in that dimension. The indices must be returned in row-major, C-style order. The returned array must have the default array index data type.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 

--- a/src/array_api_stubs/_2022_12/set_functions.py
+++ b/src/array_api_stubs/_2022_12/set_functions.py
@@ -38,6 +38,12 @@ def unique_all(x: array, /) -> Tuple[array, array, array, array]:
 
         .. note::
            The order of unique elements is not specified and may vary between implementations.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -74,6 +80,12 @@ def unique_counts(x: array, /) -> Tuple[array, array]:
 
         .. note::
            The order of unique elements is not specified and may vary between implementations.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -110,6 +122,12 @@ def unique_inverse(x: array, /) -> Tuple[array, array]:
 
         .. note::
            The order of unique elements is not specified and may vary between implementations.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -141,6 +159,12 @@ def unique_values(x: array, /) -> array:
 
         .. note::
            The order of unique elements is not specified and may vary between implementations.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 

--- a/src/array_api_stubs/_2022_12/statistical_functions.py
+++ b/src/array_api_stubs/_2022_12/statistical_functions.py
@@ -171,6 +171,9 @@ def prod(
     -   If ``N`` is ``0``, the product is `1` (i.e., the empty product).
 
     For both real-valued and complex floating-point operands, special cases must be handled as if the operation is implemented by successive application of :func:`~array_api.multiply`.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -265,6 +268,9 @@ def sum(
     -   If ``N`` is ``0``, the sum is ``0`` (i.e., the empty sum).
 
     For both real-valued and complex floating-point operands, special cases must be handled as if the operation is implemented by successive application of :func:`~array_api.add`.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 

--- a/src/array_api_stubs/_2022_12/utility_functions.py
+++ b/src/array_api_stubs/_2022_12/utility_functions.py
@@ -33,6 +33,12 @@ def all(
     -------
     out: array
         if a logical AND reduction was performed over the entire array, the returned array must be a zero-dimensional array containing the test result; otherwise, the returned array must be a non-zero-dimensional array containing the test results. The returned array must have a data type of ``bool``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 
@@ -68,6 +74,12 @@ def any(
     -------
     out: array
         if a logical OR reduction was performed over the entire array, the returned array must be a zero-dimensional array containing the test result; otherwise, the returned array must be a non-zero-dimensional array containing the test results. The returned array must have a data type of ``bool``.
+
+    Notes
+    -----
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
     """
 
 


### PR DESCRIPTION
This PR fixes #614,

- [x] Adds admonitions for changed APIs in 2022 version in the 2022.12 folder
- [x] Adds admonitions for new APIs in 2022 version in the 2022.12 folder 