### PR TITLE
Fix optional keyword argument in `take` signature

### DIFF
--- a/src/array_api_stubs/_2022_12/indexing_functions.py
+++ b/src/array_api_stubs/_2022_12/indexing_functions.py
@@ -1,7 +1,7 @@
 from ._types import Union, array
 
 
-def take(x: array, indices: array, /, *, axis: int) -> array:
+def take(x: array, indices: array, /, *, axis: Optional[int] = None) -> array:
     """
     Returns elements of an array along an axis.
 

--- a/src/array_api_stubs/_draft/indexing_functions.py
+++ b/src/array_api_stubs/_draft/indexing_functions.py
@@ -1,7 +1,7 @@
 from ._types import Union, array
 
 
-def take(x: array, indices: array, /, *, axis: int) -> array:
+def take(x: array, indices: array, /, *, axis: Optional[int] = None) -> array:
     """
     Returns elements of an array along an axis.
 


### PR DESCRIPTION
This PR:

- fixes the signature for `take` in which the default value for the `axis` keyword argument should be `None`. Without this change, the `axis` keyword argument is always required (as arguments [must always](https://peps.python.org/pep-3102/) be bound to a value), even for the one-dimensional case. This PR corrects this error in the [original PR](https://github.com/data-apis/array-api/pull/416).
- backports the change to the 2022.12 revision of the array API standard.

Ref: https://github.com/data-apis/array-api-compat/issues/34