### PR TITLE
Add `hypot` specification for computing the square root of the sum of squares

### DIFF
--- a/spec/draft/API_specification/elementwise_functions.rst
+++ b/spec/draft/API_specification/elementwise_functions.rst
@@ -45,6 +45,7 @@ Objects in API
    floor_divide
    greater
    greater_equal
+   hypot
    imag
    isfinite
    isinf

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -1354,6 +1354,8 @@ def hypot(x1: array, x2: array, /) -> array:
     Notes
     -----
 
+    The purpose of this function is to avoid underflow and overflow during intermediate stages of computation. Accordingly, conforming implementations should not use naive implementations.
+
     **Special Cases**
 
     For real-valued floating-point operands,
@@ -1367,8 +1369,6 @@ def hypot(x1: array, x2: array, /) -> array:
     - Underflow may only occur when both arguments are subnormal and the correct result is also subnormal.
 
     For real-valued floating-point operands, ``hypot(x1, x2)`` must equal ``hypot(x2, x1)``, ``hypot(x1, -x2)``, ``hypot(-x1, x2)``, and ``hypot(-x1, -x2)``.
-
-    The purpose of this function is to avoid underflow and overflow during intermediate stages of computation. Accordingly, conforming implementations should not use naive implementations.
 
     .. note::
        IEEE 754-2019 requires support for subnormal (a.k.a., denormal) numbers, which are useful for supporting gradual underflow. However, hardware support for subnormal numbers is not universal, and many platforms (e.g., accelerators) and compilers support toggling denormals-are-zero (DAZ) and/or flush-to-zero (FTZ) behavior to increase performance and to guard against timing attacks.

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -1366,11 +1366,14 @@ def hypot(x1: array, x2: array, /) -> array:
     - If ``x2_i`` is a finite number or ``NaN`` and ``x1_i`` is ``NaN``, the result is ``NaN``.
     - Underflow may only occur when both arguments are subnormal and the correct result is also subnormal.
 
-    .. note::
-       For real-valued floating-point operands, ``hypot(x1, x2)`` must equal ``hypot(x2, x1)``, ``hypot(x1, -x2)``, ``hypot(-x1, x2)``, and ``hypot(-x1, -x2)``.
+    For real-valued floating-point operands, ``hypot(x1, x2)`` must equal ``hypot(x2, x1)``, ``hypot(x1, -x2)``, ``hypot(-x1, x2)``, and ``hypot(-x1, -x2)``.
+
+    The purpose of this function is to avoid underflow and overflow during intermediate stages of computation. Accordingly, conforming implementations should not use naive implementations.
 
     .. note::
-       The purpose of this function is to avoid underflow and overflow during intermediate stages of computation. Accordingly, conforming implementations should not use naive implementations.
+       IEEE 754-2019 requires support for subnormal (a.k.a., denormal) numbers, which are useful for supporting gradual underflow. However, hardware support for subnormal numbers is not universal, and many platforms (e.g., accelerators) and compilers support toggling denormals-are-zero (DAZ) and/or flush-to-zero (FTZ) behavior to increase performance and to guard against timing attacks.
+
+       Accordingly, conforming implementations may vary in their support for subnormal numbers.
     """
 
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -27,6 +27,7 @@ __all__ = [
     "floor_divide",
     "greater",
     "greater_equal",
+    "hypot",
     "imag",
     "isfinite",
     "isinf",
@@ -1328,6 +1329,48 @@ def greater_equal(x1: array, x2: array, /) -> array:
     -------
     out: array
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
+    """
+
+
+def hypot(x1: array, x2: array, /) -> array:
+    r"""
+    Computes the square root of the sum of squares for each element ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input array ``x2``.
+
+    .. note::
+       The value computed by this function may be interpreted as the length of the hypotenuse of a right-angled triangle with sides of length ``x1_i`` and ``x2_i``, the distance of a point ``(x1_i, x2_i)`` from the origin ``(0, 0)``, or the magnitude of a complex number ``x1_i + x2_i * 1j``.
+
+    Parameters
+    ----------
+    x1: array
+       first input array. Should have a real-valued floating-point data type.
+    x2: array
+       second input array. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have a real-valued floating-point data type.
+
+    Returns
+    -------
+    out: array
+       an array containing the element-wise results. The returned array must have a real-valued floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    **Special Cases**
+
+    For real-valued floating-point operands,
+
+    - If ``x1_i`` is ``+infinity`` or ``-infinity`` and ``x2_i`` is any value, including ``NaN``, the result is ``+infinity``.
+    - If ``x2_i`` is ``+infinity`` or ``-infinity`` and ``x1_i`` is any value, including ``NaN``, the result is ``+infinity``.
+    - If ``x1_i`` is either ``+0`` or ``-0``, the result is equivalent to ``abs(x2_i)``.
+    - If ``x2_i`` is either ``+0`` or ``-0``, the result is equivalent to ``abs(x1_i)``.
+    - If ``x1_i`` is a finite number or ``NaN`` and ``x2_i`` is ``NaN``, the result is ``NaN``.
+    - If ``x2_i`` is a finite number or ``NaN`` and ``x1_i`` is ``NaN``, the result is ``NaN``.
+    - Underflow may only occur when both arguments are subnormal and the correct result is also subnormal.
+
+    .. note::
+       For real-valued floating-point operands, ``hypot(x1, x2)`` must equal ``hypot(x2, x1)``, ``hypot(x1, -x2)``, ``hypot(-x1, x2)``, and ``hypot(-x1, -x2)``.
+
+    .. note::
+       The purpose of this function is to avoid underflow and overflow during intermediate stages of computation. Accordingly, conforming implementations should not use naive implementations.
     """
 
 


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/544 by adding a specification for computing the square root of the sum of squares.
- follows IEEE 754 guidance that, if one of the operands is `+-infinity`, the result is infinity, regardless of whether the other operand is `NaN`. Intentionally, this deviates from a naive `sqrt(x**2 + y**2)` implementation.
- only allows underflow when both arguments are subnormal and the correct result is also subnormal. This follows C99 and the POSIX standard and effectively prohibits a naive implementation. The entire purpose of this API is to avoid underflow/overflow during intermediate steps of computation and allowing a naive implementation defeats that purpose.
- follows `sqrt` in requiring floating-point data types. The guidance uses "should", not "must", to allow implementations to support non-floating-point data types. The reason for the floating-point restriction is that the output data type must be a real-valued floating-point data type and promoting from, e.g., an integral to a floating-point data type is implementation-defined. For defined promotion semantics, a consumer should provide input arrays having floating-point data types.