### PR TITLE
Backport type fixes to `__getitem__` to previous specification revisions

### DIFF
--- a/spec/draft/API_specification/indexing.rst
+++ b/spec/draft/API_specification/indexing.rst
@@ -156,6 +156,9 @@ Multi-dimensional arrays must extend the concept of single-axis indexing to mult
   .. note::
     Expanding dimensions can be equivalently achieved via repeated invocation of :func:`~array_api.expand_dims`.
 
+  .. note::
+    The constant ``newaxis`` is an alias of ``None`` and can thus be used in a similar manner as ``None``.
+
 - Except in the case of providing a single ellipsis (e.g., ``A[2:10, ...]`` or ``A[1:, ..., 2:5]``), the number of provided single-axis indexing expressions (excluding ``None``) should equal ``N``. For example, if ``A`` has rank ``2``, a single-axis indexing expression should be explicitly provided for both axes (e.g., ``A[2:10, :]``). An ``IndexError`` exception should be raised if the number of provided single-axis indexing expressions (excluding ``None``) is less than ``N``.
 
   .. note::

--- a/src/array_api_stubs/_2021_12/array_object.py
+++ b/src/array_api_stubs/_2021_12/array_object.py
@@ -453,7 +453,12 @@ class _array:
     def __getitem__(
         self: array,
         key: Union[
-            int, slice, ellipsis, None, Tuple[Union[int, slice, ellipsis, None], ...], array
+            int,
+            slice,
+            ellipsis,
+            None,
+            Tuple[Union[int, slice, ellipsis, None], ...],
+            array,
         ],
         /,
     ) -> array:

--- a/src/array_api_stubs/_2021_12/array_object.py
+++ b/src/array_api_stubs/_2021_12/array_object.py
@@ -453,7 +453,7 @@ class _array:
     def __getitem__(
         self: array,
         key: Union[
-            int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], array
+            int, slice, ellipsis, None, Tuple[Union[int, slice, ellipsis, None], ...], array
         ],
         /,
     ) -> array:
@@ -464,7 +464,7 @@ class _array:
         ----------
         self: array
             array instance.
-        key: Union[int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], array]
+        key: Union[int, slice, ellipsis, None, Tuple[Union[int, slice, ellipsis, None], ...], array]
             index key.
 
         Returns

--- a/src/array_api_stubs/_2022_12/array_object.py
+++ b/src/array_api_stubs/_2022_12/array_object.py
@@ -477,7 +477,7 @@ class _array:
     def __getitem__(
         self: array,
         key: Union[
-            int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], array
+            int, slice, ellipsis, None, Tuple[Union[int, slice, ellipsis, None], ...], array
         ],
         /,
     ) -> array:
@@ -488,7 +488,7 @@ class _array:
         ----------
         self: array
             array instance.
-        key: Union[int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], array]
+        key: Union[int, slice, ellipsis, None, Tuple[Union[int, slice, ellipsis, None], ...], array]
             index key.
 
         Returns

--- a/src/array_api_stubs/_2022_12/array_object.py
+++ b/src/array_api_stubs/_2022_12/array_object.py
@@ -477,7 +477,12 @@ class _array:
     def __getitem__(
         self: array,
         key: Union[
-            int, slice, ellipsis, None, Tuple[Union[int, slice, ellipsis, None], ...], array
+            int,
+            slice,
+            ellipsis,
+            None,
+            Tuple[Union[int, slice, ellipsis, None], ...],
+            array,
         ],
         /,
     ) -> array:

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -479,7 +479,12 @@ class _array:
     def __getitem__(
         self: array,
         key: Union[
-            int, slice, ellipsis, None, Tuple[Union[int, slice, ellipsis, None], ...], array
+            int,
+            slice,
+            ellipsis,
+            None,
+            Tuple[Union[int, slice, ellipsis, None], ...],
+            array,
         ],
         /,
     ) -> array:

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -479,7 +479,7 @@ class _array:
     def __getitem__(
         self: array,
         key: Union[
-            int, slice, ellipsis, Tuple[Union[int, slice, ellipsis, None], ...], array
+            int, slice, ellipsis, None, Tuple[Union[int, slice, ellipsis, None], ...], array
         ],
         /,
     ) -> array:
@@ -490,7 +490,7 @@ class _array:
         ----------
         self: array
             array instance.
-        key: Union[int, slice, ellipsis, Tuple[Union[int, slice, ellipsis, None], ...], array]
+        key: Union[int, slice, ellipsis, None, Tuple[Union[int, slice, ellipsis, None], ...], array]
             index key.
 
         Returns


### PR DESCRIPTION
This PR

- is a follow-up to https://github.com/data-apis/array-api/pull/674, where the changes introduced in that PR are backported to previous specification revisions.
- as the specification guidance describes the use of `None` in multi-axis indexing from the 2021 revision onward, the exclusion of `None` from the typings was an omission. This PR addresses this omission.
- introduces a short note regarding `newaxis` which is not mentioned in the indexing document, but should likely be mentioned due to its use as a more literate means for introducing new axes.