### PR TITLE
Fix documentation for constants

### DIFF
--- a/spec/2021.12/API_specification/constants.rst
+++ b/spec/2021.12/API_specification/constants.rst
@@ -10,7 +10,7 @@ A conforming implementation of the array API standard must provide and support t
 Objects in API
 --------------
 
-.. currentmodule:: array_api
+.. currentmodule:: array_api.constants
 
 ..
   NOTE: please keep the functions in alphabetical order

--- a/spec/2022.12/API_specification/constants.rst
+++ b/spec/2022.12/API_specification/constants.rst
@@ -10,7 +10,7 @@ A conforming implementation of the array API standard must provide and support t
 Objects in API
 --------------
 
-.. currentmodule:: array_api
+.. currentmodule:: array_api.constants
 
 ..
   NOTE: please keep the functions in alphabetical order

--- a/spec/draft/API_specification/constants.rst
+++ b/spec/draft/API_specification/constants.rst
@@ -10,7 +10,7 @@ A conforming implementation of the array API standard must provide and support t
 Objects in API
 --------------
 
-.. currentmodule:: array_api
+.. currentmodule:: array_api.constants
 
 ..
   NOTE: please keep the functions in alphabetical order


### PR DESCRIPTION
Sphinx cannot find the docstring corresponding to a constant unless you point it to the exact file where it is, since it doesn't actually live on the object itself. See https://github.com/sphinx-doc/sphinx/issues/6495

Fixes #601