### PR TITLE
docs: add note concerning signed zeros

### DIFF
--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -1859,9 +1859,6 @@ def maximum(x1: array, x2: array, /) -> array:
     r"""
     Computes the maximum value for each element ``x1_i`` of the input array ``x1`` relative to the respective element ``x2_i`` of the input array ``x2``.
 
-    .. note::
-       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
-
     Parameters
     ----------
     x1: array
@@ -1877,6 +1874,10 @@ def maximum(x1: array, x2: array, /) -> array:
     Notes
     -----
 
+    The order of signed zeros is unspecified and thus implementation-defined. When the choosing between ``-0`` or ``+0`` as a maximum value, specification-compliant libraries may choose to return either value.
+
+    For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-defined (see :ref:`complex-number-ordering`).
+
     **Special Cases**
 
     For floating-point operands,
@@ -1888,9 +1889,6 @@ def maximum(x1: array, x2: array, /) -> array:
 def minimum(x1: array, x2: array, /) -> array:
     r"""
     Computes the minimum value for each element ``x1_i`` of the input array ``x1`` relative to the respective element ``x2_i`` of the input array ``x2``.
-
-    .. note::
-       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
 
     Parameters
     ----------
@@ -1906,6 +1904,10 @@ def minimum(x1: array, x2: array, /) -> array:
 
     Notes
     -----
+
+    The order of signed zeros is unspecified and thus implementation-defined. When the choosing between ``-0`` or ``+0`` as a minimum value, specification-compliant libraries may choose to return either value.
+
+    For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-defined (see :ref:`complex-number-ordering`).
 
     **Special Cases**
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -1874,7 +1874,7 @@ def maximum(x1: array, x2: array, /) -> array:
     Notes
     -----
 
-    The order of signed zeros is unspecified and thus implementation-defined. When the choosing between ``-0`` or ``+0`` as a maximum value, specification-compliant libraries may choose to return either value.
+    The order of signed zeros is unspecified and thus implementation-defined. When choosing between ``-0`` or ``+0`` as a maximum value, specification-compliant libraries may choose to return either value.
 
     For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-defined (see :ref:`complex-number-ordering`).
 
@@ -1905,7 +1905,7 @@ def minimum(x1: array, x2: array, /) -> array:
     Notes
     -----
 
-    The order of signed zeros is unspecified and thus implementation-defined. When the choosing between ``-0`` or ``+0`` as a minimum value, specification-compliant libraries may choose to return either value.
+    The order of signed zeros is unspecified and thus implementation-defined. When choosing between ``-0`` or ``+0`` as a minimum value, specification-compliant libraries may choose to return either value.
 
     For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-defined (see :ref:`complex-number-ordering`).
 

--- a/src/array_api_stubs/_draft/statistical_functions.py
+++ b/src/array_api_stubs/_draft/statistical_functions.py
@@ -64,12 +64,6 @@ def max(
     """
     Calculates the maximum value of the input array ``x``.
 
-    .. note::
-       When the number of elements over which to compute the maximum value is zero, the maximum value is implementation-defined. Specification-compliant libraries may choose to raise an error, return a sentinel value (e.g., if ``x`` is a floating-point input array, return ``NaN``), or return the minimum possible value for the input array ``x`` data type (e.g., if ``x`` is a floating-point array, return ``-infinity``).
-
-    .. note::
-       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
-
     Parameters
     ----------
     x: array
@@ -86,6 +80,12 @@ def max(
 
     Notes
     -----
+
+    When the number of elements over which to compute the maximum value is zero, the maximum value is implementation-defined. Specification-compliant libraries may choose to raise an error, return a sentinel value (e.g., if ``x`` is a floating-point input array, return ``NaN``), or return the minimum possible value for the input array ``x`` data type (e.g., if ``x`` is a floating-point array, return ``-infinity``).
+
+    The order of signed zeros is unspecified and thus implementation-defined. When the choosing between ``-0`` or ``+0`` as a maximum value, specification-compliant libraries may choose to return either value.
+
+    For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-defined (see :ref:`complex-number-ordering`).
 
     **Special Cases**
 
@@ -144,12 +144,6 @@ def min(
     """
     Calculates the minimum value of the input array ``x``.
 
-    .. note::
-       When the number of elements over which to compute the minimum value is zero, the minimum value is implementation-defined. Specification-compliant libraries may choose to raise an error, return a sentinel value (e.g., if ``x`` is a floating-point input array, return ``NaN``), or return the maximum possible value for the input array ``x`` data type (e.g., if ``x`` is a floating-point array, return ``+infinity``).
-
-    .. note::
-       For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-dependent (see :ref:`complex-number-ordering`).
-
     Parameters
     ----------
     x: array
@@ -166,6 +160,12 @@ def min(
 
     Notes
     -----
+
+    When the number of elements over which to compute the minimum value is zero, the minimum value is implementation-defined. Specification-compliant libraries may choose to raise an error, return a sentinel value (e.g., if ``x`` is a floating-point input array, return ``NaN``), or return the maximum possible value for the input array ``x`` data type (e.g., if ``x`` is a floating-point array, return ``+infinity``).
+
+    The order of signed zeros is unspecified and thus implementation-defined. When the choosing between ``-0`` or ``+0`` as a minimum value, specification-compliant libraries may choose to return either value.
+
+    For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-defined (see :ref:`complex-number-ordering`).
 
     **Special Cases**
 

--- a/src/array_api_stubs/_draft/statistical_functions.py
+++ b/src/array_api_stubs/_draft/statistical_functions.py
@@ -83,7 +83,7 @@ def max(
 
     When the number of elements over which to compute the maximum value is zero, the maximum value is implementation-defined. Specification-compliant libraries may choose to raise an error, return a sentinel value (e.g., if ``x`` is a floating-point input array, return ``NaN``), or return the minimum possible value for the input array ``x`` data type (e.g., if ``x`` is a floating-point array, return ``-infinity``).
 
-    The order of signed zeros is unspecified and thus implementation-defined. When the choosing between ``-0`` or ``+0`` as a maximum value, specification-compliant libraries may choose to return either value.
+    The order of signed zeros is unspecified and thus implementation-defined. When choosing between ``-0`` or ``+0`` as a maximum value, specification-compliant libraries may choose to return either value.
 
     For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-defined (see :ref:`complex-number-ordering`).
 
@@ -163,7 +163,7 @@ def min(
 
     When the number of elements over which to compute the minimum value is zero, the minimum value is implementation-defined. Specification-compliant libraries may choose to raise an error, return a sentinel value (e.g., if ``x`` is a floating-point input array, return ``NaN``), or return the maximum possible value for the input array ``x`` data type (e.g., if ``x`` is a floating-point array, return ``+infinity``).
 
-    The order of signed zeros is unspecified and thus implementation-defined. When the choosing between ``-0`` or ``+0`` as a minimum value, specification-compliant libraries may choose to return either value.
+    The order of signed zeros is unspecified and thus implementation-defined. When choosing between ``-0`` or ``+0`` as a minimum value, specification-compliant libraries may choose to return either value.
 
     For backward compatibility, conforming implementations may support complex numbers; however, inequality comparison of complex numbers is unspecified and thus implementation-defined (see :ref:`complex-number-ordering`).
 


### PR DESCRIPTION
This PR

- closes https://github.com/data-apis/array-api/issues/707 by adding a note concerning signed zeros when computing the minimum and maximum value. Namely, the order of signed zeros is left unspecified and implementations may choose to return either `-0` or `+0` when computing the minimum/maximum.
- explicitly allows conforming implementations to treat signed zeros as indistinguishable and avoid additional branching.