### PR TITLE
Fix invalid escape sequences in some files

### DIFF
--- a/src/array_api_stubs/_2021_12/creation_functions.py
+++ b/src/array_api_stubs/_2021_12/creation_functions.py
@@ -29,7 +29,7 @@ def arange(start: Union[int, float], /, stop: Optional[Union[int, float]] = None
     """
 
 def asarray(obj: Union[array, bool, int, float, NestedSequence, SupportsBufferProtocol], /, *, dtype: Optional[dtype] = None, device: Optional[device] = None, copy: Optional[bool] = None) -> array:
-    """
+    r"""
     Convert the input to an array.
 
     Parameters

--- a/src/array_api_stubs/_2021_12/elementwise_functions.py
+++ b/src/array_api_stubs/_2021_12/elementwise_functions.py
@@ -598,7 +598,7 @@ def floor(x: array, /) -> array:
     """
 
 def floor_divide(x1: array, x2: array, /) -> array:
-    """
+    r"""
     Rounds the result of dividing each element ``x1_i`` of the input array ``x1`` by the respective element ``x2_i`` of the input array ``x2`` to the greatest (i.e., closest to `+infinity`) integer-value number that is not greater than the division result.
 
     .. note::

--- a/src/array_api_stubs/_2021_12/linalg.py
+++ b/src/array_api_stubs/_2021_12/linalg.py
@@ -444,7 +444,7 @@ def vecdot(x1: array, x2: array, /, *, axis: int = None) -> array:
     """
 
 def vector_norm(x: array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False, ord: Union[int, float, Literal[inf, -inf]] = 2) -> array:
-    """
+    r"""
     Computes the vector norm of a vector (or batch of vectors) ``x``.
 
     Parameters


### PR DESCRIPTION
These can be found with the command

python -We:invalid -We::SyntaxWarning -m compileall -f -q src/