### PR TITLE
Add support for tiling an array to the specification

### DIFF
--- a/spec/draft/API_specification/manipulation_functions.rst
+++ b/spec/draft/API_specification/manipulation_functions.rst
@@ -29,4 +29,5 @@ Objects in API
    roll
    squeeze
    stack
+   tile
    unstack

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -260,7 +260,7 @@ def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) ->
 
 def tile(x: array, repetitions: Tuple[int, ...], /):
     """
-    Constructs an array by tiling a provided array.
+    Constructs an array by tiling the input array.
 
     Parameters
     ----------

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -260,7 +260,7 @@ def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) ->
 
 def tile(x: array, repetitions: Tuple[int, ...], /):
     """
-    Constructs an array by tiling the input array.
+    Constructs an array by tiling an input array.
 
     Parameters
     ----------

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -271,7 +271,7 @@ def tile(x: array, repetitions: Tuple[int, ...], /):
 
         Let ``N = len(x.shape)`` and ``M = len(repetitions)``.
 
-        If ``N > M``, the function must prepend ones until all axes (dimensions) are specified (e.g., if ``x`` has shape ``(8,6,4,2)`` and ``repetitions``is the tuple ``(3,3)``, then ``repetitions`` must be treated as ``(1,1,3,3)``).
+        If ``N > M``, the function must prepend ones until all axes (dimensions) are specified (e.g., if ``x`` has shape ``(8,6,4,2)`` and ``repetitions`` is the tuple ``(3,3)``, then ``repetitions`` must be treated as ``(1,1,3,3)``).
 
         If ``N < M``, the function must prepend singleton axes (dimensions) to ``x`` until ``x`` has as many axes (dimensions) as ``repetitions`` specifies (e.g., if ``x`` has shape ``(4,2)`` and ``repetitions`` is the tuple ``(3,3,3,3)``, then ``x`` must be treated as if it has shape ``(1,1,4,2)``).
 

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -10,6 +10,7 @@ __all__ = [
     "roll",
     "squeeze",
     "stack",
+    "tile",
     "unstack",
 ]
 
@@ -254,6 +255,30 @@ def stack(arrays: Union[Tuple[array, ...], List[array]], /, *, axis: int = 0) ->
 
         .. note::
            This specification leaves type promotion between data type families (i.e., ``intxx`` and ``floatxx``) unspecified.
+    """
+
+
+def tile(x: array, repetitions: Tuple[int, ...], /):
+    """
+    Constructs an array by tiling a provided array.
+
+    Parameters
+    ----------
+    x: array
+        input array.
+    repetitions: Tuple[int, ...]
+        number of repetitions along each axis (dimension).
+
+        Let ``N = len(x.shape)`` and ``M = len(repetitions)``.
+
+        If ``N > M``, the function must prepend ones until all axes (dimensions) are specified (e.g., if ``x`` has shape ``(8,6,4,2)`` and ``repetitions``is the tuple ``(3,3)``, then ``repetitions`` must be treated as ``(1,1,3,3)``).
+
+        If ``N < M``, the function must prepend singleton axes (dimensions) to ``x`` until ``x`` has as many axes (dimensions) as ``repetitions`` specifies (e.g., if ``x`` has shape ``(4,2)`` and ``repetitions`` is the tuple ``(3,3,3,3)``, then ``x`` must be treated as if it has shape ``(1,1,4,2)``).
+
+    Returns
+    -------
+    out: array
+        a tiled output array. The returned array must have the same data type and the same rank (i.e., number of dimensions) as ``x``. If ``S`` is the shape of the tiled array after prepending singleton dimensions (if necessary) and ``r`` is the tuple of repetitions after prepending ones (if necessary), then the number of elements along each axis (dimension) must satisfy ``S[i]*r[i]``, where ``i`` refers to the ``i``th axis (dimension).
     """
 
 

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -278,7 +278,7 @@ def tile(x: array, repetitions: Tuple[int, ...], /):
     Returns
     -------
     out: array
-        a tiled output array. The returned array must have the same data type and the same rank (i.e., number of dimensions) as ``x``. If ``S`` is the shape of the tiled array after prepending singleton dimensions (if necessary) and ``r`` is the tuple of repetitions after prepending ones (if necessary), then the number of elements along each axis (dimension) must satisfy ``S[i]*r[i]``, where ``i`` refers to the ``i`` th axis (dimension).
+        a tiled output array. The returned array must have the same data type as ``x`` and must have a rank (i.e., number of dimensions) equal to ``max(N, M)``. If ``S`` is the shape of the tiled array after prepending singleton dimensions (if necessary) and ``r`` is the tuple of repetitions after prepending ones (if necessary), then the number of elements along each axis (dimension) must satisfy ``S[i]*r[i]``, where ``i`` refers to the ``i`` th axis (dimension).
     """
 
 

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -278,7 +278,7 @@ def tile(x: array, repetitions: Tuple[int, ...], /):
     Returns
     -------
     out: array
-        a tiled output array. The returned array must have the same data type and the same rank (i.e., number of dimensions) as ``x``. If ``S`` is the shape of the tiled array after prepending singleton dimensions (if necessary) and ``r`` is the tuple of repetitions after prepending ones (if necessary), then the number of elements along each axis (dimension) must satisfy ``S[i]*r[i]``, where ``i`` refers to the ``i``th axis (dimension).
+        a tiled output array. The returned array must have the same data type and the same rank (i.e., number of dimensions) as ``x``. If ``S`` is the shape of the tiled array after prepending singleton dimensions (if necessary) and ``r`` is the tuple of repetitions after prepending ones (if necessary), then the number of elements along each axis (dimension) must satisfy ``S[i]*r[i]``, where ``i`` refers to the ``i`` th axis (dimension).
     """
 
 


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/655 by adding an API for creating a new array by tiling an input array a specified number of repetitions.
- requires that the second positional argument (`repetitions`) be a tuple of `ints`. NumPy et al support providing an integer; however, PyTorch and TensorFlow do not. PyTorch requires a tuple. TensorFlow requires an array. This PR seeks to find common ground by requiring `repetitions` to be a tuple.
- supports prepend behavior, as supported by NumPy et al and PyTorch. I.e., if `len(repetitions)` is less than the rank of `x`, then ones are prepended to `repetitions`. If the rank of `x` is less than `len(repetitions)`, singleton dimensions are prepended to `x`. TensorFlow does not support this behavior, requiring that `repetitions.shape[0]` equal the rank of `x`.