### PR TITLE
Update GitHub preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,6 +11,7 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/_site/draft/index.html
           circleci-jobs: build_page
           job-title: Check the rendered docs here!


### PR DESCRIPTION
This PR

- updates the GitHub workflow for viewing documentation previews using CircleCI. As discussed in this thread https://github.com/larsoner/circleci-artifacts-redirector-action/issues/40, providing a CircleCI API token may resolve various build failures we are currently encountering (e.g., https://github.com/data-apis/array-api/actions/runs/5604799678).

Follow-up PRs may be necessary if the changes in this PR do not resolve the underlying issue.