### PR TITLE
Clarify types to allow None in indexing

### DIFF
--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -477,7 +477,7 @@ class _array:
     def __getitem__(
         self: array,
         key: Union[
-            int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], array
+            int, slice, ellipsis, Tuple[Union[int, slice, ellipsis, None], ...], array
         ],
         /,
     ) -> array:
@@ -488,7 +488,7 @@ class _array:
         ----------
         self: array
             array instance.
-        key: Union[int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], array]
+        key: Union[int, slice, ellipsis, Tuple[Union[int, slice, ellipsis, None], ...], array]
             index key.
 
         Returns


### PR DESCRIPTION
I believe that the [indexing specification allows](https://data-apis.org/array-api/draft/API_specification/indexing.html) None in a selection tuple, but the current typing does not specify this. I have changed the signature for __getitem__ but did not change __setitem__. I am not sure where it is documented if the indexing specification applies to both equally.

> Each None in the selection tuple must expand the dimensions of the resulting selection by one dimension of size 1. The position of the added dimension must be the same as the position of None in the selection tuple.