### PR TITLE
Add specifications for `maximum` and `minimum`

### DIFF
--- a/spec/draft/API_specification/elementwise_functions.rst
+++ b/spec/draft/API_specification/elementwise_functions.rst
@@ -60,6 +60,8 @@ Objects in API
    logical_not
    logical_or
    logical_xor
+   maximum
+   minimum
    multiply
    negative
    not_equal

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -42,6 +42,8 @@ __all__ = [
     "logical_not",
     "logical_or",
     "logical_xor",
+    "maximum",
+    "minimum",
     "multiply",
     "negative",
     "not_equal",
@@ -1816,6 +1818,66 @@ def logical_xor(x1: array, x2: array, /) -> array:
     -------
     out: array
         an array containing the element-wise results. The returned array must have a data type of ``bool``.
+    """
+
+
+def maximum(x1: array, x2: array, /) -> array:
+    r"""
+    Computes the maximum value for each element ``x1_i`` of the input array ``x1`` relative to the respective element ``x2_i`` of the input array ``x2``.
+
+    .. note::
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+
+    Parameters
+    ----------
+    x1: array
+       first input array. Should have a real-valued data type.
+    x2: array
+       second input array. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have a real-valued data type.
+
+    Returns
+    -------
+    out: array
+       an array containing the element-wise maximum values. The returned array must have a data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    **Special Cases**
+
+    For floating-point operands,
+
+    -   If either ``x1_i`` or ``x2_i`` is ``NaN``, the result is ``NaN``.
+    """
+
+
+def minimum(x1: array, x2: array, /) -> array:
+    r"""
+    Computes the minimum value for each element ``x1_i`` of the input array ``x1`` relative to the respective element ``x2_i`` of the input array ``x2``.
+
+    .. note::
+       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
+
+    Parameters
+    ----------
+    x1: array
+       first input array. Should have a real-valued data type.
+    x2: array
+       second input array. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have a real-valued data type.
+
+    Returns
+    -------
+    out: array
+       an array containing the element-wise minimum values. The returned array must have a data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    **Special Cases**
+
+    For floating-point operands,
+
+    -   If either ``x1_i`` or ``x2_i`` is ``NaN``, the result is ``NaN``.
     """
 
 


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/667 by adding specifications for computing the element-wise minimum and maximum.
- as in `min` and `max`, complex number support is left unspecified. Input data types should be real-valued data types.
- as the APIs are straightforward and consistent across array libraries, the changes proposed in this PR do not have any open questions requiring resolution.