### PR TITLE
Add `repeat` to the specification

### DIFF
--- a/spec/draft/API_specification/manipulation_functions.rst
+++ b/spec/draft/API_specification/manipulation_functions.rst
@@ -25,6 +25,7 @@ Objects in API
    flip
    moveaxis
    permute_dims
+   repeat
    reshape
    roll
    squeeze

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -170,6 +170,11 @@ def repeat(
     """
     Repeats elements of an array.
 
+    .. admonition:: Data-dependent output shape
+        :class: important
+
+        The shape of the output array for this function depends on the data values in the ``repeats`` array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See :ref:`data-dependent-output-shapes` section for more details.
+
     Parameters
     ----------
     x: array

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -178,15 +178,15 @@ def repeat(
 
         If ``axis`` is ``None``, let ``N = prod(x.shape)`` and
 
-        -   if ``repeats`` is an array, ``repeats`` must be broadcast compatible with the shape ``(N)`` (i.e., be a one-dimensional array having shape ``(1)`` or ``(N)``).
-        -   if ``repeats`` is a sequence of integers, ``len(repeats)`` must be broadcast compatible with the shape ``(N)`` (i.e., the number of sequence elements be either ``1`` or ``N``).
-        -   if ``repeats`` is an integer, ``repeats`` must be broadcasted to the shape `(N)`.
+        -   if ``repeats`` is an array, ``repeats`` must be broadcast compatible with the shape ``(N,)`` (i.e., be a one-dimensional array having shape ``(1,)`` or ``(N,)``).
+        -   if ``repeats`` is a sequence of integers, ``len(repeats)`` must be broadcast compatible with the shape ``(N,)`` (i.e., the number of sequence elements be either ``1`` or ``N``).
+        -   if ``repeats`` is an integer, ``repeats`` must be broadcasted to the shape `(N,)`.
 
         If ``axis`` is not ``None``, let ``M = x.shape[axis]`` and
 
-        -   if ``repeats`` is an array, ``repeats`` must be broadcast compatible with the shape ``(M)`` (i.e., be a one-dimensional array having shape ``(1)`` or ``(M)``).
-        -   if ``repeats`` is a sequence of integers, ``len(repeats)`` must be broadcast compatible with the shape ``(M)`` (i.e., the number of sequence elements must be either ``1`` or ``M``).
-        -   if ``repeats`` is an integer, ``repeats`` must be broadcasted to the shape ``(M)``.
+        -   if ``repeats`` is an array, ``repeats`` must be broadcast compatible with the shape ``(M,)`` (i.e., be a one-dimensional array having shape ``(1,)`` or ``(M,)``).
+        -   if ``repeats`` is a sequence of integers, ``len(repeats)`` must be broadcast compatible with the shape ``(M,)`` (i.e., the number of sequence elements must be either ``1`` or ``M``).
+        -   if ``repeats`` is an integer, ``repeats`` must be broadcasted to the shape ``(M,)``.
 
         If ``repeats`` is an array, the array must have an integer data type.
     axis: Optional[int]

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -191,9 +191,8 @@ def repeat(
 
         If ``repeats`` is an array, the array must have an integer data type.
 
-
-    .. note::
-       For specification-conforming array libraries supporting hardware acceleration, providing an array for ``repeats`` may cause device synchronization due to an unknown output shape. For those array libraries where synchronization concerns are applicable, conforming array libraries are advised to include a warning in their documentation regarding potential performance degradation when ``repeats`` is an array.
+        .. note::
+           For specification-conforming array libraries supporting hardware acceleration, providing an array for ``repeats`` may cause device synchronization due to an unknown output shape. For those array libraries where synchronization concerns are applicable, conforming array libraries are advised to include a warning in their documentation regarding potential performance degradation when ``repeats`` is an array.
 
     axis: Optional[int]
         the axis (dimension) along which to repeat elements. If ``axis`` is `None`, the function must flatten the input array ``x`` and then repeat elements of the flattened input array and return the result as a one-dimensional output array. A flattened input array must be flattened in row-major, C-style order. Default: ``None``.

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -193,7 +193,7 @@ def repeat(
 
 
     .. note::
-       For specification-conforming array libraries supporting hardware acceleration, providing an array of ``repeats`` may cause device synchronization due to an unknown output shape. Conforming array libraries are advised to include a warning in their documentation regarding potential performance degradation when ``repeats`` is an array.
+       For specification-conforming array libraries supporting hardware acceleration, providing an array for ``repeats`` may cause device synchronization due to an unknown output shape. Conforming array libraries are advised to include a warning in their documentation regarding potential performance degradation when ``repeats`` is an array.
 
     axis: Optional[int]
         the axis (dimension) along which to repeat elements. If ``axis`` is `None`, the function must flatten the input array ``x`` and then repeat elements of the flattened input array and return the result as a one-dimensional output array. A flattened input array must be flattened in row-major, C-style order. Default: ``None``.

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -190,7 +190,7 @@ def repeat(
 
         If ``repeats`` is an array, the array must have an integer data type.
     axis: Optional[int]
-        the axis (dimension) along which to repeat elements. If ``axis`` is `None`, the function must repeat elements of a flattened input array ``x`` and return the result as a one-dimensional output array. Default: ``None``.
+        the axis (dimension) along which to repeat elements. If ``axis`` is `None`, the function must repeat elements of the flattened input array ``x`` and return the result as a one-dimensional output array. A flattened input array must be flattened in row-major, C-style order. Default: ``None``.
 
     Returns
     -------

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -168,7 +168,7 @@ def repeat(
     axis: Optional[int] = None,
 ) -> array:
     """
-    Repeats elements of an array.
+    Repeats each element of an array a specified number of times on a per-element basis.
 
     .. admonition:: Data-dependent output shape
         :class: important

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -193,7 +193,7 @@ def repeat(
 
 
     .. note::
-       For specification-conforming array libraries supporting hardware acceleration, providing an array for ``repeats`` may cause device synchronization due to an unknown output shape. Conforming array libraries are advised to include a warning in their documentation regarding potential performance degradation when ``repeats`` is an array.
+       For specification-conforming array libraries supporting hardware acceleration, providing an array for ``repeats`` may cause device synchronization due to an unknown output shape. For those array libraries where synchronization concerns are applicable, conforming array libraries are advised to include a warning in their documentation regarding potential performance degradation when ``repeats`` is an array.
 
     axis: Optional[int]
         the axis (dimension) along which to repeat elements. If ``axis`` is `None`, the function must flatten the input array ``x`` and then repeat elements of the flattened input array and return the result as a one-dimensional output array. A flattened input array must be flattened in row-major, C-style order. Default: ``None``.

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -189,6 +189,11 @@ def repeat(
         -   if ``repeats`` is an integer, ``repeats`` must be broadcasted to the shape ``(M,)``.
 
         If ``repeats`` is an array, the array must have an integer data type.
+
+
+        .. note::
+           For specification-conforming array libraries supporting hardware acceleration, providing an array of ``repeats`` may cause device synchronization due to an unknown output shape. Conforming array libraries are advised to include a warning in their documentation regarding potential performance degradation when ``repeats`` is an array.
+
     axis: Optional[int]
         the axis (dimension) along which to repeat elements. If ``axis`` is `None`, the function must repeat elements of the flattened input array ``x`` and return the result as a one-dimensional output array. A flattened input array must be flattened in row-major, C-style order. Default: ``None``.
 

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -196,7 +196,7 @@ def repeat(
        For specification-conforming array libraries supporting hardware acceleration, providing an array of ``repeats`` may cause device synchronization due to an unknown output shape. Conforming array libraries are advised to include a warning in their documentation regarding potential performance degradation when ``repeats`` is an array.
 
     axis: Optional[int]
-        the axis (dimension) along which to repeat elements. If ``axis`` is `None`, the function must repeat elements of the flattened input array ``x`` and return the result as a one-dimensional output array. A flattened input array must be flattened in row-major, C-style order. Default: ``None``.
+        the axis (dimension) along which to repeat elements. If ``axis`` is `None`, the function must flatten the input array ``x`` and then repeat elements of the flattened input array and return the result as a one-dimensional output array. A flattened input array must be flattened in row-major, C-style order. Default: ``None``.
 
     Returns
     -------

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -6,6 +6,7 @@ __all__ = [
     "flip",
     "moveaxis",
     "permute_dims",
+    "repeat",
     "reshape",
     "roll",
     "squeeze",
@@ -14,7 +15,7 @@ __all__ = [
 ]
 
 
-from ._types import List, Optional, Tuple, Union, array
+from ._types import List, Optional, Tuple, Union, Sequence, array
 
 
 def broadcast_arrays(*arrays: array) -> List[array]:
@@ -155,6 +156,46 @@ def permute_dims(x: array, /, axes: Tuple[int, ...]) -> array:
     -------
     out: array
         an array containing the axes permutation. The returned array must have the same data type as ``x``.
+    """
+
+
+def repeat(
+    x: array,
+    repeats: Union[int, Sequence[int], array],
+    /,
+    *,
+    axis: Optional[int] = None,
+) -> array:
+    """
+    Repeats elements of an array.
+
+    Parameters
+    ----------
+    x: array
+        input array containing elements to repeat.
+    repeats: Union[int, Sequence[int], array]
+        the number of repetitions for each element.
+
+        If ``axis`` is ``None``, let ``N = prod(x.shape)`` and
+
+        -   if ``repeats`` is an array, ``repeats`` must be broadcast compatible with the shape ``(N)`` (i.e., be a one-dimensional array having shape ``(1)`` or ``(N)``).
+        -   if ``repeats`` is a sequence of integers, ``len(repeats)`` must be broadcast compatible with the shape ``(N)`` (i.e., the number of sequence elements be either ``1`` or ``N``).
+        -   if ``repeats`` is an integer, ``repeats`` must be broadcasted to the shape `(N)`.
+
+        If ``axis`` is not ``None``, let ``M = x.shape[axis]`` and
+
+        -   if ``repeats`` is an array, ``repeats`` must be broadcast compatible with the shape ``(M)`` (i.e., be a one-dimensional array having shape ``(1)`` or ``(M)``.
+        -   if ``repeats`` is a sequence of integers, ``len(repeats)`` must be broadcast compatible with the shape ``(M)`` (i.e., the number of sequence elements must be either ``1`` or ``M``).
+        -   if ``repeats`` is an integer, ``repeats`` must be broadcasted to the shape ``(M)``.
+
+        If ``repeats`` is an array, the array must have an integer data type.
+    axis: Optional[int]
+        the axis (dimension) along which to repeat elements. If ``axis`` is `None`, the function must repeat elements of a flattened input array ``x`` and return the result as a one-dimensional output array. Default: ``None``.
+
+    Returns
+    -------
+    out: array
+        an output array containing repeated elements. The returned array must have the same data type as ``x``. If ``axis`` is ``None``, the returned array must be a one-dimensional array; otherwise, the returned array have the same shape as ``x``, except for the axis (dimension) along which elements were repeated.
     """
 
 

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 
-from ._types import List, Optional, Tuple, Union, Sequence, array
+from ._types import List, Optional, Tuple, Union, array
 
 
 def broadcast_arrays(*arrays: array) -> List[array]:

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -173,7 +173,7 @@ def repeat(
     .. admonition:: Data-dependent output shape
         :class: important
 
-        The shape of the output array for this function depend on the data values in the `repeats` array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See :ref:`data-dependent-output-shapes` section for more details.
+        The shape of the output array for this function depends on the data values in the `repeats` array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See :ref:`data-dependent-output-shapes` section for more details.
 
     Parameters
     ----------

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -170,6 +170,11 @@ def repeat(
     """
     Repeats elements of an array.
 
+    .. admonition:: Data-dependent output shape
+        :class: important
+
+        The shape of the output array for this function depend on the data values in the `repeats` array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See :ref:`data-dependent-output-shapes` section for more details.
+
     Parameters
     ----------
     x: array

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -191,8 +191,8 @@ def repeat(
         If ``repeats`` is an array, the array must have an integer data type.
 
 
-        .. note::
-           For specification-conforming array libraries supporting hardware acceleration, providing an array of ``repeats`` may cause device synchronization due to an unknown output shape. Conforming array libraries are advised to include a warning in their documentation regarding potential performance degradation when ``repeats`` is an array.
+    .. note::
+       For specification-conforming array libraries supporting hardware acceleration, providing an array of ``repeats`` may cause device synchronization due to an unknown output shape. Conforming array libraries are advised to include a warning in their documentation regarding potential performance degradation when ``repeats`` is an array.
 
     axis: Optional[int]
         the axis (dimension) along which to repeat elements. If ``axis`` is `None`, the function must repeat elements of the flattened input array ``x`` and return the result as a one-dimensional output array. A flattened input array must be flattened in row-major, C-style order. Default: ``None``.

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -184,7 +184,7 @@ def repeat(
 
         If ``axis`` is not ``None``, let ``M = x.shape[axis]`` and
 
-        -   if ``repeats`` is an array, ``repeats`` must be broadcast compatible with the shape ``(M)`` (i.e., be a one-dimensional array having shape ``(1)`` or ``(M)``.
+        -   if ``repeats`` is an array, ``repeats`` must be broadcast compatible with the shape ``(M)`` (i.e., be a one-dimensional array having shape ``(1)`` or ``(M)``).
         -   if ``repeats`` is a sequence of integers, ``len(repeats)`` must be broadcast compatible with the shape ``(M)`` (i.e., the number of sequence elements must be either ``1`` or ``M``).
         -   if ``repeats`` is an integer, ``repeats`` must be broadcasted to the shape ``(M)``.
 

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -173,7 +173,7 @@ def repeat(
     .. admonition:: Data-dependent output shape
         :class: important
 
-        Unless ``repeats`` is a literal ``int``, the shape of the output array for this function depends on the data values in the ``repeats`` array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See :ref:`data-dependent-output-shapes` section for more details.
+        When ``repeats`` is an array, the shape of the output array for this function depends on the data values in the ``repeats`` array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing the values in ``repeats``. Accordingly, such libraries may choose to omit support for ``repeats`` arrays; however, conforming implementations must support providing a literal ``int``. See :ref:`data-dependent-output-shapes` section for more details.
 
     Parameters
     ----------

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -203,7 +203,7 @@ def repeat(
     Returns
     -------
     out: array
-        an output array containing repeated elements. The returned array must have the same data type as ``x``. If ``axis`` is ``None``, the returned array must be a one-dimensional array; otherwise, the returned array have the same shape as ``x``, except for the axis (dimension) along which elements were repeated.
+        an output array containing repeated elements. The returned array must have the same data type as ``x``. If ``axis`` is ``None``, the returned array must be a one-dimensional array; otherwise, the returned array must have the same shape as ``x``, except for the axis (dimension) along which elements were repeated.
     """
 
 

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -170,11 +170,6 @@ def repeat(
     """
     Repeats elements of an array.
 
-    .. admonition:: Data-dependent output shape
-        :class: important
-
-        The shape of the output array for this function depends on the data values in the ``repeats`` array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See :ref:`data-dependent-output-shapes` section for more details.
-
     Parameters
     ----------
     x: array

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -162,7 +162,7 @@ def permute_dims(x: array, /, axes: Tuple[int, ...]) -> array:
 
 def repeat(
     x: array,
-    repeats: Union[int, Sequence[int], array],
+    repeats: Union[int, array],
     /,
     *,
     axis: Optional[int] = None,
@@ -173,25 +173,23 @@ def repeat(
     .. admonition:: Data-dependent output shape
         :class: important
 
-        The shape of the output array for this function depends on the data values in the `repeats` array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See :ref:`data-dependent-output-shapes` section for more details.
+        Unless ``repeats`` is a literal ``int``, the shape of the output array for this function depends on the data values in the ``repeats`` array; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) may find this function difficult to implement without knowing array values. Accordingly, such libraries may choose to omit this function. See :ref:`data-dependent-output-shapes` section for more details.
 
     Parameters
     ----------
     x: array
         input array containing elements to repeat.
-    repeats: Union[int, Sequence[int], array]
+    repeats: Union[int, array]
         the number of repetitions for each element.
 
         If ``axis`` is ``None``, let ``N = prod(x.shape)`` and
 
         -   if ``repeats`` is an array, ``repeats`` must be broadcast compatible with the shape ``(N,)`` (i.e., be a one-dimensional array having shape ``(1,)`` or ``(N,)``).
-        -   if ``repeats`` is a sequence of integers, ``len(repeats)`` must be broadcast compatible with the shape ``(N,)`` (i.e., the number of sequence elements be either ``1`` or ``N``).
         -   if ``repeats`` is an integer, ``repeats`` must be broadcasted to the shape `(N,)`.
 
         If ``axis`` is not ``None``, let ``M = x.shape[axis]`` and
 
         -   if ``repeats`` is an array, ``repeats`` must be broadcast compatible with the shape ``(M,)`` (i.e., be a one-dimensional array having shape ``(1,)`` or ``(M,)``).
-        -   if ``repeats`` is a sequence of integers, ``len(repeats)`` must be broadcast compatible with the shape ``(M,)`` (i.e., the number of sequence elements must be either ``1`` or ``M``).
         -   if ``repeats`` is an integer, ``repeats`` must be broadcasted to the shape ``(M,)``.
 
         If ``repeats`` is an array, the array must have an integer data type.


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/654 by adding support for `repeat` to the array API specification.
- allows `repeats` to be either an `int` or an `array`. NumPy and other inspired libraries and TensorFlow support one-dimensional arrays. NumPy also supports lists and tuples. CuPy docs suggest support for only lists and tuples. PyTorch supports a one-dimensional array; however, there has been discussion (linked to in the linked RFC) preferring sequences over arrays due to synchronization issues. However, it's not clear that providing a sequence of integers is particularly common or useful. In this PR, I've chosen to explicitly type `repeats` to support `int` and array. Should sequences be considered acceptable, this can be revisited in a future revision of the Array API standard.
- adds a data-dependent admonition and allows array libraries to omit array support for the ``repeats`` argument.