### PR TITLE
Fix version menu bug

### DIFF
--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -60,8 +60,8 @@ async function add_version_dropdown(json_loc, target_loc, text) {
 
     const p = $.getJSON(json_loc);
     console.log(p);
-    
-    p.done(onDone).fail(onFail).always(onAlways);
+
+    p.then(onVersions).fail(onFail).always(onAlways);
     await p;
 
     /**
@@ -71,7 +71,7 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     * @param {Object} versions - versions object
     * @returns {Promise} promise which resolves upon processing version data
     */
-    async function onDone(versions) {
+    async function onVersions(versions) {
         console.log(versions);
         
         // Resolve the current browser URL:

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,46 +1,114 @@
-function assign_href(a, url, path) {
-    fetch(url + "/" + path).then(response => {
+/**
+* Returns a URL corresponding to a versioned resource (if one exists).
+*
+* @private
+* @param {string} url - base URL
+* @param {string} path - resource path
+* @returns {Promise} promise which resolves a resource URL
+*/
+async function href(url, path) {
+    const defaultURL = url + "/index.html";
+    url += "/" + path;
+    await fetch(url).then(onResponse).catch(onError);
+
+    /**
+    * Success handler.
+    *
+    * @private
+    * @param {Object} response - response object
+    */
+    function onResponse(response) {
         if (response.ok) {
-            a.href = url + "/" + path;
-        } else {
-            a.href = url + "/index.html";
+            return url;
         }
-    }).catch(error => {
-        a.href = url + "/index.html";
-    });
+        return defaultURL;
+    }
+
+    /**
+    * Error handler.
+    *
+    * @private
+    * @param {Error} error - error object
+    */
+    function onError(error) {
+        return defaultURL;
+    }
 }
 
-function add_version_dropdown(json_loc, target_loc, text) {
-    var dropdown = document.createElement("div");
+/**
+* Adds a version dropdown menu with custom URL paths depending on the current page.
+*
+* @param {string} json_loc - JSON URL
+* @param {string} target_loc - target URL
+* @param {string} text - text
+* @returns {Promise} promise which resolves upon adding a version menu
+*/
+async function add_version_dropdown(json_loc, target_loc, text) {
+    const dropdown = document.createElement("div");
     dropdown.className = "md-flex__cell md-flex__cell--shrink dropdown";
-    var button = document.createElement("button");
+
+    const button = document.createElement("button");
     button.className = "dropdownbutton";
-    var content = document.createElement("div");
+
+    const content = document.createElement("div");
     content.className = "dropdown-content md-hero";
+
     dropdown.appendChild(button);
     dropdown.appendChild(content);
-    $.getJSON(json_loc, function(versions) {
-        var currentURL = window.location.href;
-        var path = currentURL.split(/_site|array_api/)[1];
+
+    await $.getJSON(json_loc, onVersions).done(onDone).fail(onFail).always(onAlways);
+
+    /**
+    * Callback invoked upon successfully resolving a list of versions.
+    *
+    * @private
+    * @param {Object} versions - versions object
+    */
+    async function onVersions(versions) {
+        const currentURL = window.location.href;
+        let path = currentURL.split(/_site|array_api/)[1];
         if (path) {
             path = path.split("/");
             path = path.slice(2, path.length);
             path = path.join("/");
-            for (var key in versions) {
-                if (versions.hasOwnProperty(key)) {
-                    var a = document.createElement("a");
-                    a.innerHTML = key;
-                    a.title = key;
-                    assign_href(a, target_loc + versions[key], path);
-                    content.appendChild(a);
-                }
+        } else {
+            path = "";
+        }
+        for (let key in versions) {
+            if (versions.hasOwnProperty(key)) {
+                let a = document.createElement("a");
+                a.innerHTML = key;
+                a.title = key;
+                a.href = await href(target_loc + versions[key], path);
+                content.appendChild(a);
             }
         }
-    }).done(function() {
+    }
+
+    /**
+    * Callback invoked upon resolving a JSON resource.
+    *
+    * @private
+    */
+    function onDone() {
         button.innerHTML = text;
-    }).fail(function() {
+    }
+
+    /**
+    * Callback invoked upon failing to resolve a JSON resource.
+    *
+    * @private
+    */
+    function onFail() {
         button.innerHTML = "Other Versions Not Found";
-    }).always(function() {
+    }
+
+    /**
+    * Callback which is always invoked upon attempting to resolve a JSON resource.
+    *
+    * @private
+    */
+    function onAlways() {
         $(".navheader").append(dropdown);
-    });
+    }
 };

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -65,6 +65,7 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     *
     * @private
     * @param {Object} versions - versions object
+    * @returns {Promise} promise which resolves upon processing version data
     */
     async function onDone(versions) {
         const currentURL = window.location.href;

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -1,5 +1,5 @@
 /**
-* Returns a URL corresponding to a versioned resource (if one exists).
+* Returns a promise for resolving a URL corresponding to a versioned resource (if one exists).
 *
 * @private
 * @param {string} url - base URL

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -61,9 +61,10 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     const p = $.getJSON(json_loc);
     console.log(p);
 
+    p.then(onVersions);
     p.fail(onFail).always(onAlways);
 
-    await p.then(onVersions);
+    await p.promise();
 
     /**
     * Callback invoked upon resolving a JSON resource.

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -9,6 +9,8 @@
 async function href(url, path) {
     const defaultURL = url + "/index.html";
     url += "/" + path;
+
+    // If a versioned resource exists, return the resource's URL; otherwise, return a default URL:
     await fetch(url).then(onResponse).catch(onError);
 
     /**

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -87,7 +87,7 @@ async function add_version_dropdown(json_loc, target_loc, text) {
         const currentURL = window.location.href;
 
         // Check whether the user is currently on a resource page (e.g., is viewing the specification for a particular function):
-        let path = currentURL.split(/_site|array_api/)[1];
+        let path = currentURL.split(/_site|array\-api/)[1];
 
         // Extract the resource subpath:
         if (path) {

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -130,7 +130,7 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     *
     * @private
     */
-    function onFail() {
+    function onError() {
         button.innerHTML = "Other Versions Not Found";
 
         // Append dropdown:

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -58,7 +58,11 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     dropdown.appendChild(button);
     dropdown.appendChild(content);
 
-    await $.getJSON(json_loc).done(onDone).fail(onFail).always(onAlways);
+    const p = $.getJSON(json_loc);
+    console.log(p);
+    
+    p.done(onDone).fail(onFail).always(onAlways);
+    await p;
 
     /**
     * Callback invoked upon resolving a JSON resource.
@@ -115,6 +119,7 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     * @private
     */
     function onFail() {
+        console.log("Failure");
         button.innerHTML = "Other Versions Not Found";
     }
 
@@ -124,6 +129,7 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     * @private
     */
     function onAlways() {
+        console.log("Always");
         $(".navheader").append(dropdown);
     }
 };

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -11,7 +11,10 @@ function href(url, path) {
     url += "/" + path;
 
     // If a versioned resource exists, return the resource's URL; otherwise, return a default URL:
-    return fetch(url).then(onResponse).catch(onError);
+    const opts = {
+        'method': 'HEAD'
+    };
+    return fetch(url, opts).then(onResponse).catch(onError);
 
     /**
     * Callback invoked upon successfully resolving a resource.

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -9,7 +9,7 @@
 function href(url, path) {
     const defaultURL = url + "/index.html";
     url += "/" + path;
-console.log(url);
+
     // If a versioned resource exists, return the resource's URL; otherwise, return a default URL:
     return fetch(url).then(onResponse).catch(onError);
 
@@ -86,7 +86,7 @@ async function add_version_dropdown(json_loc, target_loc, text) {
 
         // Check whether the user is currently on a resource page (e.g., is viewing the specification for a particular function):
         let path = currentURL.split(/_site|array\-api/)[1];
-console.log(path);
+
         // Extract the resource subpath:
         if (path) {
             path = path.split("/");

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -68,6 +68,7 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     * @returns {Promise} promise which resolves upon processing version data
     */
     async function onDone(versions) {
+        console.log(versions)
         const currentURL = window.location.href;
         let path = currentURL.split(/_site|array_api/)[1];
         if (path) {

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -61,8 +61,9 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     const p = $.getJSON(json_loc);
     console.log(p);
 
-    p.then(onVersions).fail(onFail).always(onAlways);
-    await p;
+    p.fail(onFail).always(onAlways);
+
+    await p.then(onVersions);
 
     /**
     * Callback invoked upon resolving a JSON resource.
@@ -119,7 +120,6 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     * @private
     */
     function onFail() {
-        console.log("Failure");
         button.innerHTML = "Other Versions Not Found";
     }
 

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -14,7 +14,7 @@ async function href(url, path) {
     await fetch(url).then(onResponse).catch(onError);
 
     /**
-    * Success handler.
+    * Callback invoked upon successfully resolving a resource.
     *
     * @private
     * @param {Object} response - response object
@@ -27,7 +27,7 @@ async function href(url, path) {
     }
 
     /**
-    * Error handler.
+    * Callback invoked upon failing to resolve a resource.
     *
     * @private
     * @param {Error} error - error object

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -9,7 +9,7 @@
 function href(url, path) {
     const defaultURL = url + "/index.html";
     url += "/" + path;
-
+console.log(url);
     // If a versioned resource exists, return the resource's URL; otherwise, return a default URL:
     return fetch(url).then(onResponse).catch(onError);
 
@@ -81,14 +81,12 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     * @returns {Promise} promise which resolves upon processing version data
     */
     async function onVersions(versions) {
-        console.log(versions);
-        
         // Resolve the current browser URL:
         const currentURL = window.location.href;
 
         // Check whether the user is currently on a resource page (e.g., is viewing the specification for a particular function):
         let path = currentURL.split(/_site|array\-api/)[1];
-
+console.log(path);
         // Extract the resource subpath:
         if (path) {
             path = path.split("/");

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -58,13 +58,20 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     dropdown.appendChild(button);
     dropdown.appendChild(content);
 
-    const p = $.getJSON(json_loc);
-    console.log(p);
+    const opts = {
+        'method': 'GET'
+    };
+    await fetch(json_loc, opts).then(onResponse).then(onVersions).catch(onError);
 
-    p.then(onVersions);
-    p.fail(onFail).always(onAlways);
-
-    await p.promise();
+    /**
+    * Callback invoked upon resolving a resource.
+    *
+    * @private
+    * @param {Object} response - response object
+    */
+    function onResponse(response) {
+        return response.json();
+    }
 
     /**
     * Callback invoked upon resolving a JSON resource.
@@ -113,24 +120,20 @@ async function add_version_dropdown(json_loc, target_loc, text) {
         }
         // Set the button text:
         button.innerHTML = text;
+
+        // Append dropdown:
+        $(".navheader").append(dropdown);
     }
 
     /**
-    * Callback invoked upon failing to resolve a JSON resource.
+    * Callback invoked upon failing to resolve a resource.
     *
     * @private
     */
     function onFail() {
         button.innerHTML = "Other Versions Not Found";
-    }
 
-    /**
-    * Callback which is always invoked upon attempting to resolve a JSON resource.
-    *
-    * @private
-    */
-    function onAlways() {
-        console.log("Always");
+        // Append dropdown:
         $(".navheader").append(dropdown);
     }
 };

--- a/spec/_static/javascripts/version_dropdown.js
+++ b/spec/_static/javascripts/version_dropdown.js
@@ -56,15 +56,15 @@ async function add_version_dropdown(json_loc, target_loc, text) {
     dropdown.appendChild(button);
     dropdown.appendChild(content);
 
-    await $.getJSON(json_loc, onVersions).done(onDone).fail(onFail).always(onAlways);
+    await $.getJSON(json_loc).done(onDone).fail(onFail).always(onAlways);
 
     /**
-    * Callback invoked upon successfully resolving a list of versions.
+    * Callback invoked upon resolving a JSON resource.
     *
     * @private
     * @param {Object} versions - versions object
     */
-    async function onVersions(versions) {
+    async function onDone(versions) {
         const currentURL = window.location.href;
         let path = currentURL.split(/_site|array_api/)[1];
         if (path) {
@@ -83,14 +83,6 @@ async function add_version_dropdown(json_loc, target_loc, text) {
                 content.appendChild(a);
             }
         }
-    }
-
-    /**
-    * Callback invoked upon resolving a JSON resource.
-    *
-    * @private
-    */
-    function onDone() {
         button.innerHTML = text;
     }
 


### PR DESCRIPTION
This PR

- refactors version menu logic to use async/await.
- refactors the implementation to accommodate when a resource path does not have expected path segments.
- adds JSDoc comments to clarify callback intent
- reduces network traffic by performing a `HEAD` request rather than a full `GET`. This addresses the intent of [gh-628](https://github.com/data-apis/array-api/pull/628), but in that PR, a full `GET` request is made.