### PR TITLE
Remove outdated content from Purpose and Scope document

### DIFF
--- a/spec/2022.12/purpose_and_scope.md
+++ b/spec/2022.12/purpose_and_scope.md
@@ -144,7 +144,7 @@ standard is shown in this diagram:
    _Rationale: execution is the domain of implementations. Attempting to specify
    execution behavior in a standard is likely to require much more fine-grained
    coordination between developers of implementations, and hence is likely to
-   become an obstable to adoption._
+   become an obstacle to adoption._
 
 3. Non-Python API standardization (e.g., Cython or NumPy C APIs)
 
@@ -153,14 +153,13 @@ standard is shown in this diagram:
    this point in time to standardize anything. See
    the [C API section](design_topics/C_API.md) for more details._
 
-4. Standardization of these dtypes is out of scope: bfloat16, complex, extended
+4. Standardization of these dtypes is out of scope: bfloat16, extended
    precision floating point, datetime, string, object and void dtypes.
 
    _Rationale: these dtypes aren't uniformly supported, and their inclusion at
    this point in time could put a significant implementation burden on
    libraries. It is expected that some of these dtypes - in particular
-   `bfloat16`, `complex64`, and `complex128` - will be included in a future
-   version of the standard._
+   `bfloat16` - will be included in a future version of the standard._
 
 5. The following topics are out of scope: I/O, polynomials, error handling,
    testing routines, building and packaging related functionality, methods of

--- a/spec/draft/purpose_and_scope.md
+++ b/spec/draft/purpose_and_scope.md
@@ -144,7 +144,7 @@ standard is shown in this diagram:
    _Rationale: execution is the domain of implementations. Attempting to specify
    execution behavior in a standard is likely to require much more fine-grained
    coordination between developers of implementations, and hence is likely to
-   become an obstable to adoption._
+   become an obstacle to adoption._
 
 3. Non-Python API standardization (e.g., Cython or NumPy C APIs)
 

--- a/spec/draft/purpose_and_scope.md
+++ b/spec/draft/purpose_and_scope.md
@@ -153,14 +153,13 @@ standard is shown in this diagram:
    this point in time to standardize anything. See
    the [C API section](design_topics/C_API.md) for more details._
 
-4. Standardization of these dtypes is out of scope: bfloat16, complex, extended
+4. Standardization of these dtypes is out of scope: bfloat16, extended
    precision floating point, datetime, string, object and void dtypes.
 
    _Rationale: these dtypes aren't uniformly supported, and their inclusion at
    this point in time could put a significant implementation burden on
    libraries. It is expected that some of these dtypes - in particular
-   `bfloat16`, `complex64`, and `complex128` - will be included in a future
-   version of the standard._
+   `bfloat16` - will be included in a future version of the standard._
 
 5. The following topics are out of scope: I/O, polynomials, error handling,
    testing routines, building and packaging related functionality, methods of


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/711 by removing outdated content from the Purpose and Scope document. Namely, the document currently states that complex dtype support will be included in a future revision of the specification; however, complex dtype support was added in the 2022 revision.
- backports the changes to the 2022 revision of the Array API Standard.