### PR TITLE
feat: add `reciprocal` to the specification

### DIFF
--- a/spec/draft/API_specification/elementwise_functions.rst
+++ b/spec/draft/API_specification/elementwise_functions.rst
@@ -70,6 +70,7 @@ Objects in API
    positive
    pow
    real
+   reciprocal
    remainder
    round
    sign

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -52,6 +52,7 @@ __all__ = [
     "positive",
     "pow",
     "real",
+    "reciprocal",
     "remainder",
     "round",
     "sign",
@@ -2221,6 +2222,29 @@ def real(x: array, /) -> array:
     -----
 
     .. versionadded:: 2022.12
+    """
+
+
+def reciprocal(x: array, /) -> array:
+    """
+    Returns the reciprocal for each element ``x_i`` of the input array ``x``.
+
+    Parameters
+    ----------
+    x: array
+        input array. Should have a floating-point data type.
+
+    Returns
+    -------
+    out: array
+        an array containing the element-wise results. The returned array must have a floating-point data type determined by :ref:`type-promotion`.
+
+    Notes
+    -----
+
+    **Special cases**
+
+    For floating-point operands, special cases must be handled as if the operation is implemented as ``1.0 / x`` (see :func:`~array_api.divide`).
     """
 
 


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/790 by adding support for computing the reciprocal to the specification.
- requires that special cases be handled as if implemented as `1.0 / x`.
- adopts the same "type promotion" language as other unary element-wise APIs, which is based on the premise that an input array promotes to itself. If this language should be changed, we should do as part of a follow-up PR across all relevant element-wise APIs.
- requires ("should") that the input array have a floating-point data type, as the output array should have a floating-point data type and promotion of mixed kinds is left unspecified.