### PR TITLE
Support `copy` and `device` keywords in `from_dlpack`

### DIFF
--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -293,7 +293,7 @@ class _array:
         *,
         stream: Optional[Union[int, Any]] = None,
         max_version: Optional[tuple[int, int]] = None,
-        dl_device: Optional[Tuple[Enum, int]] = None,
+        dl_device: Optional[tuple[Enum, int]] = None,
         copy: Optional[bool] = None,
     ) -> PyCapsule:
         """
@@ -347,7 +347,7 @@ class _array:
             if it does support that), or of a different version.
             This means the consumer must verify the version even when
             `max_version` is passed.
-        dl_device: Optional[Tuple[Enum, int]]
+        dl_device: Optional[tuple[enum.Enum, int]]
             the DLPack device type. Default is ``None``, meaning the exported capsule
             should be on the same device as ``self`` is. When specified, the format
             must be a 2-tuple, following that of the return value of :meth:`array.__dlpack_device__`.

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -293,6 +293,8 @@ class _array:
         *,
         stream: Optional[Union[int, Any]] = None,
         max_version: Optional[tuple[int, int]] = None,
+        dl_device: Optional[Tuple[Enum, int]] = None,
+        copy: Optional[bool] = False
     ) -> PyCapsule:
         """
         Exports the array for consumption by :func:`~array_api.from_dlpack` as a DLPack capsule.
@@ -339,6 +341,17 @@ class _array:
             if it does support that), or of a different version.
             This means the consumer must verify the version even when
             `max_version` is passed.
+        dl_device: Optional[Tuple[Enum, int]]
+            The DLPack device type. Default is ``None``, meaning the exported capsule
+            should be on the same device as ``self`` is. When specified, the format
+            must follow that of the return value of :meth:`array.__dlpack_device__`.
+            If the device type cannot be handled by the producer, this function must
+            raise `BufferError`.
+        copy: Optional[bool]
+            Whether or not a copy should be made. Default is ``False`` to enable
+            zero-copy data exchange. However, a user can request a copy to be made
+            by the producer (through the consumer's :func:`~array_api.from_dlpack`)
+            to move data across the library (and/or device) boundary.
 
         Returns
         -------
@@ -394,7 +407,7 @@ class _array:
                     # here to tell users that the consumer's max_version is too
                     # old to allow the data exchange to happen.
 
-        And this logic for the consumer in ``from_dlpack``:
+        And this logic for the consumer in :func:`~array_api.from_dlpack`:
 
         .. code:: python
 
@@ -409,7 +422,7 @@ class _array:
             Added BufferError.
 
         .. versionchanged:: 2023.12
-            Added the ``max_version`` keyword.
+            Added the ``max_version``, ``dl_device``, and ``copy`` keywords.
         """
 
     def __dlpack_device__(self: array, /) -> Tuple[Enum, int]:
@@ -436,6 +449,8 @@ class _array:
               METAL = 8
               VPI = 9
               ROCM = 10
+              CUDA_MANAGED = 13
+              ONE_API = 14
         """
 
     def __eq__(self: array, other: Union[int, float, bool, array], /) -> array:

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -357,9 +357,8 @@ class _array:
             The v2023.12 standard only mandates that a compliant library should offer a way for
             ``__dlpack__`` to return a capsule referencing an array whose underlying memory is
             accessible to the Python interpreter (represented by the ``kDLCPU`` enumerator in DLPack).
-            If the array library does not support ``kDLCPU`` at all, the function must raise
-            ``BufferError``. If a copy must be made to enable this support but ``copy`` is set to
-            ``False``, the function must raise ``ValueError``.
+            If a copy must be made to enable this support but ``copy`` is set to ``False``, the
+            function must raise ``ValueError``.
 
             Other device kinds will be considered for standardization in a future version of this
             API standard.

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -294,7 +294,7 @@ class _array:
         stream: Optional[Union[int, Any]] = None,
         max_version: Optional[tuple[int, int]] = None,
         dl_device: Optional[Tuple[Enum, int]] = None,
-        copy: Optional[bool] = None
+        copy: Optional[bool] = None,
     ) -> PyCapsule:
         """
         Exports the array for consumption by :func:`~array_api.from_dlpack` as a DLPack capsule.

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -294,7 +294,7 @@ class _array:
         stream: Optional[Union[int, Any]] = None,
         max_version: Optional[tuple[int, int]] = None,
         dl_device: Optional[Tuple[Enum, int]] = None,
-        copy: Optional[bool] = False
+        copy: Optional[bool] = None
     ) -> PyCapsule:
         """
         Exports the array for consumption by :func:`~array_api.from_dlpack` as a DLPack capsule.
@@ -335,23 +335,24 @@ class _array:
                 not want to think about stream handling at all, potentially at the
                 cost of more synchronizations than necessary.
         max_version: Optional[tuple[int, int]]
-            The maximum DLPack version that the *consumer* (i.e., the caller of
+            the maximum DLPack version that the *consumer* (i.e., the caller of
             ``__dlpack__``) supports, in the form of a 2-tuple ``(major, minor)``.
             This method may return a capsule of version ``max_version`` (recommended
             if it does support that), or of a different version.
             This means the consumer must verify the version even when
             `max_version` is passed.
         dl_device: Optional[Tuple[Enum, int]]
-            The DLPack device type. Default is ``None``, meaning the exported capsule
+            the DLPack device type. Default is ``None``, meaning the exported capsule
             should be on the same device as ``self`` is. When specified, the format
             must follow that of the return value of :meth:`array.__dlpack_device__`.
             If the device type cannot be handled by the producer, this function must
             raise `BufferError`.
         copy: Optional[bool]
-            Whether or not a copy should be made. Default is ``False`` to enable
-            zero-copy data exchange. However, a user can request a copy to be made
-            by the producer (through the consumer's :func:`~array_api.from_dlpack`)
-            to move data across the library (and/or device) boundary.
+            boolean indicating whether or not to copy the input. If ``True``, the
+            function must always copy (paerformed by the producer), potentially allowing
+            data movement across the library (and/or device) boundary. If ``False``,
+            the function must never copy. If ``None``, the function must reuse existing
+            memory buffer if possible and copy otherwise. Default: ``None``.
 
         Returns
         -------

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -355,10 +355,11 @@ class _array:
             raise ``BufferError``.
         copy: Optional[bool]
             boolean indicating whether or not to copy the input. If ``True``, the
-            function must always copy (paerformed by the producer), potentially allowing
-            data movement across the library (and/or device) boundary. If ``False``,
-            the function must never copy. If ``None``, the function must reuse existing
-            memory buffer if possible and copy otherwise. Default: ``None``.
+            function must always copy (performed by the producer). If ``False``, the
+            function must never copy, and raise a ``BufferError`` in case a copy is
+            deemed necessary (e.g. if a cross-device data movement is requested, and
+            it is not possible without a copy). If ``None``, the function must reuse
+            the existing memory buffer if possible and copy otherwise. Default: ``None``.
 
             When a copy happens, the ``DLPACK_FLAG_BITMASK_IS_COPIED`` flag must be set.
 

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -353,6 +353,16 @@ class _array:
             must be a 2-tuple, following that of the return value of :meth:`array.__dlpack_device__`.
             If the device type cannot be handled by the producer, this function must
             raise ``BufferError``.
+
+            The v2023.12 standard only mandates that a compliant library should offer a way for
+            ``__dlpack__`` to return a capsule referencing an array whose underlying memory is
+            accessible to the Python interpreter (represented by the ``kDLCPU`` enumerator in DLPack).
+            If the array library does not support ``kDLCPU`` at all, the function must raise
+            ``BufferError``. If a copy must be made to enable this support but ``copy`` is set to
+            ``False``, the function must raise ``ValueError``.
+
+            Other device kinds will be considered for standardization in a future version of this
+            API standard.
         copy: Optional[bool]
             boolean indicating whether or not to copy the input. If ``True``, the
             function must always copy (performed by the producer). If ``False``, the

--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -230,8 +230,9 @@ def from_dlpack(
     device: Optional[device]
         device on which to place the created array. If ``device`` is ``None`` and ``x`` supports DLPack, the output array must be on the same device as ``x``. Default: ``None``.
 
-        The v2023.12 standard only mandates that a compliant library must offer a way for ``from_dlpack`` to create an array on CPU (using
-        a library-specific way to represent the CPU device (``kDLCPU`` in DLPack) e.g. a ``"CPU"`` string or a ``Device("CPU")`` object).
+        The v2023.12 standard only mandates that a compliant library must offer a way for ``from_dlpack`` to create an array
+        whose underlying memory is accessible to the Python interpreter (using a library-specific way to represent the CPU
+        device (``kDLCPU`` in DLPack) e.g. a ``"CPU"`` string or a ``Device("CPU")`` object).
         If the array library does not support the CPU device and needs to outsource to another (compliant) array library, it may do so
         with a clear user documentation and/or run-time warning. If a copy must be made to enable this, and ``copy`` is set to ``False``,
         the function must raise ``ValueError``.

--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -218,7 +218,7 @@ def eye(
 def from_dlpack(
     x: object, /, *,
     device: Optional[device] = None,
-    copy: Optional[bool] = False,
+    copy: Optional[bool] = None
 ) -> Union[array, Any]:
     """
     Returns a new array containing the data from another (array) object with a ``__dlpack__`` method.
@@ -238,7 +238,7 @@ def from_dlpack(
 
         Other kinds of devices will be considered for standardization in a future version.
     copy: Optional[bool]
-        boolean indicating whether or not to copy the input. If ``True``, the function must always copy. If ``False``, the function must never copy and must raise a ``BufferError`` in case a copy would be necessary (e.g. the producer disallows views). Default: ``False``.
+        boolean indicating whether or not to copy the input. If ``True``, the function must always copy. If ``False``, the function must never copy and must raise a ``BufferError`` in case a copy would be necessary (e.g. the producer disallows views). If ``None``, the function must reuse existing memory buffer if possible and copy otherwise. Default: ``None``.
 
         If a copy is needed, the stream over which the copy is performed must be taken from the consumer, following the DLPack protocol (see :meth:`array.__dlpack__`).
 

--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -231,12 +231,12 @@ def from_dlpack(
     device: Optional[device]
         device on which to place the created array. If ``device`` is ``None`` and ``x`` supports DLPack, the output array must be on the same device as ``x``. Default: ``None``.
 
-        The v2023.12 standard only mandates that a compliant library should offer a way for ``from_dlpack`` to create an array
-        whose underlying memory is accessible to the Python interpreter (represented by the ``kDLCPU`` enumerator in DLPack).
-        If the array library does not support such case at all, the function must raise ``BufferError``. If a copy must be made
-        to enable this but ``copy`` is set to ``False``, the function must raise ``ValueError``.
+        The v2023.12 standard only mandates that a compliant library should offer a way for ``from_dlpack`` to return an array
+        whose underlying memory is accessible to the Python interpreter, when the corresponding ``device`` is provided. If the
+        array library does not support such cases at all, the function must raise ``BufferError``. If a copy must be made to
+        enable this support but ``copy`` is set to ``False``, the function must raise ``ValueError``.
 
-        Other kinds of devices will be considered for standardization in a future version of this API standard.
+        Other device kinds will be considered for standardization in a future version of this API standard.
     copy: Optional[bool]
         boolean indicating whether or not to copy the input. If ``True``, the function must always copy. If ``False``, the function must never copy, and raise ``BufferError`` in case a copy is deemed necessary (e.g.  if a cross-device data movement is requested, and it is not possible without a copy). If ``None``, the function must reuse the existing memory buffer if possible and copy otherwise. Default: ``None``.
 

--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -240,6 +240,8 @@ def from_dlpack(
     copy: Optional[bool]
         boolean indicating whether or not to copy the input. If ``True``, the function must always copy. If ``False``, the function must never copy and must raise a ``BufferError`` in case a copy would be necessary (e.g. the producer disallows views). Default: ``False``.
 
+        If a copy is needed, the stream over which the copy is performed must be taken from the consumer, following the DLPack protocol (see :meth:`array.__dlpack__`).
+
     Returns
     -------
     out: Union[array, Any]

--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -228,19 +228,17 @@ def from_dlpack(
     x: object
         input (array) object.
     device: Optional[device]
-        device on which to place the created array. If ``device`` is ``None`` and ``x`` supports DLPack, the output array device must be inferred from ``x``. Default: ``None``.
+        device on which to place the created array. If ``device`` is ``None`` and ``x`` supports DLPack, the output array device must be inferred from ``x.device``. Default: ``None``.
 
         The v2023.12 standard only mandates that a compliant library must offer a way for ``from_dlpack`` to create an array on CPU (using
-        the library-chosen way to represent the CPU device - ``kDLCPU`` in DLPack - e.g. a ``"CPU"`` string or a ``Device("CPU")`` object).
-        If the compliant library does not support the CPU device and needs to outsource to another (compliant) array library, it may do so
+        a library-specifc way to represent the CPU device (``kDLCPU`` in DLPack) e.g. a ``"CPU"`` string or a ``Device("CPU")`` object).
+        If the array library does not support the CPU device and needs to outsource to another (compliant) array library, it may do so
         with a clear user documentation and/or run-time warning. If a copy must be made to enable this, and ``copy`` is set to ``False``,
         the function must raise ``ValueError``.
 
-        Other kinds of devices will be considered for standardization in a future version.
+        Other kinds of devices will be considered for standardization in a future version of this API standard.
     copy: Optional[bool]
-        boolean indicating whether or not to copy the input. If ``True``, the function must always copy. If ``False``, the function must never copy and must raise a ``BufferError`` in case a copy would be necessary (e.g. the producer disallows views). If ``None``, the function must reuse existing memory buffer if possible and copy otherwise. Default: ``None``.
-
-        If a copy is needed, the stream over which the copy is performed must be taken from the consumer, following the DLPack protocol (see :meth:`array.__dlpack__`).
+        boolean indicating whether or not to copy the input. If ``True``, the function must always copy. If ``False``, the function must never copy and must raise a ``BufferError`` in case a copy is deemed necessary (e.g. the producer disallows views). If ``None``, the function must reuse the existing memory buffer if possible and copy otherwise. Default: ``None``.
 
     Returns
     -------

--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -238,7 +238,7 @@ def from_dlpack(
 
         Other kinds of devices will be considered for standardization in a future version of this API standard.
     copy: Optional[bool]
-        boolean indicating whether or not to copy the input. If ``True``, the function must always copy. If ``False``, the function must never copy and must raise a ``BufferError`` in case a copy is deemed necessary (e.g. the producer disallows views). If ``None``, the function must reuse the existing memory buffer if possible and copy otherwise. Default: ``None``.
+        boolean indicating whether or not to copy the input. If ``True``, the function must always copy. If ``False``, the function must never copy, and raise ``BufferError`` in case a copy is deemed necessary (e.g.  if a cross-device data movement is requested, and it is not possible without a copy). If ``None``, the function must reuse the existing memory buffer if possible and copy otherwise. Default: ``None``.
 
     Returns
     -------

--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -279,12 +279,12 @@ def from_dlpack(
         def func(x, y):
             xp_x = x.__array_namespace__()
             xp_y = y.__array_namespace__()
-        
+
             # Other functions than `from_dlpack` only work if both arrays are from the same library. So if
             # `y` is from a different one than `x`, let's convert `y` into an array of the same type as `x`:
             if not xp_x == xp_y:
                 y = xp_x.from_dlpack(y, copy=True, device=x.device)
-        
+
             # From now on use `xp_x.xxxxx` functions, as both arrays are from the library `xp_x`
             ...
 

--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -228,10 +228,10 @@ def from_dlpack(
     x: object
         input (array) object.
     device: Optional[device]
-        device on which to place the created array. If ``device`` is ``None`` and ``x`` supports DLPack, the output array device must be inferred from ``x.device``. Default: ``None``.
+        device on which to place the created array. If ``device`` is ``None`` and ``x`` supports DLPack, the output array must be on the same device as ``x``. Default: ``None``.
 
         The v2023.12 standard only mandates that a compliant library must offer a way for ``from_dlpack`` to create an array on CPU (using
-        a library-specifc way to represent the CPU device (``kDLCPU`` in DLPack) e.g. a ``"CPU"`` string or a ``Device("CPU")`` object).
+        a library-specific way to represent the CPU device (``kDLCPU`` in DLPack) e.g. a ``"CPU"`` string or a ``Device("CPU")`` object).
         If the array library does not support the CPU device and needs to outsource to another (compliant) array library, it may do so
         with a clear user documentation and/or run-time warning. If a copy must be made to enable this, and ``copy`` is set to ``False``,
         the function must raise ``ValueError``.

--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -216,9 +216,11 @@ def eye(
 
 
 def from_dlpack(
-    x: object, /, *,
+    x: object,
+    /,
+    *,
     device: Optional[device] = None,
-    copy: Optional[bool] = None
+    copy: Optional[bool] = None,
 ) -> Union[array, Any]:
     """
     Returns a new array containing the data from another (array) object with a ``__dlpack__`` method.


### PR DESCRIPTION
~~Blocked by #602.~~

Close #626. As discussed there, we expand the DLPack data exchange protocol to formalize copies. In particular, we allow two common needs:
1. Explicitly enable/disable data copies (through the new `copy` argument). The default is still `None` ("may copy") to preserve backward compatibility and align with other constructors (ex: `asarray`).
2. Allow copying to CPU (through the new `device` argument, plus setting `copy=True`)

In principle, arbitrary cross-device copies could be allowed too, but the consensus in #626 was that limiting to device-to-host copies is enough for now. This also avoids the needs of ~~actual~~ **exhaustive** library support and clarifying unforeseen semantics issues.

This PR requires an accompanying PR to the DLPack repo (https://github.com/dmlc/dlpack/pull/136), in order for the producer to signal if a copy has been made (through a new bit mask), so please review both together.