### PR TITLE
Modify versions menu to keep you on the same page

### DIFF
--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,15 +1,14 @@
 function assign_href( a, url, path ) {
     const r = fetch( url + "/" + path );
     r.then( response => {
-        console.log('...', response);
         if( response.ok ){
             a.href = url + "/" + path;
         }
         else {
-            a.href = url;
+            a.href = url + "/index.html";
         }
     }).catch( error => {
-        a.href = url;
+        a.href = url + "/index.html";
     });
 }
 
@@ -22,7 +21,6 @@ function add_version_dropdown(json_loc, target_loc, text) {
     content.className = "dropdown-content md-hero";
     dropdown.appendChild(button);
     dropdown.appendChild(content);
-    console.log('*********');
     $.getJSON(json_loc, function(versions) {
         var currentURL = window.location.href;
         var path = currentURL.split( "_site" )[ 1 ];

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -5,6 +5,9 @@ function assign_href( a, url, path ) {
         if( response.ok ){
             a.href = url + "/" + path;
         }
+        else {
+            a.href = url;
+        }
     }).catch( error => {
         a.href = url;
     });

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -21,9 +21,22 @@ function add_version_dropdown(json_loc, target_loc, text) {
                 var a = document.createElement("a");
                 a.innerHTML = key;
                 a.title = key;
-                a.href = target_loc + versions[key] + "/" + path;
-                console.log('----', a.href);
-                content.appendChild(a);
+                var url = target_loc + versions[key];
+                var http = new XMLHttpRequest();
+                http.open('HEAD', url + "/" + path );
+                http.onreadystatechange = function() {
+                    if (this.readyState == this.DONE) {
+                        callback(this.status != 404);
+                        if(this.status != 404 ){
+                            a.href = url + "/" + path;
+                        }
+                        else {
+                            a.href = url;
+                        }
+                        content.appendChild(a);
+                    }
+                };
+                http.send();
             }
         }
     }).done(function() {

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -13,7 +13,7 @@ function add_version_dropdown(json_loc, target_loc, text) {
         var currentURL = window.location.href;
         var path = currentURL.split( "_site" )[ 1 ];
         path = path.split('/');
-        path = path.slice(1, path.length);
+        path = path.slice(2, path.length);
         path = path.join('/');
         for (var key in versions) {
             if (versions.hasOwnProperty(key)) {

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,12 +1,11 @@
-function assign_href( a, url, path ) {
-    fetch( url + "/" + path ).then( response => {
-        if( response.ok ){
+function assign_href(a, url, path) {
+    fetch(url + "/" + path).then(response => {
+        if (response.ok){
             a.href = url + "/" + path;
-        }
-        else {
+        } else {
             a.href = url + "/index.html";
         }
-    }).catch( error => {
+    }).catch(error => {
         a.href = url + "/index.html";
     });
 }
@@ -22,17 +21,16 @@ function add_version_dropdown(json_loc, target_loc, text) {
     dropdown.appendChild(content);
     $.getJSON(json_loc, function(versions) {
         var currentURL = window.location.href;
-        var path = currentURL.split( "_site" )[ 1 ];
-        path = path.split('/');
+        var path = currentURL.split("_site")[1];
+        path = path.split("/");
         path = path.slice(2, path.length);
-        path = path.join('/');
+        path = path.join("/");
         for (var key in versions) {
             if (versions.hasOwnProperty(key)) {
-                console.log(key, versions[key]);
                 var a = document.createElement("a");
                 a.innerHTML = key;
                 a.title = key;
-                assign_href( a, target_loc + versions[key], path );
+                assign_href(a, target_loc + versions[key], path);
                 content.appendChild(a);
             }
         }

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,4 +1,4 @@
-function add_custom_version_dropdown(json_loc, target_loc, text) {
+function add_version_dropdown(json_loc, target_loc, text) {
 
     var dropdown = document.createElement("div");
     dropdown.className = "md-flex__cell md-flex__cell--shrink dropdown";

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,4 +1,4 @@
-function assign_href( a ) {
+function assign_href( a, url, path ) {
     var http = new XMLHttpRequest();
     http.open('GET', url + "/" + path );
     http.onreadystatechange = function() {
@@ -37,7 +37,7 @@ function add_version_dropdown(json_loc, target_loc, text) {
                 var a = document.createElement("a");
                 a.innerHTML = key;
                 a.title = key;
-                assign_href( a );
+                assign_href( a, target_loc + versions[key], path );
                 content.appendChild(a);
             }
         }

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,18 +1,14 @@
 function assign_href( a, url, path ) {
-    var http = new XMLHttpRequest();
-    http.open('GET', url + "/" + path );
-    http.onreadystatechange = function() {
-        if (this.readyState == this.DONE) {
-            if(this.status != 404 ){
-                console.log('%%%%', this);
-                a.href = url + "/" + path;
-            }
-            else {
-                a.href = url;
-            }
+    const r = fetch( url + "/" + path );
+    r.then( response => {
+        console.log('...', response);
+        if( response.ok ){
+            a.href = url + "/" + path;
         }
-    };
-    http.send();
+        else {
+            a.href = url;
+        }
+    });
 }
 
 function add_version_dropdown(json_loc, target_loc, text) {

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,0 +1,31 @@
+function add_custom_version_dropdown(json_loc, target_loc, text) {
+
+    var dropdown = document.createElement("div");
+    dropdown.className = "md-flex__cell md-flex__cell--shrink dropdown";
+    var button = document.createElement("button");
+    button.className = "dropdownbutton";
+    var content = document.createElement("div");
+    content.className = "dropdown-content md-hero";
+    dropdown.appendChild(button);
+    dropdown.appendChild(content);
+    console.log('*********');
+    $.getJSON(json_loc, function(versions) {
+        for (var key in versions) {
+            if (versions.hasOwnProperty(key)) {
+                console.log(key, versions[key]);
+                var a = document.createElement("a");
+                a.innerHTML = key;
+                a.title = key;
+                a.href = target_loc + versions[key] + "/{{ pagename }}.html";
+                console.log('----', a.href);
+                content.appendChild(a);
+            }
+        }
+    }).done(function() {
+        button.innerHTML = text;
+    }).fail(function() {
+        button.innerHTML = "Other Versions Not Found";
+    }).always(function() {
+        $(".navheader").append(dropdown);
+    });
+};

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -26,7 +26,6 @@ function add_version_dropdown(json_loc, target_loc, text) {
                 http.open('HEAD', url + "/" + path );
                 http.onreadystatechange = function() {
                     if (this.readyState == this.DONE) {
-                        callback(this.status != 404);
                         if(this.status != 404 ){
                             a.href = url + "/" + path;
                         }

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -2,9 +2,9 @@ function assign_href( a, url, path ) {
     var http = new XMLHttpRequest();
     http.open('GET', url + "/" + path );
     http.onreadystatechange = function() {
-        console.log('%%%%', this);
         if (this.readyState == this.DONE) {
             if(this.status != 404 ){
+                console.log('%%%%', this);
                 a.href = url + "/" + path;
             }
             else {

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,6 +1,6 @@
 function assign_href(a, url, path) {
     fetch(url + "/" + path).then(response => {
-        if (response.ok){
+        if (response.ok) {
             a.href = url + "/" + path;
         } else {
             a.href = url + "/index.html";

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -10,15 +10,18 @@ function add_version_dropdown(json_loc, target_loc, text) {
     dropdown.appendChild(content);
     console.log('*********');
     $.getJSON(json_loc, function(versions) {
+        var currentURL = window.location.href;
+        var path = currentURL.split( "_site" )[ 1 ];
+        path = path.split('/');
+        path = path.slice(1, path.length);
+        path = path.join('/');
         for (var key in versions) {
             if (versions.hasOwnProperty(key)) {
                 console.log(key, versions[key]);
-                var currentURL = window.location.href;
-                var path = currentURL.split( versions[key] )[ 1 ];
                 var a = document.createElement("a");
                 a.innerHTML = key;
                 a.title = key;
-                a.href = target_loc + versions[key] + path;
+                a.href = target_loc + versions[key] + "/" + path;
                 console.log('----', a.href);
                 content.appendChild(a);
             }

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -32,10 +32,10 @@ function add_version_dropdown(json_loc, target_loc, text) {
                         else {
                             a.href = url;
                         }
-                        content.appendChild(a);
                     }
                 };
                 http.send();
+                content.appendChild(a);
             }
         }
     }).done(function() {

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,5 +1,21 @@
-function add_version_dropdown(json_loc, target_loc, text) {
+function assign_href( a ) {
+    var http = new XMLHttpRequest();
+    http.open('GET', url + "/" + path );
+    http.onreadystatechange = function() {
+        console.log('%%%%', this);
+        if (this.readyState == this.DONE) {
+            if(this.status != 404 ){
+                a.href = url + "/" + path;
+            }
+            else {
+                a.href = url;
+            }
+        }
+    };
+    http.send();
+}
 
+function add_version_dropdown(json_loc, target_loc, text) {
     var dropdown = document.createElement("div");
     dropdown.className = "md-flex__cell md-flex__cell--shrink dropdown";
     var button = document.createElement("button");
@@ -21,21 +37,7 @@ function add_version_dropdown(json_loc, target_loc, text) {
                 var a = document.createElement("a");
                 a.innerHTML = key;
                 a.title = key;
-                var url = target_loc + versions[key];
-                var http = new XMLHttpRequest();
-                http.open('GET', url + "/" + path );
-                http.onreadystatechange = function() {
-                    console.log('%%%%', this);
-                    if (this.readyState == this.DONE) {
-                        if(this.status != 404 ){
-                            a.href = url + "/" + path;
-                        }
-                        else {
-                            a.href = url;
-                        }
-                    }
-                };
-                http.send();
+                assign_href( a );
                 content.appendChild(a);
             }
         }

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -13,10 +13,12 @@ function add_version_dropdown(json_loc, target_loc, text) {
         for (var key in versions) {
             if (versions.hasOwnProperty(key)) {
                 console.log(key, versions[key]);
+                var currentURL = window.location.href;
+                var path = currentURL.split( versions[key] )[ 1 ];
                 var a = document.createElement("a");
                 a.innerHTML = key;
                 a.title = key;
-                a.href = target_loc + versions[key] + "/{{ pagename }}.html";
+                a.href = target_loc + versions[key] + path;
                 console.log('----', a.href);
                 content.appendChild(a);
             }

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -23,7 +23,7 @@ function add_version_dropdown(json_loc, target_loc, text) {
                 a.title = key;
                 var url = target_loc + versions[key];
                 var http = new XMLHttpRequest();
-                http.open('HEAD', url + "/" + path );
+                http.open('GET', url + "/" + path );
                 http.onreadystatechange = function() {
                     if (this.readyState == this.DONE) {
                         if(this.status != 404 ){

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,6 +1,5 @@
 function assign_href( a, url, path ) {
-    const r = fetch( url + "/" + path );
-    r.then( response => {
+    fetch( url + "/" + path ).then( response => {
         if( response.ok ){
             a.href = url + "/" + path;
         }

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -5,9 +5,8 @@ function assign_href( a, url, path ) {
         if( response.ok ){
             a.href = url + "/" + path;
         }
-        else {
-            a.href = url;
-        }
+    }).catch( error => {
+        a.href = url;
     });
 }
 

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -25,6 +25,7 @@ function add_version_dropdown(json_loc, target_loc, text) {
                 var http = new XMLHttpRequest();
                 http.open('GET', url + "/" + path );
                 http.onreadystatechange = function() {
+                    console.log('%%%%', this);
                     if (this.readyState == this.DONE) {
                         if(this.status != 404 ){
                             a.href = url + "/" + path;


### PR DESCRIPTION
This PR fixes #620 

- Modify function of sphinx-material to remain in the same page if the version is changed.

## Extra info

I realized that we cannot guarantee that there will be a page available with the same path in the rest of versions. For example, if the function was added/removed/renamed in a later version.

If the page doesn't exist we will have an error that looks like this,

<img width="1295" alt="image" src="https://github.com/data-apis/array-api/assets/20992645/2e828636-8677-4ad5-81cc-fba8283535cd">

My fix was to add a head request before assigning the `href` to just verify if it is working, if it doesn't exist then it will redirect to the other version's homepage.