### PR TITLE
Add `signbit` specification for determining whether a sign bit is set

### DIFF
--- a/spec/draft/API_specification/elementwise_functions.rst
+++ b/spec/draft/API_specification/elementwise_functions.rst
@@ -69,6 +69,7 @@ Objects in API
    remainder
    round
    sign
+   signbit
    sin
    sinh
    square

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -51,6 +51,7 @@ __all__ = [
     "remainder",
     "round",
     "sign",
+    "signbit",
     "sin",
     "sinh",
     "square",
@@ -2212,6 +2213,38 @@ def sign(x: array, /) -> array:
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+    """
+
+
+def signbit(x: array, /) -> array:
+    r"""
+    Determines whether the sign bit is set for each element ``x_i`` of the input array ``x``.
+
+    Parameters
+    ----------
+    x: array
+        input array. Should have a real-valued floating-point data type.
+
+    Returns
+    -------
+    out: array
+        an array containing the evaluated result for each element in ``x``. The returned array must have a data type of ``bool``.
+
+    Notes
+    -----
+
+    **Special cases**
+
+    For real-valued floating-point operands,
+
+    - If ``x_i`` is ``+0``, the result is ``False``.
+    - If ``x_i`` is ``-0``, the result is ``True``.
+    - If ``x_i`` is ``+infinity``, the result is ``False``.
+    - If ``x_i`` is ``-infinity``, the result is ``True``.
+    - If ``x_i`` is a positive (i.e., greater than ``0``) finite number, the result is ``False``.
+    - If ``x_i`` is a negative (i.e., less than ``0``) finite number, the result is ``True``.
+    - If ``x_i`` is ``NaN`` and the sign bit of ``x_i`` is ``0``, the result is ``False``.
+    - If ``x_i`` is ``NaN`` and the sign bit of ``x_i`` is ``1``, the result is ``True``.
     """
 
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -2220,7 +2220,7 @@ def signbit(x: array, /) -> array:
     r"""
     Determines whether the sign bit is set for each element ``x_i`` of the input array ``x``.
 
-    The sign bit of a real-valued floating-point number ``x_i`` is set whenever ``x_i`` is either ``-0``, less than zero, or a signed ``NaN`` (i.e., a ``NaN`` value whose sign bit is set).
+    The sign bit of a real-valued floating-point number ``x_i`` is set whenever ``x_i`` is either ``-0``, less than zero, or a signed ``NaN`` (i.e., a ``NaN`` value whose sign bit is ``1``).
 
     Parameters
     ----------

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -2220,6 +2220,8 @@ def signbit(x: array, /) -> array:
     r"""
     Determines whether the sign bit is set for each element ``x_i`` of the input array ``x``.
 
+    The sign bit of a real-valued floating-point number ``x_i`` is set whenever ``x_i`` is either ``-0``, less than zero, or a signed ``NaN`` (i.e., a ``NaN`` value whose sign bit is set).
+
     Parameters
     ----------
     x: array


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/670 by adding a specification for `signbit` for determining whether a sign bit is set for each floating-point number in a provided input array.
- follows Python conventions in which a boolean is returned. In [C99](https://en.cppreference.com/w/c/numeric/math/signbit), this is a macro which returns an integral value, where a positive result can be any non-zero integral value and a negative result must be zero.
- limits the input data type to real-valued floating-point data types. The current text uses "should", indicating that array libraries may extend support to additional data types (e.g., signed integer data types) for, e.g., backward compatibility reasons. This PR does not use the more liberal real-valued data type, as the intent of this function is for distinguishing `+0` and `-0` and the determining the sign of `NaN`, values which are not possible outside of floating-point data types. For complex data types, users need to provide the real and imaginary components separately.
- as this [API](https://github.com/data-apis/array-api-comparison/blob/20880a575994c2cc5d9c0b2be5a5d4c3b4f73544/signatures/mathematical-functions-elementwise/signbit.md) is commonly implemented across array libraries without deviation, there are no open questions requiring resolution before specification inclusion.