### PR TITLE
Add recommendation on what to do with DLPack read-only flag

### DIFF
--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -444,6 +444,12 @@ class _array:
         This logic is also applicable to handling of the new ``dl_device`` and ``copy``
         keywords.
 
+        DLPack 1.0 added a flag to indicate that the array is read-only
+        (``DLPACK_FLAG_BITMASK_READ_ONLY``). A consumer that does not support
+        read-only arrays should ignore this flag (this is preferred over
+        raising an exception; the user is then responsible for ensuring the
+        memory isn't modified).
+
         .. versionchanged:: 2022.12
             Added BufferError.
 


### PR DESCRIPTION
This is a follow-up to the discussion in gh-191. It's a recommendation rather than a hard requirement to allow implementers some choice. That said, this is how things worked in practice before DLPack 1.0 as well, since there was no flag to represent read-only. Experience with JAX showed that exposing shared memory was preferred by users over raising or always making a copy of the data on the producer side.