### PR TITLE
Add note to `to_device` regarding copy behavior when moving to same device

### DIFF
--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -1086,8 +1086,11 @@ class _array:
             an array with the same data and data type as ``self`` and located on the specified ``device``.
 
 
-        .. note::
-           If ``stream`` is given, the copy operation should be enqueued on the provided ``stream``; otherwise, the copy operation should be enqueued on the default stream/queue. Whether the copy is performed synchronously or asynchronously is implementation-dependent. Accordingly, if synchronization is required to guarantee data safety, this must be clearly explained in a conforming library's documentation.
+        Notes
+        -----
+
+        -   When a provided ``device`` object corresponds to the same device on which an array instance resides, implementations may choose to perform an explicit copy or return ``self``.
+        -   If ``stream`` is provided, the copy operation should be enqueued on the provided ``stream``; otherwise, the copy operation should be enqueued on the default stream/queue. Whether the copy is performed synchronously or asynchronously is implementation-dependent. Accordingly, if synchronization is required to guarantee data safety, this must be clearly explained in a conforming array library's documentation.
         """
 
 


### PR DESCRIPTION
This PR

- closes https://github.com/data-apis/array-api/issues/645 by adding a note concerning expected behavior when a specified device corresponds to the device on which an array instance resides. Namely, copy behavior is left implementation-dependent, with conforming array libraries being allowed to either return `self` or perform an explicit copy, as discussed in https://github.com/data-apis/array-api/issues/645#issuecomment-1634419029.

cc @leofang @rgommers 