### PR TITLE
Making RFC 2119 usage clearer

### DIFF
--- a/spec/2023.12/API_specification/data_types.rst
+++ b/spec/2023.12/API_specification/data_types.rst
@@ -9,35 +9,38 @@ A conforming implementation of the array API standard must provide and support
 the following data types ("dtypes") in its array object, and as data type
 objects in its main namespace under the specified names:
 
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| dtype object | description                                                                                                                                                                                |
-+==============+============================================================================================================================================================================================+
-| bool         | Boolean (``True`` or ``False``).                                                                                                                                                           |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| int8         | An 8-bit signed integer whose values exist on the interval ``[-128, +127]``.                                                                                                               |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| int16        | A 16-bit signed integer whose values exist on the interval ``[−32,767, +32,767]``.                                                                                                         |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| int32        | A 32-bit signed integer whose values exist on the interval ``[−2,147,483,647, +2,147,483,647]``.                                                                                           |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| int64        | A 64-bit signed integer whose values exist on the interval ``[−9,223,372,036,854,775,807, +9,223,372,036,854,775,807]``.                                                                   |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| uint8        | An 8-bit unsigned integer whose values exist on the interval ``[0, +255]``.                                                                                                                |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| uint16       | A 16-bit unsigned integer whose values exist on the interval ``[0, +65,535]``.                                                                                                             |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| uint32       | A 32-bit unsigned integer whose values exist on the interval ``[0, +4,294,967,295]``.                                                                                                      |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| uint64       | A 64-bit unsigned integer whose values exist on the interval ``[0, +18,446,744,073,709,551,615]``.                                                                                         |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| float32      | IEEE 754 single-precision (32-bit) binary floating-point number (see IEEE 754-2019).                                                                                                       |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| float64      | IEEE 754 double-precision (64-bit) binary floating-point number (see IEEE 754-2019).                                                                                                       |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| complex64    | Single-precision (64-bit) complex floating-point number whose real and imaginary components must be IEEE 754 single-precision (32-bit) binary floating-point numbers (see IEEE 754-2019).  |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| complex128   | Double-precision (128-bit) complex floating-point number whose real and imaginary components must be IEEE 754 double-precision (64-bit) binary floating-point numbers (see IEEE 754-2019). |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - dtype object
+     - description
+   * - bool
+     - Boolean (``True`` or ``False``).
+   * - int8
+     - An 8-bit signed integer whose values exist on the interval ``[-128, +127]``.
+   * - int16
+     - A 16-bit signed integer whose values exist on the interval ``[−32,767, +32,767]``.
+   * - int32
+     - A 32-bit signed integer whose values exist on the interval ``[−2,147,483,647, +2,147,483,647]``.
+   * - int64
+     - A 64-bit signed integer whose values exist on the interval ``[−9,223,372,036,854,775,807, +9,223,372,036,854,775,807]``.
+   * - uint8
+     - An 8-bit unsigned integer whose values exist on the interval ``[0, +255]``.
+   * - uint16
+     - A 16-bit unsigned integer whose values exist on the interval ``[0, +65,535]``.
+   * - uint32
+     - A 32-bit unsigned integer whose values exist on the interval ``[0, +4,294,967,295]``.
+   * - uint64
+     - A 64-bit unsigned integer whose values exist on the interval ``[0, +18,446,744,073,709,551,615]``.
+   * - float32
+     - IEEE 754 single-precision (32-bit) binary floating-point number (see IEEE 754-2019).
+   * - float64
+     - IEEE 754 double-precision (64-bit) binary floating-point number (see IEEE 754-2019).
+   * - complex64
+     - Single-precision (64-bit) complex floating-point number whose real and imaginary components must be IEEE 754 single-precision (32-bit) binary floating-point numbers (see IEEE 754-2019).
+   * - complex128
+     - Double-precision (128-bit) complex floating-point number whose real and imaginary components must be IEEE 754 double-precision (64-bit) binary floating-point numbers (see IEEE 754-2019).
 
 Data type objects must have the following methods (no attributes are required):
 

--- a/spec/draft/API_specification/data_types.rst
+++ b/spec/draft/API_specification/data_types.rst
@@ -9,35 +9,38 @@ A conforming implementation of the array API standard must provide and support
 the following data types ("dtypes") in its array object, and as data type
 objects in its main namespace under the specified names:
 
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| dtype object | description                                                                                                                                                                                |
-+==============+============================================================================================================================================================================================+
-| bool         | Boolean (``True`` or ``False``).                                                                                                                                                           |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| int8         | An 8-bit signed integer whose values exist on the interval ``[-128, +127]``.                                                                                                               |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| int16        | A 16-bit signed integer whose values exist on the interval ``[−32,767, +32,767]``.                                                                                                         |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| int32        | A 32-bit signed integer whose values exist on the interval ``[−2,147,483,647, +2,147,483,647]``.                                                                                           |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| int64        | A 64-bit signed integer whose values exist on the interval ``[−9,223,372,036,854,775,807, +9,223,372,036,854,775,807]``.                                                                   |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| uint8        | An 8-bit unsigned integer whose values exist on the interval ``[0, +255]``.                                                                                                                |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| uint16       | A 16-bit unsigned integer whose values exist on the interval ``[0, +65,535]``.                                                                                                             |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| uint32       | A 32-bit unsigned integer whose values exist on the interval ``[0, +4,294,967,295]``.                                                                                                      |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| uint64       | A 64-bit unsigned integer whose values exist on the interval ``[0, +18,446,744,073,709,551,615]``.                                                                                         |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| float32      | IEEE 754 single-precision (32-bit) binary floating-point number (see IEEE 754-2019).                                                                                                       |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| float64      | IEEE 754 double-precision (64-bit) binary floating-point number (see IEEE 754-2019).                                                                                                       |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| complex64    | Single-precision (64-bit) complex floating-point number whose real and imaginary components must be IEEE 754 single-precision (32-bit) binary floating-point numbers (see IEEE 754-2019).  |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| complex128   | Double-precision (128-bit) complex floating-point number whose real and imaginary components must be IEEE 754 double-precision (64-bit) binary floating-point numbers (see IEEE 754-2019). |
-+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - dtype object
+     - description
+   * - bool
+     - Boolean (``True`` or ``False``).
+   * - int8
+     - An 8-bit signed integer whose values exist on the interval ``[-128, +127]``.
+   * - int16
+     - A 16-bit signed integer whose values exist on the interval ``[−32,767, +32,767]``.
+   * - int32
+     - A 32-bit signed integer whose values exist on the interval ``[−2,147,483,647, +2,147,483,647]``.
+   * - int64
+     - A 64-bit signed integer whose values exist on the interval ``[−9,223,372,036,854,775,807, +9,223,372,036,854,775,807]``.
+   * - uint8
+     - An 8-bit unsigned integer whose values exist on the interval ``[0, +255]``.
+   * - uint16
+     - A 16-bit unsigned integer whose values exist on the interval ``[0, +65,535]``.
+   * - uint32
+     - A 32-bit unsigned integer whose values exist on the interval ``[0, +4,294,967,295]``.
+   * - uint64
+     - A 64-bit unsigned integer whose values exist on the interval ``[0, +18,446,744,073,709,551,615]``.
+   * - float32
+     - IEEE 754 single-precision (32-bit) binary floating-point number (see IEEE 754-2019).
+   * - float64
+     - IEEE 754 double-precision (64-bit) binary floating-point number (see IEEE 754-2019).
+   * - complex64
+     - Single-precision (64-bit) complex floating-point number whose real and imaginary components must be IEEE 754 single-precision (32-bit) binary floating-point numbers (see IEEE 754-2019).
+   * - complex128
+     - Double-precision (128-bit) complex floating-point number whose real and imaginary components must be IEEE 754 double-precision (64-bit) binary floating-point numbers (see IEEE 754-2019).
 
 Data type objects must have the following methods (no attributes are required):
 

--- a/spec/draft/purpose_and_scope.md
+++ b/spec/draft/purpose_and_scope.md
@@ -460,6 +460,8 @@ a dimension whose size is one.
 **vector**:
 a one-dimensional array.
 
+In addition to the above terms, the key words "**must**", "**must not**", "**required**", "**shall**", "**shall not**", "**should**", "**should not**", "**recommended**", "**may**", and "**optional**" in this specification are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
 * * *
 
 ## Normative References

--- a/src/_array_api_conf.py
+++ b/src/_array_api_conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx_favicon",
     "sphinx_markdown_tables",
     "sphinxcontrib.jquery",
+    "autobold_rfc2119",
 ]
 
 autosummary_generate = True

--- a/src/autobold_rfc2119.py
+++ b/src/autobold_rfc2119.py
@@ -1,0 +1,30 @@
+from sphinx.application import Sphinx
+import re
+
+rfc_2119_words = [
+    'must',
+    'must not',
+    'required',
+    'shall',
+    'shall not',
+    'should',
+    'should not',
+    'recommended',
+    'not recommended',
+    'may',
+    'optional',
+]
+
+def bold_terms(source):
+    return re.sub(rf'\b({"|".join(rfc_2119_words)})\b(?!\[)', r'**\1**', source, flags=re.IGNORECASE)
+
+def bold_terms_source_read(app, docname, source):
+    source[0] = bold_terms(source[0])
+
+def bold_terms_autodoc(app, what, name, obj, options, lines):
+    for i in range(len(lines)):
+        lines[i] = bold_terms(lines[i])
+
+def setup(app: Sphinx):
+    app.connect('source-read', bold_terms_source_read)
+    app.connect('autodoc-process-docstring', bold_terms_autodoc)


### PR DESCRIPTION
I've

- Added text to the end of the term definitions indicating that RFC 2119 is used.
- Add a Sphinx extension that automatically bolds RFC 2119 words.

However, note that our usage of some of the RFC terms is not always consistent, especially for less used terms like "required", "may", "optional", and "recommended". So I would suggest that we either

- Audit our use of these terms and fix them to align with RFC 2119 usage.
- Add some text to clarify that certain terms are not used in accordance with RFC 2119.

For example, we use the term "optional" to refer to "optional parameters". 

Fixes https://github.com/data-apis/array-api/issues/796