### PR TITLE
Fix version switcher by using sphinxcontrib-jquery

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -5,3 +5,4 @@ sphinx_markdown_tables
 sphinx_copybutton
 sphinx_favicon
 sphinx-math-dollar
+sphinxcontrib-jquery

--- a/src/_array_api_conf.py
+++ b/src/_array_api_conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_favicon",
     "sphinx_markdown_tables",
+    "sphinxcontrib.jquery",
 ]
 
 autosummary_generate = True


### PR DESCRIPTION
Note that this doesn't work on local doc builds, it'll now give:
```
  Cross-Origin Request Blocked: The Same Origin Policy disallows reading
  the remote resource at file:///path/to/array-api/_site/versions.json.
  (Reason: CORS request not http)
```

As long as it works on the deployed site that is of later concern though. _EDIT: see [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSRequestNotHttp?utm_source=devtools&utm_medium=firefox-cors-errors&utm_campaign=default) for the explanation about why it doesn't work without a server._

Closes gh-753