### PR TITLE
feat: add `diff` to specification

### DIFF
--- a/spec/draft/API_specification/utility_functions.rst
+++ b/spec/draft/API_specification/utility_functions.rst
@@ -20,3 +20,4 @@ Objects in API
 
    all
    any
+   diff

--- a/src/array_api_stubs/_draft/utility_functions.py
+++ b/src/array_api_stubs/_draft/utility_functions.py
@@ -1,4 +1,4 @@
-__all__ = ["all", "any"]
+__all__ = ["all", "any", "diff"]
 
 
 from ._types import Optional, Tuple, Union, array
@@ -83,4 +83,46 @@ def any(
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+    """
+
+
+def diff(
+    x: array,
+    /,
+    *,
+    axis: int = -1,
+    n: int = 1,
+    prepend: Optional[array],
+    append: Optional[array],
+) -> array:
+    """
+    Calculates the n-th discrete forward difference along a specified axis.
+
+    Parameters
+    ----------
+    x: array
+        input array. Should have a numeric data type.
+    axis: int
+        axis along which to compute differences. A valid ``axis`` must be an integer on the interval ``[-N, N)``, where ``N`` is the rank (number of dimensions) of ``x``. If an ``axis`` is specified as a negative integer, the function must determine the axis along which to compute differences by counting backward from the last dimension (where ``-1`` refers to the last dimension). If provided an invalid ``axis``, the function must raise an exception. Default: ``-1``.
+    n: int
+        number of times to recursively compute differences. Default: ``1``.
+    prepend: array
+        values to prepend to a specified axis prior to computing differences. Must have the same shape as ``x``, except for the axis specified by ``axis`` which may have any size. Should have the same data type as ``x``.
+    append: array
+        values to append to a specified axis prior to computing differences. Must have the same shape as ``x``, except for the axis specified by ``axis`` which may have any size. Should have the same data type as ``x``.
+
+    Returns
+    -------
+    out: array
+        an array containing the n-th differences. Should have the same data type as ``x``. Must have the same shape as ``x``, except for the axis specified by ``axis`` which must have a size determined as follows:
+
+        -   Let ``M`` be the number of elements along an axis specified by ``axis``.
+        -   Let ``N1`` be the number of prepended values along an axis specified by ``axis``.
+        -   Let ``N2`` be the number of appended values along an axis specified by ``axis``.
+        -   The final size of the axis specified by ``axis`` must be ``M + N1 + N2 - n``.
+
+    Notes
+    -----
+
+    -   The first-order differences are given by ``out[i] = x[i+1] - x[i]`` along a specified axis. Higher-order differences must be calculated recursively (e.g., by calling ``diff(out, axis=axis, n=n-1)``).
     """

--- a/src/array_api_stubs/_draft/utility_functions.py
+++ b/src/array_api_stubs/_draft/utility_functions.py
@@ -92,8 +92,8 @@ def diff(
     *,
     axis: int = -1,
     n: int = 1,
-    prepend: Optional[array],
-    append: Optional[array],
+    prepend: Optional[array] = None,
+    append: Optional[array] = None,
 ) -> array:
     """
     Calculates the n-th discrete forward difference along a specified axis.
@@ -106,10 +106,10 @@ def diff(
         axis along which to compute differences. A valid ``axis`` must be an integer on the interval ``[-N, N)``, where ``N`` is the rank (number of dimensions) of ``x``. If an ``axis`` is specified as a negative integer, the function must determine the axis along which to compute differences by counting backward from the last dimension (where ``-1`` refers to the last dimension). If provided an invalid ``axis``, the function must raise an exception. Default: ``-1``.
     n: int
         number of times to recursively compute differences. Default: ``1``.
-    prepend: array
-        values to prepend to a specified axis prior to computing differences. Must have the same shape as ``x``, except for the axis specified by ``axis`` which may have any size. Should have the same data type as ``x``.
-    append: array
-        values to append to a specified axis prior to computing differences. Must have the same shape as ``x``, except for the axis specified by ``axis`` which may have any size. Should have the same data type as ``x``.
+    prepend: Optional[array]
+        values to prepend to a specified axis prior to computing differences. Must have the same shape as ``x``, except for the axis specified by ``axis`` which may have any size. Should have the same data type as ``x``. Default: ``None``.
+    append: Optional[array]
+        values to append to a specified axis prior to computing differences. Must have the same shape as ``x``, except for the axis specified by ``axis`` which may have any size. Should have the same data type as ``x``. Default: ``None``.
 
     Returns
     -------


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/784 by adding `diff` to the specification.
- restricts portable behavior for `prepend` and `append` to arrays. While NumPy and others support scalars (a common use case), PyTorch does not support scalars.
- supports all numeric dtypes (real and complex floats, signed and unsigned integers).
- allows some wiggle room for array libraries supporting "exotic" dtypes, such as datetimes, by stating that the output array "should" have the same data type as the input array `x`. E.g., NumPy supports datetimes and returns timedeltas. For numeric dtypes, the output array should always have the same dtype.
- restricts `prepend` and `append` to the same data type as the input array. If we more generally allow any combination of dtypes among `x`, `prepend`, and `append`, we'd need to consider type promotion semantics. We don't have much, if any, precedent in the specification for array kwargs causing an input array to upcast, and I don't think we should establish precedent here.
- set the defaults for `prepend` and `append` to `None`. This is in contrast to NumPy which doesn't set a default value.