### PR TITLE
Revise guidance to require a minimum upper bound for supported ranks

### DIFF
--- a/spec/draft/API_specification/array_object.rst
+++ b/spec/draft/API_specification/array_object.rst
@@ -7,7 +7,7 @@ Array object
 
 A conforming implementation of the array API standard must provide and support an array object having the following attributes and methods.
 
-Furthermore, a conforming implementation of the array API standard must support array objects of arbitrary rank ``N`` (i.e., number of dimensions), where ``N`` is greater than or equal to zero.
+Furthermore, a conforming implementation of the array API standard must support, at minimum, array objects of rank (i.e., number of dimensions) ``0``, ``1``, ``2``, ``3``, and ``4`` and must explicitly document their maximum supported rank ``N``.
 
 .. note::
     Conforming implementations must support zero-dimensional arrays.


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/479 by revising the guidance requiring conforming implementations to support arrays of arbitrary rank and specifying that array libraries must support, at minimum, arrays of rank `4`. Additionally, array libraries will be required to explicitly document their maximum supported rank.

## Related

- <https://github.com/data-apis/array-api/issues/694>