### PR TITLE
Clarify flattening behavior and fix required output shape for inverse indices in `unique_*` APIs

### DIFF
--- a/src/array_api_stubs/_2021_12/set_functions.py
+++ b/src/array_api_stubs/_2021_12/set_functions.py
@@ -32,8 +32,8 @@ def unique_all(x: array, /) -> Tuple[array, array, array, array]:
         a namedtuple ``(values, indices, inverse_indices, counts)`` whose
 
         - first element must have the field name ``values`` and must be an array containing the unique elements of ``x``. The array must have the same data type as ``x``.
-        - second element must have the field name ``indices`` and must be an array containing the indices (first occurrences) of ``x`` that result in ``values``. The array must have the same shape as ``values`` and must have the default array index data type.
-        - third element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct ``x``. The array must have the same shape as ``x`` and must have the default array index data type.
+        - second element must have the field name ``indices`` and must be an array containing the indices (first occurrences) of a flattened ``x`` that result in ``values``. The array must have the same shape as ``values`` and must have the default array index data type.
+        - third element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct a flattened ``x``. The array must have the same shape as a flattened ``x`` and must have the default array index data type.
         - fourth element must have the field name ``counts`` and must be an array containing the number of times each unique element occurs in ``x``. The returned array must have same shape as ``values`` and must have the default array index data type.
 
         .. note::
@@ -104,7 +104,7 @@ def unique_inverse(x: array, /) -> Tuple[array, array]:
         a namedtuple ``(values, inverse_indices)`` whose
 
         -   first element must have the field name ``values`` and must be an array containing the unique elements of ``x``. The array must have the same data type as ``x``.
-        -   second element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct ``x``. The array must have the same shape as ``x`` and have the default array index data type.
+        -   second element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct a flattened ``x``. The array must have the same shape as a flattened ``x`` and have the default array index data type.
 
         .. note::
            The order of unique elements is not specified and may vary between implementations.

--- a/src/array_api_stubs/_2022_12/set_functions.py
+++ b/src/array_api_stubs/_2022_12/set_functions.py
@@ -32,8 +32,8 @@ def unique_all(x: array, /) -> Tuple[array, array, array, array]:
         a namedtuple ``(values, indices, inverse_indices, counts)`` whose
 
         - first element must have the field name ``values`` and must be an array containing the unique elements of ``x``. The array must have the same data type as ``x``.
-        - second element must have the field name ``indices`` and must be an array containing the indices (first occurrences) of ``x`` that result in ``values``. The array must have the same shape as ``values`` and must have the default array index data type.
-        - third element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct ``x``. The array must have the same shape as ``x`` and must have the default array index data type.
+        - second element must have the field name ``indices`` and must be an array containing the indices (first occurrences) of a flattened ``x`` that result in ``values``. The array must have the same shape as ``values`` and must have the default array index data type.
+        - third element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct a flattened ``x``. The array must have the same shape as a flattened ``x`` and must have the default array index data type.
         - fourth element must have the field name ``counts`` and must be an array containing the number of times each unique element occurs in ``x``. The returned array must have same shape as ``values`` and must have the default array index data type.
 
         .. note::
@@ -118,7 +118,7 @@ def unique_inverse(x: array, /) -> Tuple[array, array]:
         a namedtuple ``(values, inverse_indices)`` whose
 
         -   first element must have the field name ``values`` and must be an array containing the unique elements of ``x``. The array must have the same data type as ``x``.
-        -   second element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct ``x``. The array must have the same shape as ``x`` and have the default array index data type.
+        -   second element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct a flattened ``x``. The array must have the same shape as a flattened ``x`` and have the default array index data type.
 
         .. note::
            The order of unique elements is not specified and may vary between implementations.

--- a/src/array_api_stubs/_draft/set_functions.py
+++ b/src/array_api_stubs/_draft/set_functions.py
@@ -27,7 +27,7 @@ def unique_all(x: array, /) -> Tuple[array, array, array, array]:
     Parameters
     ----------
     x: array
-        input array. If ``x`` has more than one dimension, the function must flatten ``x`` and return the unique elements of the flattened array.
+        input array. If ``x`` has more than one dimension, the function must flatten ``x`` in row-major, C-style order and return the unique elements of the flattened array.
 
     Returns
     -------
@@ -35,9 +35,9 @@ def unique_all(x: array, /) -> Tuple[array, array, array, array]:
         a namedtuple ``(values, indices, inverse_indices, counts)`` whose
 
         - first element must have the field name ``values`` and must be an array containing the unique elements of ``x``. The array must have the same data type as ``x``.
-        - second element must have the field name ``indices`` and must be an array containing the indices (first occurrences) of ``x`` that result in ``values``. The array must have the same shape as ``values`` and must have the default array index data type.
-        - third element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct ``x``. The array must have the same shape as ``x`` and must have the default array index data type.
-        - fourth element must have the field name ``counts`` and must be an array containing the number of times each unique element occurs in ``x``. The returned array must have same shape as ``values`` and must have the default array index data type.
+        - second element must have the field name ``indices`` and must be an array containing the indices (first occurrences) of a flattened ``x`` that result in ``values``. The array must have the same shape as ``values`` and must have the default array index data type.
+        - third element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct a flattened ``x``. The array must have the same shape as a flattened ``x`` and must have the default array index data type.
+        - fourth element must have the field name ``counts`` and must be an array containing the number of times each unique element occurs in ``x``. The order of the returned counts must match the order of ``values``, such that a specific element in ``counts`` corresponds to the respective unique element in ``values``. The returned array must have same shape as ``values`` and must have the default array index data type.
 
         .. note::
            The order of unique elements is not specified and may vary between implementations.
@@ -71,7 +71,7 @@ def unique_counts(x: array, /) -> Tuple[array, array]:
     Parameters
     ----------
     x: array
-        input array. If ``x`` has more than one dimension, the function must flatten ``x`` and return the unique elements of the flattened array.
+        input array. If ``x`` has more than one dimension, the function must flatten ``x`` in row-major, C-style order and return the unique elements of the flattened array.
 
     Returns
     -------
@@ -79,7 +79,7 @@ def unique_counts(x: array, /) -> Tuple[array, array]:
         a namedtuple `(values, counts)` whose
 
         -   first element must have the field name ``values`` and must be an array containing the unique elements of ``x``. The array must have the same data type as ``x``.
-        -   second element must have the field name `counts` and must be an array containing the number of times each unique element occurs in ``x``. The returned array must have same shape as ``values`` and must have the default array index data type.
+        -   second element must have the field name `counts` and must be an array containing the number of times each unique element occurs in ``x``. The order of the returned counts must match the order of ``values``, such that a specific element in ``counts`` corresponds to the respective unique element in ``values``. The returned array must have same shape as ``values`` and must have the default array index data type.
 
         .. note::
            The order of unique elements is not specified and may vary between implementations.
@@ -113,7 +113,7 @@ def unique_inverse(x: array, /) -> Tuple[array, array]:
     Parameters
     ----------
     x: array
-        input array. If ``x`` has more than one dimension, the function must flatten ``x`` and return the unique elements of the flattened array.
+        input array. If ``x`` has more than one dimension, the function must flatten ``x`` in row-major, C-style order and return the unique elements of the flattened array.
 
     Returns
     -------
@@ -121,7 +121,7 @@ def unique_inverse(x: array, /) -> Tuple[array, array]:
         a namedtuple ``(values, inverse_indices)`` whose
 
         -   first element must have the field name ``values`` and must be an array containing the unique elements of ``x``. The array must have the same data type as ``x``.
-        -   second element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct ``x``. The array must have the same shape as ``x`` and have the default array index data type.
+        -   second element must have the field name ``inverse_indices`` and must be an array containing the indices of ``values`` that reconstruct a flattened ``x``. The array must have the same shape as a flattened ``x`` and have the default array index data type.
 
         .. note::
            The order of unique elements is not specified and may vary between implementations.
@@ -153,7 +153,7 @@ def unique_values(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. If ``x`` has more than one dimension, the function must flatten ``x`` and return the unique elements of the flattened array.
+        input array. If ``x`` has more than one dimension, the function must flatten ``x`` in row-major, C-style order and return the unique elements of the flattened array.
 
     Returns
     -------


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/588 by clarifying flattening behavior and fixing the required output shape for returned inverse indices.
- makes explicit in the draft specification that flattening should be in row-major, C-style order. This is not backported to prior revisions. While this flattening behavior may have been assumed at the time of writing the specifications, we shouldn't be post-writing this assumption into prior revisions. Instead, we clarify expected behavior going forward. A strict reading of the prior revisions by downstream consumers should entail no guarantees regarding flattening order.
- makes explicit in the draft specification that the count order should match the order in `values` (i.e., the returned array of unique values). This was not made explicit in prior revisions, and its omission might indicate that `counts` could be returned in any order. While unlikely, we prohibit arbitrary count order for subsequent revisions.
- backports the following changes to the 2021 and 2022 revisions of the Array API standard:
    - correction to the required output shape of `inverse_indices`. Prior revisions stated that this should have the same shape as `x`, but this is only true if `x` is one-dimensional. For multi-dimensional `x`, the output shape should the shape of a flattened `x`.
    - clarifications regarding the contents of returned indices (first occurrences). Namely, that the returned array should include indices into a flattened `x`. For the case where `x` is one-dimensional, the guidance is the same. For multi-dimensional `x`, this clarifies that returned indices are for the flattened `x` and not the original input array.