### PR TITLE
Corrected typo in `__bool__` with backport

### DIFF
--- a/src/array_api_stubs/_2022_12/array_object.py
+++ b/src/array_api_stubs/_2022_12/array_object.py
@@ -237,7 +237,7 @@ class _array:
         - If ``self`` is either ``+infinity`` or ``-infinity``, the result is ``True``.
         - If ``self`` is either ``+0`` or ``-0``, the result is ``False``.
 
-        For complex floating-point operands, special cases must be handled as if the operation is implemented as the logical AND of ``bool(real(self))`` and ``bool(imag(self))``.
+        For complex floating-point operands, special cases must be handled as if the operation is implemented as the logical OR of ``bool(real(self))`` and ``bool(imag(self))``.
 
         .. versionchanged:: 2022.12
             Added boolean and complex data type support.

--- a/src/array_api_stubs/_2023_12/array_object.py
+++ b/src/array_api_stubs/_2023_12/array_object.py
@@ -239,7 +239,7 @@ class _array:
         - If ``self`` is either ``+infinity`` or ``-infinity``, the result is ``True``.
         - If ``self`` is either ``+0`` or ``-0``, the result is ``False``.
 
-        For complex floating-point operands, special cases must be handled as if the operation is implemented as the logical AND of ``bool(real(self))`` and ``bool(imag(self))``.
+        For complex floating-point operands, special cases must be handled as if the operation is implemented as the logical OR of ``bool(real(self))`` and ``bool(imag(self))``.
 
         **Lazy implementations**
 

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -239,7 +239,7 @@ class _array:
         - If ``self`` is either ``+infinity`` or ``-infinity``, the result is ``True``.
         - If ``self`` is either ``+0`` or ``-0``, the result is ``False``.
 
-        For complex floating-point operands, special cases must be handled as if the operation is implemented as the logical AND of ``bool(real(self))`` and ``bool(imag(self))``.
+        For complex floating-point operands, special cases must be handled as if the operation is implemented as the logical OR of ``bool(real(self))`` and ``bool(imag(self))``.
 
         **Lazy implementations**
 


### PR DESCRIPTION
Corrected a typo in `__bool__` to match convention that `x.__bool__() == bool(real(x)) or bool(imag(x))`

cc: @asmeurer 