### PR TITLE
Backport typo fix in tensordot

### DIFF
--- a/src/array_api_stubs/_2021_12/linear_algebra_functions.py
+++ b/src/array_api_stubs/_2021_12/linear_algebra_functions.py
@@ -75,7 +75,7 @@ def tensordot(x1: array, x2: array, /, *, axes: Union[int, Tuple[Sequence[int], 
         -   If ``N`` equals ``1``, the result is the tensor dot product.
         -   If ``N`` equals ``2``, the result is the tensor double contraction (default).
 
-        If ``axes`` is a tuple of two sequences ``(x1_axes, x2_axes)``, the first sequence must apply to ``x`` and the second sequence to ``x2``. Both sequences must have the same length. Each axis (dimension) ``x1_axes[i]`` for ``x1`` must have the same size as the respective axis (dimension) ``x2_axes[i]`` for ``x2``. Each sequence must consist of unique (nonnegative) integers that specify valid axes for each respective array.
+        If ``axes`` is a tuple of two sequences ``(x1_axes, x2_axes)``, the first sequence must apply to ``x1`` and the second sequence to ``x2``. Both sequences must have the same length. Each axis (dimension) ``x1_axes[i]`` for ``x1`` must have the same size as the respective axis (dimension) ``x2_axes[i]`` for ``x2``. Each sequence must consist of unique (nonnegative) integers that specify valid axes for each respective array.
 
     Returns
     -------

--- a/src/array_api_stubs/_2022_12/linear_algebra_functions.py
+++ b/src/array_api_stubs/_2022_12/linear_algebra_functions.py
@@ -96,7 +96,7 @@ def tensordot(
         -   If ``N`` equals ``1``, the result is the tensor dot product.
         -   If ``N`` equals ``2``, the result is the tensor double contraction (default).
 
-        If ``axes`` is a tuple of two sequences ``(x1_axes, x2_axes)``, the first sequence must apply to ``x`` and the second sequence to ``x2``. Both sequences must have the same length. Each axis (dimension) ``x1_axes[i]`` for ``x1`` must have the same size as the respective axis (dimension) ``x2_axes[i]`` for ``x2``. Each sequence must consist of unique (nonnegative) integers that specify valid axes for each respective array.
+        If ``axes`` is a tuple of two sequences ``(x1_axes, x2_axes)``, the first sequence must apply to ``x1`` and the second sequence to ``x2``. Both sequences must have the same length. Each axis (dimension) ``x1_axes[i]`` for ``x1`` must have the same size as the respective axis (dimension) ``x2_axes[i]`` for ``x2``. Each sequence must consist of unique (nonnegative) integers that specify valid axes for each respective array.
 
 
     .. note::


### PR DESCRIPTION
This PR backports the fix made in https://github.com/data-apis/array-api/pull/622 to,

- [x] 2021 version
- [x] 2022 version

