### PR TITLE
Fix typo in input data type for `conj` specification

### DIFF
--- a/src/array_api_stubs/_2022_12/elementwise_functions.py
+++ b/src/array_api_stubs/_2022_12/elementwise_functions.py
@@ -727,7 +727,7 @@ def conj(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a complex-floating point data type.
+        input array. Should have a complex floating-point data type.
 
     Returns
     -------

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -791,7 +791,7 @@ def conj(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a complex-floating point data type.
+        input array. Should have a complex floating-point data type.
 
     Returns
     -------


### PR DESCRIPTION
This PR

- fixes a typo for the input data type in the `conj` specification. Currently, the hyphen is misplaced, and this PR corrects that mistake. This mistake was identified in https://github.com/data-apis/array-api-tests/pull/208#discussion_r1394205425, requiring an undesired workaround in the test suite which attempts to use pattern matching for deriving test strategies.
- backports the typo correction to the `2022.12` specification release in which `conj` was added to the specification.