### PR TITLE
Add `device` kwarg support to `can_cast` and `result_type`

### DIFF
--- a/src/array_api_stubs/_draft/data_type_functions.py
+++ b/src/array_api_stubs/_draft/data_type_functions.py
@@ -85,7 +85,7 @@ def can_cast(
     Returns
     -------
     out: bool
-        ``True`` if the cast is possible; otherwise, ``False``.
+        ``True`` if the cast can occur; otherwise, ``False``.
     """
 
 

--- a/src/array_api_stubs/_draft/data_type_functions.py
+++ b/src/array_api_stubs/_draft/data_type_functions.py
@@ -60,7 +60,13 @@ def astype(
     """
 
 
-def can_cast(from_: Union[dtype, array], to: dtype, /) -> bool:
+def can_cast(
+    from_: Union[dtype, array],
+    to: dtype,
+    /,
+    *,
+    device: Optional[device] = None,
+) -> bool:
     """
     Determines if one data type can be cast to another data type according :ref:`type-promotion` rules.
 
@@ -70,11 +76,16 @@ def can_cast(from_: Union[dtype, array], to: dtype, /) -> bool:
         input data type or array from which to cast.
     to: dtype
         desired data type.
+    device: Optional[device]
+        device on which to perform a cast. If ``device`` is ``None``, the function must apply :ref:`type-promotion` rules irrespective of device capabilities. If ``device`` is a device object, the function must determine whether a cast can be performed on the specified device. Default: ``None``.
+
+        .. note::
+           While specification-conforming array libraries are expected to support all data types included in this specification, array libraries may support devices which do not have full data type support. Accordingly, the inclusion of a ``device`` keyword argument allows downstream array API consumers to test casting support for particular devices.
 
     Returns
     -------
     out: bool
-        ``True`` if the cast can occur according to :ref:`type-promotion` rules; otherwise, ``False``.
+        ``True`` if the cast is possible; otherwise, ``False``.
     """
 
 
@@ -206,7 +217,10 @@ def isdtype(
     """
 
 
-def result_type(*arrays_and_dtypes: Union[array, dtype]) -> dtype:
+def result_type(
+    *arrays_and_dtypes: Union[array, dtype],
+    device: Optional[device] = None,
+) -> dtype:
     """
     Returns the dtype that results from applying the type promotion rules (see :ref:`type-promotion`) to the arguments.
 
@@ -217,6 +231,11 @@ def result_type(*arrays_and_dtypes: Union[array, dtype]) -> dtype:
     ----------
     arrays_and_dtypes: Union[array, dtype]
         an arbitrary number of input arrays and/or dtypes.
+    device: Optional[device]
+        device on which to apply type promotion rules. If ``device`` is ``None``, the function must apply :ref:`type-promotion` rules irrespective of device capabilities. If ``device`` is a device object, the function must apply type promotion rules with respect to the specified device. Default: ``None``.
+
+        .. note::
+           While specification-conforming array libraries are expected to support all data types included in this specification, array libraries may support devices which do not have full data type support. Accordingly, the inclusion of a ``device`` keyword argument allows downstream array API consumers to apply type promotions with respect to particular devices.
 
     Returns
     -------


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/672 by adding `device` keyword argument support to `can_cast` and `result_type`.
- adds guidance indicating that, by default, device capabilities should **not** be considered when applying type promotion rules. Currently, the specification is mum on whether device capabilities should be considered. For both functions, when `device` is `None`, only Array API type promotion rules may be applied. When `device` is a device object, consideration can be made as to whether particular type promotion rules are possible. E.g., if a device only supports `float32`, then
  
  ```python
  can_cast(xp.float32, xp.float64, device=<device>)
  ```

  can return `false`. Otherwise, users have to workaround in which they apply `can_cast` and then use the proposed inspection APIs (https://github.com/data-apis/array-api/pull/689) to determine whether a device supports the promoted type. This PR makes this operation more direct.