### PR TITLE
Add `clip` to the specification

### DIFF
--- a/spec/draft/API_specification/elementwise_functions.rst
+++ b/spec/draft/API_specification/elementwise_functions.rst
@@ -33,6 +33,7 @@ Objects in API
    bitwise_right_shift
    bitwise_xor
    ceil
+   clamp
    conj
    copysign
    cos

--- a/spec/draft/API_specification/elementwise_functions.rst
+++ b/spec/draft/API_specification/elementwise_functions.rst
@@ -33,7 +33,7 @@ Objects in API
    bitwise_right_shift
    bitwise_xor
    ceil
-   clamp
+   clip
    conj
    copysign
    cos

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -801,6 +801,7 @@ def clip(
 
     - If both ``min`` and ``max`` are ``None``, the elements of the returned array must equal the respective elements in ``x``.
     - If a broadcasted element in ``min`` is greater than a corresponding broadcasted element in ``max``, behavior is unspecified and thus implementation-dependent.
+    - If ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent.
     """
 
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -15,7 +15,7 @@ __all__ = [
     "bitwise_right_shift",
     "bitwise_xor",
     "ceil",
-    "clamp",
+    "clip",
     "conj",
     "copysign",
     "cos",

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -788,14 +788,14 @@ def clamp(
     x: array
       input array. Should have a real-valued data type.
     min: Optional[Union[int, float, array]]
-      lower-bound of the range to which to clamp. If ``None``, no lower bound must be applied. Must broadcast to the same shape as ``x`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
+      lower-bound of the range to which to clamp. If ``None``, no lower bound must be applied. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
     max: Optional[Union[int, float, array]]
-      upper-bound of the range to which to clamp. If ``None``, no upper bound must be applied. Must broadcast to the same shape as ``x`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
+      upper-bound of the range to which to clamp. If ``None``, no upper bound must be applied. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
 
     Returns
     -------
     out: array
-      an array containing element-wise results. The returned array must have the same shape as ``x`` and have a data type determined by :ref:`type-promotion`.
+      an array containing element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
 
     Notes
     -----

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -15,6 +15,7 @@ __all__ = [
     "bitwise_right_shift",
     "bitwise_xor",
     "ceil",
+    "clamp",
     "conj",
     "copysign",
     "cos",
@@ -62,7 +63,7 @@ __all__ = [
 ]
 
 
-from ._types import array
+from ._types import Optional, Union, array
 
 
 def abs(x: array, /) -> array:
@@ -769,6 +770,38 @@ def ceil(x: array, /) -> array:
     - If ``x_i`` is ``+0``, the result is ``+0``.
     - If ``x_i`` is ``-0``, the result is ``-0``.
     - If ``x_i`` is ``NaN``, the result is ``NaN``.
+    """
+
+
+def clamp(
+    x: array,
+    /,
+    *,
+    min: Optional[Union[int, float, array]] = None,
+    max: Optional[Union[int, float, array]] = None,
+) -> array:
+    r"""
+    Clamps each element ``x_i`` of the input array ``x`` to the range ``[min, max]``.
+
+    Parameters
+    ----------
+    x: array
+      input array. Should have a real-valued data type.
+    min: Optional[Union[int, float, array]]
+      lower-bound of the range to which to clamp. If ``None``, no lower bound must be applied. Must broadcast to the same shape as ``x`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
+    max: Optional[Union[int, float, array]]
+      upper-bound of the range to which to clamp. If ``None``, no upper bound must be applied. Must broadcast to the same shape as ``x`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
+
+    Returns
+    -------
+    out: array
+      an array containing element-wise results. The returned array must have the same shape as ``x`` and have a data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    - If both ``min`` and ``max`` are ``None``, the elements of the returned array must equal the respective elements in ``x``.
+    - If a broadcasted element in ``min`` is greater than a corresponding broadcasted element in ``max``, behavior is unspecified and thus implementation-dependent.
     """
 
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -773,7 +773,7 @@ def ceil(x: array, /) -> array:
     """
 
 
-def clamp(
+def clip(
     x: array,
     /,
     *,
@@ -795,7 +795,7 @@ def clamp(
     Returns
     -------
     out: array
-      an array containing element-wise results. The returned array must have a data type determined by :ref:`type-promotion`.
+      an array containing element-wise results. The returned array must have the same data type as ``x``.
 
     Notes
     -----

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -776,7 +776,6 @@ def ceil(x: array, /) -> array:
 def clip(
     x: array,
     /,
-    *,
     min: Optional[Union[int, float, array]] = None,
     max: Optional[Union[int, float, array]] = None,
 ) -> array:


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/482 by adding `clip` to the Array API specification for clamping each element of an input array to a specified range.
- requires that the output data type be the same as the input array. One could argue that the output data type follow type promotion rules (between `x`, `min`, `max`). This would be in the spirit of earlier [efforts](https://github.com/data-apis/array-api/pull/201) to ensure that type promotion rules are applied consistently throughout the specification. However, in contrast to https://github.com/data-apis/array-api/pull/201, `min` and `max` are kwargs, and we do not have, TMK, any precedent for array kwargs influencing the data type of the output array. Furthermore, when clamping, users are more likely to want an output array of the same data type as the input array (this was also raised on the NumPy issue tracker: https://github.com/numpy/numpy/issues/24976).
- allows the input array `x` to be broadcast, thus allowing the output array to have a rank greater than the input array. This differs from TensorFlow, which requires that the output array shape be the same as the input array shape. NumPy, however, supports such broadcasting behavior. Note that `x` can be broadcast is somewhat at odds with not allowing type promotion. For the output data type, I argued that `min` and `max` should not affect the output data type, but, in allowing `x` to be broadcast, this would mean that `min` and `max` should affect the output array shape. This is likely fine and consistent with the rest of the specification, where we have plenty of kwargs which affect the output array shape, although this would be the first, TMK, involving broadcasting.
- specifies that if `min > max`, behavior is unspecified. NumPy et al set output values to `max`; however, other implementations should be free to raise an exception or support alternative behavior.
- allows both `min` and `max` to be optional. When both `min` and `max` are `None`, the function is essentially a no-op. This follows PyTorch, but differs from NumPy which allows `min` and `max` be `None`, but not at the same time.
- does not prohibit mixed data types, but leaves behavior unspecified (e.g., when `x` is an integer data type and `min` or `max` is a floating-point data type), which is consistent elsewhere in the specification. TensorFlow raises an exception in such a scenario. 
- makes `min` and `max` positional and keyword arguments.
- Follows [NumPy](https://numpy.org/doc/stable/reference/generated/numpy.clip.html), [JAX](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.clip.html), [CuPy](https://docs.cupy.dev/en/stable/reference/generated/cupy.clip.html), and [Dask](https://docs.dask.org/en/stable/generated/dask.array.clip.html) in naming the API `clip`. [TensorFlow](https://www.tensorflow.org/api_docs/python/tf/clip_by_value) uses the name [`clip_by_value`](https://www.tensorflow.org/api_docs/python/tf/clip_by_value). PyTorch also includes [`clip`](https://pytorch.org/docs/stable/generated/torch.clip.html), but this aliases to [`clamp`](https://pytorch.org/docs/stable/generated/torch.clamp.html#torch.clamp).

Note that this PR would introduce changes to existing `clip` functionality in NumPy et al. Namely,

- `min` and `max` are positional and keyword arguments; whereas, in NumPy, `a_min` and `a_max` are positional.
- deviates from NumPy's naming convention of `a_min` and `a_max`.
- NumPy requires that only one of `min` or `max` be allowed to be `None` at the same time.
