### PR TITLE
Add custom css to avoid line-through decorations in Literal arguments

### DIFF
--- a/spec/_static/css/custom.css
+++ b/spec/_static/css/custom.css
@@ -1,0 +1,3 @@
+s {
+    text-decoration: inherit;
+}

--- a/src/_array_api_conf.py
+++ b/src/_array_api_conf.py
@@ -211,3 +211,4 @@ def process_signature(app, what, name, obj, options, signature, return_annotatio
 
 def setup(app):
     app.connect("autodoc-process-signature", process_signature)
+    app.add_css_file('css/custom.css')


### PR DESCRIPTION
This PR fixes https://github.com/data-apis/array-api/issues/646

Apparently this issue was happening because the user agent stylesheet is overriding Sphinx css style. By adding a custom css file this issue is fixed! 

Before:
<img width="1114" alt="image" src="https://github.com/data-apis/array-api/assets/20992645/f0944b5b-5407-4e8b-807b-a8f2072aec91">

After:
<img width="741" alt="image" src="https://github.com/data-apis/array-api/assets/20992645/bd233df7-ccdc-4c8b-b325-05618a55f41e">