### PR TITLE
Fix definition of complex inner product in `vecdot`

### DIFF
--- a/src/array_api_stubs/_2022_12/linear_algebra_functions.py
+++ b/src/array_api_stubs/_2022_12/linear_algebra_functions.py
@@ -122,9 +122,9 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     Let :math:`\mathbf{a}` be a vector in ``x1`` and :math:`\mathbf{b}` be a corresponding vector in ``x2``. The dot product is defined as
 
     .. math::
-       \mathbf{a} \cdot \mathbf{b} = \sum_{i=0}^{n-1} a_i\overline{b_i}
+       \mathbf{a} \cdot \mathbf{b} = \sum_{i=0}^{n-1} \overline{a_i}b_i
 
-    over the dimension specified by ``axis`` and where :math:`n` is the dimension size and :math:`\overline{b_i}` denotes the complex conjugate if :math:`b_i` is complex and the identity if :math:`b_i` is real-valued.
+    over the dimension specified by ``axis`` and where :math:`n` is the dimension size and :math:`\overline{a_i}` denotes the complex conjugate if :math:`a_i` is complex and the identity if :math:`a_i` is real-valued.
 
     Parameters
     ----------

--- a/src/array_api_stubs/_draft/linear_algebra_functions.py
+++ b/src/array_api_stubs/_draft/linear_algebra_functions.py
@@ -126,9 +126,9 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     Let :math:`\mathbf{a}` be a vector in ``x1`` and :math:`\mathbf{b}` be a corresponding vector in ``x2``. The dot product is defined as
 
     .. math::
-       \mathbf{a} \cdot \mathbf{b} = \sum_{i=0}^{n-1} a_i\overline{b_i}
+       \mathbf{a} \cdot \mathbf{b} = \sum_{i=0}^{n-1} \overline{a_i}b_i
 
-    over the dimension specified by ``axis`` and where :math:`n` is the dimension size and :math:`\overline{b_i}` denotes the complex conjugate if :math:`b_i` is complex and the identity if :math:`b_i` is real-valued.
+    over the dimension specified by ``axis`` and where :math:`n` is the dimension size and :math:`\overline{a_i}` denotes the complex conjugate if :math:`a_i` is complex and the identity if :math:`a_i` is real-valued.
 
     Parameters
     ----------


### PR DESCRIPTION
Hi!

As `torch.vdot`, `torch.linalg.vecdot` and `numpy.vdot` perform conjugate on the first parameter it appears that the definition of `vecdot` in the Array API is incorrect: It performs conjugate on the second parameter.

This PR updates `vecdot` definition. WDYT?