### PR TITLE
Fix invalid latex in `qr` function API docstring

### DIFF
--- a/src/array_api_stubs/_2022_12/linalg.py
+++ b/src/array_api_stubs/_2022_12/linalg.py
@@ -473,7 +473,7 @@ def qr(
 
     where :math:`Q \in\ \mathbb{K}^{m \times n}` and :math:`R \in\ \mathbb{K}^{n \times n}`.
 
-    The reduced QR decomposition equals with the complete QR decomposition when :math:`n \qeq m` (wide matrix).
+    The reduced QR decomposition equals with the complete QR decomposition when :math:`n \geq m` (wide matrix).
 
     When ``x`` is a stack of matrices, the function must compute the QR decomposition for each matrix in the stack.
 

--- a/src/array_api_stubs/_draft/linalg.py
+++ b/src/array_api_stubs/_draft/linalg.py
@@ -473,7 +473,7 @@ def qr(
 
     where :math:`Q \in\ \mathbb{K}^{m \times n}` and :math:`R \in\ \mathbb{K}^{n \times n}`.
 
-    The reduced QR decomposition equals with the complete QR decomposition when :math:`n \qeq m` (wide matrix).
+    The reduced QR decomposition equals with the complete QR decomposition when :math:`n \geq m` (wide matrix).
 
     When ``x`` is a stack of matrices, the function must compute the QR decomposition for each matrix in the stack.
 


### PR DESCRIPTION
This PR fixes invalid latex in `qr` function in,

- [x] 2022.12 version
- [x] draft version

This issue was raised by @asmeurer in https://github.com/data-apis/array-api/issues/646#issuecomment-1624167124

Before:
<img width="954" alt="image" src="https://github.com/data-apis/array-api/assets/20992645/bcedb680-e533-41d3-a48d-53dd40564447">

After:
<img width="775" alt="image" src="https://github.com/data-apis/array-api/assets/20992645/cae9c0d3-ea39-4cf2-8676-b0b6e1f75113">
