### PR TITLE
docs: add changelog for v2023.12 specification revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,140 @@
 
 This changelog is organized by specification version and notes all changes with respect to the previous version. Within the section for a specific version (e.g., v2022.12), separate sections are used for (a) changes to existing APIs and requirements, (b) new APIs and new requirements, and (c) errata.
 
+## v2023.12
+
+### Updates
+
+> Updates to existing APIs and requirements.
+
+#### Normative
+
+- Clarify expectations concerning exception handling ([gh-613](https://github.com/data-apis/array-api/pull/613))
+- Clarify that the constant `newaxis` is an alias of `None` ([gh-687](https://github.com/data-apis/array-api/pull/687))
+- Add design discussion on lazy versus eager implementations ([gh-708](https://github.com/data-apis/array-api/pull/708))
+- Revise guidance to require a minimum upper bound for supported ranks ([gh-702](https://github.com/data-apis/array-api/pull/702))
+- Relax design requirements for positional and keyword-only arguments ([gh-730](https://github.com/data-apis/array-api/pull/730))
+- Add recommendation to `__dlpack__` for handling read-only arrays ([gh-749](https://github.com/data-apis/array-api/pull/749))
+
+#### APIs
+
+- `__bool__`: allow lazy implementations to raise from intrinsically eager functions ([gh-652](https://github.com/data-apis/array-api/pull/652))
+- `__complex__`: allow lazy implementations to raise from intrinsically eager functions ([gh-652](https://github.com/data-apis/array-api/pull/652))
+- `__dlpack__`: add `max_version` keyword argument to support versioning ([gh-602](https://github.com/data-apis/array-api/pull/602))
+- `__dlpack__`: add `dl_device` and `copy` keyword arguments ([gh-741](https://github.com/data-apis/array-api/pull/741))
+- `__float__`: allow lazy implementations to raise from intrinsically eager functions ([gh-652](https://github.com/data-apis/array-api/pull/652))
+- `__index__`: allow lazy implementations to raise from intrinsically eager functions ([gh-652](https://github.com/data-apis/array-api/pull/652))
+- `__int__`: allow lazy implementations to raise from intrinsically eager functions ([gh-652](https://github.com/data-apis/array-api/pull/652))
+- `astype`: add support for an optional `device` keyword argument ([gh-665](https://github.com/data-apis/array-api/pull/665))
+- `from_dlpack`: require exceptions to address unsupported use cases ([gh-709](https://github.com/data-apis/array-api/pull/709))
+- `from_dlpack`: add support for `copy` and `device` keywords ([gh-741](https://github.com/data-apis/array-api/pull/741))
+- `max`: clarify that the order of signed zeros is unspecified ([gh-751](https://github.com/data-apis/array-api/pull/751))
+- `min`: clarify that the order of signed zeros is unspecified ([gh-751](https://github.com/data-apis/array-api/pull/751))
+- `take`: explicitly leave out-of-bounds behavior unspecified ([gh-701](https://github.com/data-apis/array-api/pull/701))
+- `tensordot`: allow negative axes ([gh-625](https://github.com/data-apis/array-api/pull/625))
+- `to_device`: clarified behavior when a provided `device` object corresponds to the same device on which an array instance resides ([gh-742](https://github.com/data-apis/array-api/pull/742))
+- `unique_all`: clarify the shape of the array containing unique values and the order of returned counts ([gh-752](https://github.com/data-apis/array-api/pull/752))
+- `unique_counts`: clarify the shape of the array containing unique values and the order of returned counts ([gh-752](https://github.com/data-apis/array-api/pull/752))
+- `unique_inverse`: clarify the shape of the array containing unique values ([gh-752](https://github.com/data-apis/array-api/pull/752))
+- `unique_values`: clarify the shape of the returned array ([gh-752](https://github.com/data-apis/array-api/pull/752))
+
+#### Extensions
+
+> Updates to APIs and requirements included as part of specification extensions.
+
+- `fft.*`: clarify behavior of the `n` and `s` keyword arguments and the expected output array shape ([gh-720](https://github.com/data-apis/array-api/pull/720) and [gh-746](https://github.com/data-apis/array-api/pull/746))
+
+	- **Note**: these changes were backported to the v2022.12 revision of the Array API specification.
+
+* * *
+
+### Additions
+
+> New APIs and requirements added to the specification.
+
+#### APIs
+
+The following APIs were added to the specification:
+
+- `__array_namespace_info__`: namespace with Array API namespace inspection utilities ([gh-689](https://github.com/data-apis/array-api/pull/689))
+- `clip`: clamp each element of an input array to a specified range ([gh-715](https://github.com/data-apis/array-api/pull/715))
+- `copysign`: compose a floating-point value with the magnitude of a `x1_i` and the sign of `x2_i` ([gh-693](https://github.com/data-apis/array-api/pull/693))
+- `cumulative_sum`: calculate the cumulative sum ([gh-653](https://github.com/data-apis/array-api/pull/653))
+- `hypot`: compute the square root of the sum of squares for each element in an array ([gh-703](https://github.com/data-apis/array-api/pull/703))
+- `maximum`: compute the maximum value for each element of an array relative to the respective element in another array ([gh-713](https://github.com/data-apis/array-api/pull/713))
+- `minimum`: compute the minimum value for each element of an array relative to the respective element in another array ([gh-713](https://github.com/data-apis/array-api/pull/713))
+- `moveaxis`: move array axes to new positions, while leaving other axes in their original positions ([gh-656](https://github.com/data-apis/array-api/pull/656))
+- `repeat`: repeat each element of an array a specified number of times ([gh-690](https://github.com/data-apis/array-api/pull/690))
+- `searchsorted`: find the indices into `x1` such that, if the corresponding elements in `x2` were inserted before the indices, the order of `x1`, when sorted in ascending order, would be preserved ([gh-699](https://github.com/data-apis/array-api/pull/699))
+- `signbit`: determine whether the sign bit is set for each element of an array ([gh-705](https://github.com/data-apis/array-api/pull/705))
+- `tile`: construct an array by tiling an input array ([gh-692](https://github.com/data-apis/array-api/pull/692))
+- `unstack`: split an array into a sequence of arrays along a given axis ([gh-604](https://github.com/data-apis/array-api/pull/604))
+
+#### Inspection APIs
+
+The following inspection APIs were added to the specification:
+
+- `capabilities`: return a dictionary of array library capabilities ([gh-689](https://github.com/data-apis/array-api/pull/689))
+- `default_device`: return the default device ([gh-689](https://github.com/data-apis/array-api/pull/689))
+- `default_dtypes`: return a dictionary containing default data types ([gh-689](https://github.com/data-apis/array-api/pull/689))
+- `dtypes`: return a dictionary support Array API data types ([gh-689](https://github.com/data-apis/array-api/pull/689))
+- `devices`: return a list of supported devices ([gh-689](https://github.com/data-apis/array-api/pull/689))
+
+* * *
+
+### Breaking Changes
+
+The following is a list of breaking changes relative to the previous version of the specification:
+
+- `prod`: when provided a floating-point array, the function must return a floating-point array having the same data type ([gh-744](https://github.com/data-apis/array-api/pull/744))
+- `sum`: when provided a floating-point array, the function must return a floating-point array having the same data type ([gh-744](https://github.com/data-apis/array-api/pull/744))
+- `vecdot`: only allow a negative integer for the `axis` keyword argument ([gh-740](https://github.com/data-apis/array-api/pull/740))
+
+#### Extensions
+
+The following is a list of breaking changes in specification extensions relative to the previous version of the specification:
+
+- `fft.fft`: require the input array to have a complex-valued floating-point data type and require that the output array have the same data type as the input array ([gh-720](https://github.com/data-apis/array-api/pull/720); backported to v2022.12 revision of Array API specification)
+- `fft.fftn`: require the input array to have a complex-valued floating-point data type and require that the output array have the same data type as the input array ([gh-720](https://github.com/data-apis/array-api/pull/720); backported to v2022.12 revision of Array API specification)
+- `fft.hfft`: require the input array to have a complex-valued floating-point data type and require that the output array have a real-valued data type having the same precision as the input array ([gh-720](https://github.com/data-apis/array-api/pull/720); backported to v2022.12 revision of Array API specification)
+- `fft.ifft`: require the input array to have a complex-valued floating-point data type and require that the output array have the same data type as the input array ([gh-720](https://github.com/data-apis/array-api/pull/720); backported to v2022.12 revision of Array API specification)
+- `fft.ifftn`: require the input array to have a complex-valued floating-point data type and require that the output array have the same data type as the input array ([gh-720](https://github.com/data-apis/array-api/pull/720); backported to v2022.12 revision of Array API specification)
+- `fft.irfft`: require the output array have a real-valued floating-point data type having the same precision as the input array ([gh-720](https://github.com/data-apis/array-api/pull/720); backported to v2022.12 revision of Array API specification)
+- `fft.irfftn`: require the output array have a real-valued floating-point data type having the same precision as the input array ([gh-720](https://github.com/data-apis/array-api/pull/720); backported to v2022.12 revision of Array API specification)
+- `fft.fftfreq`: require the output array have the default real-valued floating-point data type ([gh-720](https://github.com/data-apis/array-api/pull/720); backported to v2022.12 revision of Array API specification)
+- `fft.rfftfreq`: require the output array have the default real-valued floating-point data type ([gh-720](https://github.com/data-apis/array-api/pull/720); backported to v2022.12 revision of Array API specification)
+- `linalg.cross`: broadcast only along non-compute axes and only allow a negative integer for the `axis` keyword argument ([gh-740](https://github.com/data-apis/array-api/pull/740))
+- `linalg.trace`: when provided a floating-point array, the function must return a floating-point array having the same data type ([gh-744](https://github.com/data-apis/array-api/pull/744))
+
+* * *
+
+### Errata
+
+The following is a list of fixes and points of clarification with regard to the previous version of the specification:
+
+- `__getitem__`: clarify typing to allow `None` in indexing ([gh-674](https://github.com/data-apis/array-api/pull/674) and [gh-687](https://github.com/data-apis/array-api/pull/687))
+- `__ge__`: clarify that operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
+- `__gt__`: clarify that operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
+- `__le__`: clarify that operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
+- `__lt__`: clarify that operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
+- `abs`: fix typo in return value description ([gh-633](https://github.com/data-apis/array-api/pull/633))
+- `asarray`: fix typo in `device` keyword argument description ([gh-681](https://github.com/data-apis/array-api/pull/681))
+- `conj`: fix typo in parameter description ([gh-706](https://github.com/data-apis/array-api/pull/706))
+- `finfo_object`: fix missing `dtype` attribute ([gh-639](https://github.com/data-apis/array-api/pull/639))
+- `fft.*`: fix various typing issues and input/output data type guidance ([gh-720](https://github.com/data-apis/array-api/pull/720))
+- `iinfo_object`: fix missing `dtype` attribute ([gh-639](https://github.com/data-apis/array-api/pull/639))
+- `linalg.qr`: fix typo in function description ([gh-661](https://github.com/data-apis/array-api/pull/661))
+- `linalg.cholesky`: fix typo in function description ([gh-677](https://github.com/data-apis/array-api/pull/677))
+- `linalg.svd`: fix return type ([gh-619](https://github.com/data-apis/array-api/pull/619))
+- `prod`: clarify type promotion behavior when `dtype=None` ([gh-666](https://github.com/data-apis/array-api/pull/666))
+- `sum`: clarify type promotion behavior when `dtype=None` ([gh-666](https://github.com/data-apis/array-api/pull/666))
+- `take`: fix typing for optional `axis` keyword argument ([gh-644](https://github.com/data-apis/array-api/pull/644))
+- `tensordot`: fix typo in parameter description ([gh-622](https://github.com/data-apis/array-api/pull/622))
+- `trace`: clarify type promotion behavior when `dtype=None` ([gh-666](https://github.com/data-apis/array-api/pull/666))
+- `vecdot`: fix definition of complex inner product ([gh-723](https://github.com/data-apis/array-api/pull/723))
+
+* * *
+
 ## v2022.12
 
 ### Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ The following is a list of fixes and points of clarification with regard to the 
 - `asarray`: fix typo in `device` keyword argument description ([gh-681](https://github.com/data-apis/array-api/pull/681))
 - `conj`: fix typo in parameter description ([gh-706](https://github.com/data-apis/array-api/pull/706))
 - `finfo_object`: fix missing `dtype` attribute ([gh-639](https://github.com/data-apis/array-api/pull/639))
-- `fft.*`: fix various typing issues and input/output data type guidance ([gh-720](https://github.com/data-apis/array-api/pull/720))
+- `fft.*`: fix various typing issues ([gh-720](https://github.com/data-apis/array-api/pull/720))
 - `iinfo_object`: fix missing `dtype` attribute ([gh-639](https://github.com/data-apis/array-api/pull/639))
 - `linalg.qr`: fix typo in function description ([gh-661](https://github.com/data-apis/array-api/pull/661))
 - `linalg.cholesky`: fix typo in function description ([gh-677](https://github.com/data-apis/array-api/pull/677))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This changelog is organized by specification version and notes all changes with 
 - `min`: clarify that the order of signed zeros is unspecified ([gh-751](https://github.com/data-apis/array-api/pull/751))
 - `take`: explicitly leave out-of-bounds behavior unspecified ([gh-701](https://github.com/data-apis/array-api/pull/701))
 - `tensordot`: allow negative axes ([gh-625](https://github.com/data-apis/array-api/pull/625))
-- `to_device`: clarified behavior when a provided `device` object corresponds to the same device on which an array instance resides ([gh-742](https://github.com/data-apis/array-api/pull/742))
+- `to_device`: clarify behavior when a provided `device` object corresponds to the same device on which an array instance resides ([gh-742](https://github.com/data-apis/array-api/pull/742))
 - `unique_all`: clarify the shape of the array containing unique values and the order of returned counts ([gh-752](https://github.com/data-apis/array-api/pull/752))
 - `unique_counts`: clarify the shape of the array containing unique values and the order of returned counts ([gh-752](https://github.com/data-apis/array-api/pull/752))
 - `unique_inverse`: clarify the shape of the array containing unique values ([gh-752](https://github.com/data-apis/array-api/pull/752))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,10 +116,10 @@ The following is a list of breaking changes in specification extensions relative
 The following is a list of fixes and points of clarification with regard to the previous version of the specification:
 
 - `__getitem__`: clarify typing to allow `None` in indexing ([gh-674](https://github.com/data-apis/array-api/pull/674) and [gh-687](https://github.com/data-apis/array-api/pull/687))
-- `__ge__`: clarify that operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
-- `__gt__`: clarify that operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
-- `__le__`: clarify that operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
-- `__lt__`: clarify that operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
+- `__ge__`: clarify that the operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
+- `__gt__`: clarify that the operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
+- `__le__`: clarify that the operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
+- `__lt__`: clarify that the operation is only defined for arrays having real-valued data types ([gh-736](https://github.com/data-apis/array-api/pull/736))
 - `abs`: fix typo in return value description ([gh-633](https://github.com/data-apis/array-api/pull/633))
 - `asarray`: fix typo in `device` keyword argument description ([gh-681](https://github.com/data-apis/array-api/pull/681))
 - `conj`: fix typo in parameter description ([gh-706](https://github.com/data-apis/array-api/pull/706))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,7 @@ This changelog is organized by specification version and notes all changes with 
 
 > Updates to APIs and requirements included as part of specification extensions.
 
-- `fft.*`: clarify behavior of the `n` and `s` keyword arguments and the expected output array shape ([gh-720](https://github.com/data-apis/array-api/pull/720) and [gh-746](https://github.com/data-apis/array-api/pull/746))
-
-	- **Note**: these changes were backported to the v2022.12 revision of the Array API specification.
+- `fft.*`: clarify behavior of the `n` and `s` keyword arguments and the expected output array shape ([gh-720](https://github.com/data-apis/array-api/pull/720) and [gh-746](https://github.com/data-apis/array-api/pull/746); backported to v2022.12 revision of Array API specification)
 
 * * *
 

--- a/src/array_api_stubs/_2022_12/indexing_functions.py
+++ b/src/array_api_stubs/_2022_12/indexing_functions.py
@@ -14,7 +14,7 @@ def take(x: array, indices: array, /, *, axis: Optional[int] = None) -> array:
         input array.
     indices: array
         array indices. The array must be one-dimensional and have an integer data type.
-    axis: int
+    axis: Optional[int]
         axis over which to select values. If ``axis`` is negative, the function must determine the axis along which to select values by counting from the last dimension.
 
         If ``x`` is a one-dimensional array, providing an ``axis`` is optional; however, if ``x`` has more than one dimension, providing an ``axis`` is required.

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -247,6 +247,9 @@ class _array:
 
         .. versionchanged:: 2022.12
             Added boolean and complex data type support.
+
+        .. versionchanged:: 2023.12
+            Allow lazy implementations to error.
         """
 
     def __complex__(self: array, /) -> complex:
@@ -285,6 +288,9 @@ class _array:
         The Python language requires the return value to be of type ``complex``. Lazy implementations are therefore not able to return any kind of lazy/delayed object here and should raise a ``ValueError`` instead.
 
         .. versionadded:: 2022.12
+
+        .. versionchanged:: 2023.12
+            Allow lazy implementations to error.
         """
 
     def __dlpack__(
@@ -451,10 +457,13 @@ class _array:
         memory isn't modified).
 
         .. versionchanged:: 2022.12
-            Added BufferError.
+           Added BufferError.
 
         .. versionchanged:: 2023.12
-            Added the ``max_version``, ``dl_device``, and ``copy`` keywords.
+           Added the ``max_version``, ``dl_device``, and ``copy`` keywords.
+
+        .. versionchanged:: 2023.12
+           Added recommendation for handling read-only arrays.
         """
 
     def __dlpack_device__(self: array, /) -> Tuple[Enum, int]:
@@ -539,6 +548,9 @@ class _array:
 
         .. versionchanged:: 2022.12
             Added boolean and complex data type support.
+
+        .. versionchanged:: 2023.12
+            Allow lazy implementations to error.
         """
 
     def __floordiv__(self: array, other: Union[int, float, array], /) -> array:
@@ -664,6 +676,9 @@ class _array:
         **Lazy implementations**
 
         The Python language requires the return value to be of type ``int``. Lazy implementations are therefore not able to return any kind of lazy/delayed object here and should raise a ``ValueError`` instead.
+
+        .. versionchanged:: 2023.12
+            Allow lazy implementations to error.
         """
 
     def __int__(self: array, /) -> int:
@@ -711,6 +726,9 @@ class _array:
 
         .. versionchanged:: 2022.12
             Added boolean and complex data type support.
+
+        .. versionchanged:: 2023.12
+            Allow lazy implementations to error.
         """
 
     def __invert__(self: array, /) -> array:
@@ -1192,6 +1210,9 @@ class _array:
 
         -   When a provided ``device`` object corresponds to the same device on which an array instance resides, implementations may choose to perform an explicit copy or return ``self``.
         -   If ``stream`` is provided, the copy operation should be enqueued on the provided ``stream``; otherwise, the copy operation should be enqueued on the default stream/queue. Whether the copy is performed synchronously or asynchronously is implementation-dependent. Accordingly, if synchronization is required to guarantee data safety, this must be clearly explained in a conforming array library's documentation.
+
+        .. versionchanged:: 2023.12
+           Clarified behavior when a provided ``device`` object corresponds to the device on which an array instance resides.
         """
 
 

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -249,7 +249,7 @@ class _array:
             Added boolean and complex data type support.
 
         .. versionchanged:: 2023.12
-            Allow lazy implementations to error.
+            Allowed lazy implementations to error.
         """
 
     def __complex__(self: array, /) -> complex:
@@ -290,7 +290,7 @@ class _array:
         .. versionadded:: 2022.12
 
         .. versionchanged:: 2023.12
-            Allow lazy implementations to error.
+            Allowed lazy implementations to error.
         """
 
     def __dlpack__(
@@ -550,7 +550,7 @@ class _array:
             Added boolean and complex data type support.
 
         .. versionchanged:: 2023.12
-            Allow lazy implementations to error.
+            Allowed lazy implementations to error.
         """
 
     def __floordiv__(self: array, other: Union[int, float, array], /) -> array:
@@ -678,7 +678,7 @@ class _array:
         The Python language requires the return value to be of type ``int``. Lazy implementations are therefore not able to return any kind of lazy/delayed object here and should raise a ``ValueError`` instead.
 
         .. versionchanged:: 2023.12
-            Allow lazy implementations to error.
+            Allowed lazy implementations to error.
         """
 
     def __int__(self: array, /) -> int:
@@ -728,7 +728,7 @@ class _array:
             Added boolean and complex data type support.
 
         .. versionchanged:: 2023.12
-            Allow lazy implementations to error.
+            Allowed lazy implementations to error.
         """
 
     def __invert__(self: array, /) -> array:

--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -290,6 +290,9 @@ def from_dlpack(
 
 
     .. versionchanged:: 2023.12
+       Required exceptions to address unsupported use cases.
+
+    .. versionchanged:: 2023.12
        Added device and copy support.
     """
 

--- a/src/array_api_stubs/_draft/data_type_functions.py
+++ b/src/array_api_stubs/_draft/data_type_functions.py
@@ -57,6 +57,9 @@ def astype(
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+
+    .. versionchanged:: 2023.12
+       Added device keyword argument support.
     """
 
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -806,6 +806,8 @@ def clip(
     - If both ``min`` and ``max`` are ``None``, the elements of the returned array must equal the respective elements in ``x``.
     - If a broadcasted element in ``min`` is greater than a corresponding broadcasted element in ``max``, behavior is unspecified and thus implementation-dependent.
     - If ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent.
+
+    .. versionadded:: 2023.12
     """
 
 
@@ -880,6 +882,8 @@ def copysign(x1: array, x2: array, /) -> array:
     - If ``x2_i`` is greater than ``0``, the result is ``NaN`` with a sign bit of ``0``.
     - If ``x2_i`` is ``NaN`` and the sign bit of ``x2_i`` is ``1``, the result is ``NaN`` with a sign bit of ``1``.
     - If ``x2_i`` is ``NaN`` and the sign bit of ``x2_i`` is ``0``, the result is ``NaN`` with a sign bit of ``0``.
+
+    .. versionadded:: 2023.12
     """
 
 
@@ -1410,6 +1414,8 @@ def hypot(x1: array, x2: array, /) -> array:
        IEEE 754-2019 requires support for subnormal (a.k.a., denormal) numbers, which are useful for supporting gradual underflow. However, hardware support for subnormal numbers is not universal, and many platforms (e.g., accelerators) and compilers support toggling denormals-are-zero (DAZ) and/or flush-to-zero (FTZ) behavior to increase performance and to guard against timing attacks.
 
        Accordingly, conforming implementations may vary in their support for subnormal numbers.
+
+    .. versionadded:: 2023.12
     """
 
 
@@ -1929,6 +1935,8 @@ def maximum(x1: array, x2: array, /) -> array:
     For floating-point operands,
 
     -   If either ``x1_i`` or ``x2_i`` is ``NaN``, the result is ``NaN``.
+
+    .. versionadded:: 2023.12
     """
 
 
@@ -1960,6 +1968,8 @@ def minimum(x1: array, x2: array, /) -> array:
     For floating-point operands,
 
     -   If either ``x1_i`` or ``x2_i`` is ``NaN``, the result is ``NaN``.
+
+    .. versionadded:: 2023.12
     """
 
 
@@ -2390,6 +2400,8 @@ def signbit(x: array, /) -> array:
     - If ``x_i`` is a negative (i.e., less than ``0``) finite number, the result is ``True``.
     - If ``x_i`` is ``NaN`` and the sign bit of ``x_i`` is ``0``, the result is ``False``.
     - If ``x_i`` is ``NaN`` and the sign bit of ``x_i`` is ``1``, the result is ``True``.
+
+    .. versionadded:: 2023.12
     """
 
 

--- a/src/array_api_stubs/_draft/fft.py
+++ b/src/array_api_stubs/_draft/fft.py
@@ -64,6 +64,9 @@ def fft(
     -----
 
     .. versionadded:: 2022.12
+
+    .. versionchanged:: 2023.12
+       Required the input array have a complex-valued floating-point data type and required that the output array have the same data type as the input array.
     """
 
 
@@ -113,6 +116,9 @@ def ifft(
     -----
 
     .. versionadded:: 2022.12
+
+    .. versionchanged:: 2023.12
+       Required the input array have a complex-valued floating-point data type and required that the output array have the same data type as the input array.
     """
 
 
@@ -168,6 +174,9 @@ def fftn(
     -----
 
     .. versionadded:: 2022.12
+
+    .. versionchanged:: 2023.12
+       Required the input array have a complex-valued floating-point data type and required that the output array have the same data type as the input array.
     """
 
 
@@ -223,6 +232,9 @@ def ifftn(
     -----
 
     .. versionadded:: 2022.12
+
+    .. versionchanged:: 2023.12
+       Required the input array have a complex-valued floating-point data type and required that the output array have the same data type as the input array.
     """
 
 
@@ -323,6 +335,9 @@ def irfft(
     -   In order to return an array having an odd number of elements along the transformed axis, the function must be provided an odd integer for ``n``.
 
     .. versionadded:: 2022.12
+
+    .. versionchanged:: 2023.12
+       Required the output array have a real-valued floating-point data type having the same precision as the input array.
     """
 
 
@@ -435,6 +450,9 @@ def irfftn(
     -   In order to return an array having an odd number of elements along the last transformed axis, the function must be provided an odd integer for ``s[-1]``.
 
     .. versionadded:: 2022.12
+
+    .. versionchanged:: 2023.12
+       Required the output array have a real-valued floating-point data type having the same precision as the input array.
     """
 
 
@@ -481,6 +499,9 @@ def hfft(
     -----
 
     .. versionadded:: 2022.12
+
+    .. versionchanged:: 2023.12
+       Required the input array to have a complex-valued floating-point data type and required that the output array have a real-valued data type having the same precision as the input array.
     """
 
 
@@ -559,6 +580,9 @@ def fftfreq(n: int, /, *, d: float = 1.0, device: Optional[device] = None) -> ar
     -----
 
     .. versionadded:: 2022.12
+
+    .. versionchanged:: 2023.12
+       Required the output array have the default real-valued floating-point data type.
     """
 
 
@@ -593,6 +617,9 @@ def rfftfreq(n: int, /, *, d: float = 1.0, device: Optional[device] = None) -> a
     -----
 
     .. versionadded:: 2022.12
+
+    .. versionchanged:: 2023.12
+       Required the output array have the default real-valued floating-point data type.
     """
 
 

--- a/src/array_api_stubs/_draft/indexing_functions.py
+++ b/src/array_api_stubs/_draft/indexing_functions.py
@@ -20,7 +20,7 @@ def take(x: array, indices: array, /, *, axis: Optional[int] = None) -> array:
         .. note::
            This specification does not require bounds checking. The behavior for out-of-bounds indices is left unspecified.
 
-    axis: int
+    axis: Optional[int]
         axis over which to select values. If ``axis`` is negative, the function must determine the axis along which to select values by counting from the last dimension.
 
         If ``x`` is a one-dimensional array, providing an ``axis`` is optional; however, if ``x`` has more than one dimension, providing an ``axis`` is required.
@@ -34,4 +34,7 @@ def take(x: array, indices: array, /, *, axis: Optional[int] = None) -> array:
     -----
 
     .. versionadded:: 2022.12
+
+    .. versionchanged:: 2023.12
+       Out-of-bounds behavior is explicitly left unspecified.
     """

--- a/src/array_api_stubs/_draft/info.py
+++ b/src/array_api_stubs/_draft/info.py
@@ -43,6 +43,8 @@ def __array_namespace_info__() -> Info:
       info.dtypes()
       info.default_dtypes()
       # ...
+
+    .. versionadded: 2023.12
     """
 
 
@@ -59,6 +61,11 @@ def capabilities() -> Capabilities:
     -------
     out: Capabilities
         a dictionary of array library capabilities.
+
+    Notes
+    -----
+
+    .. versionadded: 2023.12
     """
 
 
@@ -70,6 +77,11 @@ def default_device() -> device:
     -------
     out: device
         an object corresponding to the default device.
+
+    Notes
+    -----
+
+    .. versionadded: 2023.12
     """
 
 
@@ -101,6 +113,11 @@ def default_dtypes(
     -------
     out: DefaultDataTypes
         a dictionary containing the default data type for respective data type kinds.
+
+    Notes
+    -----
+
+    .. versionadded: 2023.12
     """
 
 
@@ -151,6 +168,11 @@ def dtypes(
 
         .. note::
            Dictionary keys must only consist of canonical names as defined in :ref:`data-types`.
+
+    Notes
+    -----
+
+    .. versionadded: 2023.12
     """
 
 
@@ -167,4 +189,9 @@ def devices() -> List[device]:
     -----
 
     Each device object (see :ref:`device-support`) in the list of returned devices must be an object which can be provided as a valid keyword-argument to array creation functions.
+
+    Notes
+    -----
+
+    .. versionadded: 2023.12
     """

--- a/src/array_api_stubs/_draft/linalg.py
+++ b/src/array_api_stubs/_draft/linalg.py
@@ -102,15 +102,18 @@ def cross(x1: array, x2: array, /, *, axis: int = -1) -> array:
     Notes
     -----
 
+    **Raises**
+
+    -   if the size of the axis over which to compute the cross product is not equal to ``3`` (before broadcasting) for both ``x1`` and ``x2``.
+
     .. versionchanged:: 2022.12
        Added support for broadcasting.
 
     .. versionchanged:: 2022.12
        Added complex data type support.
 
-    **Raises**
-
-    -   if the size of the axis over which to compute the cross product is not equal to ``3`` (before broadcasting) for both ``x1`` and ``x2``.
+    .. versionchanged:: 2023.12
+       Restricted broadcasting to only non-compute axes and required that ``axis`` be a negative integer.
     """
 
 
@@ -772,6 +775,9 @@ def trace(x: array, /, *, offset: int = 0, dtype: Optional[dtype] = None) -> arr
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+
+    .. versionchanged:: 2023.12
+       Required the function to return a floating-point array having the same data type as the input array when provided a floating-point array.
     """
 
 

--- a/src/array_api_stubs/_draft/linear_algebra_functions.py
+++ b/src/array_api_stubs/_draft/linear_algebra_functions.py
@@ -116,6 +116,9 @@ def tensordot(
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+
+    .. versionchanged:: 2023.12
+       Allow negative axes.
     """
 
 
@@ -151,10 +154,13 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     Notes
     -----
 
-    .. versionchanged:: 2022.12
-       Added complex data type support.
-
     **Raises**
 
     -   if the size of the axis over which to compute the dot product is not the same (before broadcasting) for both ``x1`` and ``x2``.
+
+    .. versionchanged:: 2022.12
+       Added complex data type support.
+
+    .. versionchanged:: 2023.12
+       Restricted ``axis`` to only negative integers.
     """

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -139,6 +139,11 @@ def moveaxis(
     -------
     out: array
         an array containing reordered axes. The returned array must have the same data type as ``x``.
+
+    Notes
+    -----
+
+    .. versionadded:: 2023.12
     """
 
 
@@ -204,6 +209,11 @@ def repeat(
     -------
     out: array
         an output array containing repeated elements. The returned array must have the same data type as ``x``. If ``axis`` is ``None``, the returned array must be a one-dimensional array; otherwise, the returned array must have the same shape as ``x``, except for the axis (dimension) along which elements were repeated.
+
+    Notes
+    -----
+
+    .. versionadded:: 2023.12
     """
 
 
@@ -327,6 +337,11 @@ def tile(x: array, repetitions: Tuple[int, ...], /):
     -------
     out: array
         a tiled output array. The returned array must have the same data type as ``x`` and must have a rank (i.e., number of dimensions) equal to ``max(N, M)``. If ``S`` is the shape of the tiled array after prepending singleton dimensions (if necessary) and ``r`` is the tuple of repetitions after prepending ones (if necessary), then the number of elements along each axis (dimension) must satisfy ``S[i]*r[i]``, where ``i`` refers to the ``i`` th axis (dimension).
+
+    Notes
+    -----
+
+    .. versionadded:: 2023.12
     """
 
 
@@ -345,4 +360,9 @@ def unstack(x: array, /, *, axis: int = 0) -> Tuple[array, ...]:
     -------
     out: Tuple[array, ...]
         tuple of slices along the given dimension. All the arrays have the same shape.
+
+    Notes
+    -----
+
+    .. versionadded:: 2023.12
     """

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -134,6 +134,8 @@ def searchsorted(
     For real-valued floating-point arrays, the sort order of NaNs and signed zeros is unspecified and thus implementation-dependent. Accordingly, when a real-valued floating-point array contains NaNs and signed zeros, what constitutes ascending order may vary among specification-conforming array libraries.
 
     While behavior for arrays containing NaNs and signed zeros is implementation-dependent, specification-conforming libraries should, however, ensure consistency with ``sort`` and ``argsort`` (i.e., if a value in ``x2`` is inserted into ``x1`` according to the corresponding index in the output array and ``sort`` is invoked on the resultant array, the sorted result should be an array in the same order).
+
+    .. versionadded:: 2023.12
     """
 
 

--- a/src/array_api_stubs/_draft/set_functions.py
+++ b/src/array_api_stubs/_draft/set_functions.py
@@ -47,6 +47,9 @@ def unique_all(x: array, /) -> Tuple[array, array, array, array]:
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+
+    .. versionchanged:: 2023.12
+       Clarified flattening behavior and required the order of ``counts`` match the order of ``values``.
     """
 
 
@@ -89,6 +92,9 @@ def unique_counts(x: array, /) -> Tuple[array, array]:
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+
+    .. versionchanged:: 2023.12
+       Clarified flattening behavior and required the order of ``counts`` match the order of ``values``.
     """
 
 
@@ -131,6 +137,9 @@ def unique_inverse(x: array, /) -> Tuple[array, array]:
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+
+    .. versionchanged:: 2023.12
+       Clarified flattening behavior.
     """
 
 
@@ -168,4 +177,7 @@ def unique_values(x: array, /) -> array:
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+
+    .. versionchanged:: 2023.12
+       Required that the output array must be one-dimensional.
     """

--- a/src/array_api_stubs/_draft/statistical_functions.py
+++ b/src/array_api_stubs/_draft/statistical_functions.py
@@ -51,6 +51,8 @@ def cumulative_sum(
     **Special Cases**
 
     For both real-valued and complex floating-point operands, special cases must be handled as if the operation is implemented by successive application of :func:`~array_api.add`.
+
+    .. versionadded:: 2023.12
     """
 
 
@@ -92,6 +94,9 @@ def max(
     For floating-point operands,
 
     -   If ``x_i`` is ``NaN``, the maximum value is ``NaN`` (i.e., ``NaN`` values propagate).
+
+    .. versionchanged:: 2023.12
+       Clarified that the order of signed zeros is implementation-defined.
     """
 
 
@@ -172,6 +177,9 @@ def min(
     For floating-point operands,
 
     -   If ``x_i`` is ``NaN``, the minimum value is ``NaN`` (i.e., ``NaN`` values propagate).
+
+    .. versionchanged:: 2023.12
+       Clarified that the order of signed zeros is implementation-defined.
     """
 
 
@@ -222,6 +230,9 @@ def prod(
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+
+    .. versionchanged:: 2023.12
+       Required the function to return a floating-point array having the same data type as the input array when provided a floating-point array.
     """
 
 
@@ -314,6 +325,9 @@ def sum(
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+
+    .. versionchanged:: 2023.12
+       Required the function to return a floating-point array having the same data type as the input array when provided a floating-point array.
     """
 
 


### PR DESCRIPTION
This PR

- adds changelog entries for the v2023.12 revision of the Array API specification.
- adds `versionadded` and `versionchanged` Sphinx directives to affected APIs.