### PR TITLE
feat: add `max rank` to inspection API capabilities

### DIFF
--- a/src/array_api_stubs/_draft/_types.py
+++ b/src/array_api_stubs/_draft/_types.py
@@ -140,5 +140,10 @@ DataTypes = TypedDict(
     total=False,
 )
 Capabilities = TypedDict(
-    "Capabilities", {"boolean indexing": bool, "data-dependent shapes": bool}
+    "Capabilities",
+    {
+        "boolean indexing": bool,
+        "data-dependent shapes": bool,
+        "max rank": Optional[int],
+    },
 )

--- a/src/array_api_stubs/_draft/info.py
+++ b/src/array_api_stubs/_draft/info.py
@@ -56,6 +56,7 @@ def capabilities() -> Capabilities:
 
     -   `"boolean indexing"`: boolean indicating whether an array library supports boolean indexing. If a conforming implementation fully supports boolean indexing in compliance with this specification (see :ref:`indexing`), the corresponding dictionary value must be ``True``; otherwise, the value must be ``False``.
     -   `"data-dependent shapes"`: boolean indicating whether an array library supports data-dependent output shapes. If a conforming implementation fully supports all APIs included in this specification (excluding boolean indexing) which have data-dependent output shapes, as explicitly demarcated throughout the specification, the corresponding dictionary value must be ``True``; otherwise, the value must be ``False``.
+    -   `"max rank"`: maximum number of supported dimensions. If a conforming implementation supports arrays having an arbitrary number of dimensions (potentially infinite), the corresponding dictionary value must be ``None``; otherwise, the value must be a finite integer.
 
     Returns
     -------


### PR DESCRIPTION
This PR

- adds support for querying the maximum number of supported dimensions (i.e., the maximum array rank).
- requires that conforming array libraries supporting an infinite number of dimensions specify the max rank as `None` (i.e., there is not maximum array rank), and, for those unable to support infinite dimensions, those libraries must specify a finite integer value.
- closes: https://github.com/data-apis/array-api/issues/694