### PR TITLE
Add version to the nav title

### DIFF
--- a/spec/2021.12/conf.py
+++ b/spec/2021.12/conf.py
@@ -6,4 +6,8 @@ from array_api_stubs import _2021_12 as stubs_mod
 from _array_api_conf import *
 
 release = "2021.12"
+
+nav_title = html_theme_options.get("nav_title") + " v{}".format(release)
+html_theme_options.update({"nav_title": nav_title})
+
 sys.modules["array_api"] = stubs_mod

--- a/spec/2022.12/conf.py
+++ b/spec/2022.12/conf.py
@@ -6,4 +6,7 @@ from array_api_stubs import _2022_12 as stubs_mod
 from _array_api_conf import *
 
 release = "2022.12"
+
+nav_title = html_theme_options.get("nav_title") + " v{}".format(release)
+html_theme_options.update({"nav_title": nav_title})
 sys.modules["array_api"] = stubs_mod

--- a/spec/draft/conf.py
+++ b/spec/draft/conf.py
@@ -6,4 +6,7 @@ from array_api_stubs import _draft as stubs_mod
 from _array_api_conf import *
 
 release = "DRAFT"
+
+nav_title = html_theme_options.get("nav_title") + " {}".format(release)
+html_theme_options.update({"nav_title": nav_title})
 sys.modules["array_api"] = stubs_mod


### PR DESCRIPTION
Fixes https://github.com/data-apis/array-api/issues/651

This PR adds the version to the nav title so it will be visible in the header and in the sidebar. This is how it looks with the changes for the current versions,

**Version 2021.12**
<img width="1739" alt="image" src="https://github.com/data-apis/array-api/assets/20992645/2b96cd67-5069-4c43-9ca5-5891c4ef4244">

**Version 2022.12**
<img width="1741" alt="image" src="https://github.com/data-apis/array-api/assets/20992645/08d2a0b7-ad5f-4d7c-b4a8-9085cf4fb2d5">

**Draft version**
<img width="1758" alt="image" src="https://github.com/data-apis/array-api/assets/20992645/56f8101c-a911-4ccb-8a9e-af74c96ae9a7">

I don't love how the Draft version looks, I don't know if there's a preference between uppercase, lowercase or capitalized. 