### PR TITLE
Fix doc-requirements.txt to work with conda

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,8 +1,8 @@
 sphinx==7.2.6
 sphinx-material==0.0.36
 myst-parser
-sphinx_markdown_tables
-sphinx_copybutton
-sphinx_favicon
+sphinx-markdown-tables
+sphinx-copybutton
+sphinx-favicon
 sphinx-math-dollar
 sphinxcontrib-jquery


### PR DESCRIPTION
pip treats dashes and underscores the same but conda does not. The package names here are actually dashes (pip just replaces an underscore with a dash) so this is more correct anyways.