### PR TITLE
feat: add `nextafter` to specification

### DIFF
--- a/spec/draft/API_specification/elementwise_functions.rst
+++ b/spec/draft/API_specification/elementwise_functions.rst
@@ -66,6 +66,7 @@ Objects in API
    minimum
    multiply
    negative
+   nextafter
    not_equal
    positive
    pow

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -48,6 +48,7 @@ __all__ = [
     "minimum",
     "multiply",
     "negative",
+    "nextafter",
     "not_equal",
     "positive",
     "pow",
@@ -2066,6 +2067,35 @@ def negative(x: array, /) -> array:
 
     .. versionchanged:: 2022.12
        Added complex data type support.
+    """
+
+
+def nextafter(x1: array, x2: array, /) -> array:
+    """
+    Returns the next representable floating-point value for each element ``x1_i`` of the input array ``x1`` in the direction of the respective element ``x2_i`` of the input array ``x2``.
+
+    Parameters
+    ----------
+    x1: array
+        first input array. Should have a real-valued floating-point data type.
+    x2: array
+        second input array. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have the same data type as ``x1``.
+
+    Returns
+    -------
+    out: array
+        an array containing the element-wise results. The returned array must have the same data type as ``x1``.
+
+    Notes
+    -----
+
+    **Special cases**
+
+    For real-valued floating-point operands,
+
+    - If either ``x1_i`` or ``x2_i`` is ``NaN``, the result is ``NaN``.
+    - If ``x1_i`` is ``-0`` and ``x2_i`` is ``+0``, the result is ``+0``.
+    - If ``x1_i`` is ``+0`` and ``x2_i`` is ``-0``, the result is ``-0``.
     """
 
 


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/664 by adding `nextafter` to the specification.
- restricts `x2` to an array for portable behavior. While NumPy and others support scalars (and this is a common use case), PyTorch only supports tensors for `x2`. In general, we are consistent throughout the specification in requiring that positional array arguments be strictly arrays. Were we to make an exception here, I'd imagine that the exception would apply equally to other arithmetic operations (e.g., `add`, `multiply`, etc) for which we have standardized functional APIs.
- requires ("should") that `x2` have the same data type as `x1` for portable behavior. Libraries are free to support other data types and subsequently type promotion (e.g., NumPy), but this should not be guaranteed across conforming array libraries, as the general expectation is that one typically wants the next representable value in the **same** precision as `x1`.
- follows [C99](https://en.cppreference.com/w/c/numeric/math/nextafter) (checked with NumPy) in ensuring consistent behavior around zero. Namely, when `x1` and `x2` are equal and both zero, the result should be `x2`.