### PR TITLE
Fix sidebar contents under Extensions

### DIFF
--- a/spec/draft/extensions/index.rst
+++ b/spec/draft/extensions/index.rst
@@ -24,11 +24,10 @@ the implementer, e.g. via a regular submodule that is imported under the
 The functions in an extension must adhere to the same conventions as those in
 the array API standard. See :ref:`api-specification`.
 
-
-Extensions
-----------
+------------------------------------------------------------------------------
 
 .. toctree::
+   :caption: Extension modules:
    :maxdepth: 1
 
    fourier_transform_functions


### PR DESCRIPTION
The problem was that the sidebar doesn't show the named pages in the toctree if that toctree is under a subheading in index.rst

Closes gh-716