### PR TITLE
Add note clarifying behavior for out-of-bounds indices in `take`

### DIFF
--- a/src/array_api_stubs/_draft/indexing_functions.py
+++ b/src/array_api_stubs/_draft/indexing_functions.py
@@ -16,6 +16,10 @@ def take(x: array, indices: array, /, *, axis: Optional[int] = None) -> array:
         input array.
     indices: array
         array indices. The array must be one-dimensional and have an integer data type.
+
+        .. note::
+           This specification does not require bounds checking. The behavior for out-of-bounds indices is left unspecified.
+
     axis: int
         axis over which to select values. If ``axis`` is negative, the function must determine the axis along which to select values by counting from the last dimension.
 


### PR DESCRIPTION
This PR

- addresses a comment made concerning out-of-bounds index behavior in `take` (see https://github.com/data-apis/array-api/issues/177#issuecomment-1513903987). Namely, a note is added to indicate that behavior for out-of-bounds indices is left unspecified. This is consistent with current [guidance](https://data-apis.org/array-api/2022.12/API_specification/indexing.html#single-axis-indexing) for integer indexing.