### PR TITLE
docs: specify the behavior of `clip()` when one of the operands is NaN

### DIFF
--- a/src/array_api_stubs/_2023_12/elementwise_functions.py
+++ b/src/array_api_stubs/_2023_12/elementwise_functions.py
@@ -807,6 +807,12 @@ def clip(
     - If a broadcasted element in ``min`` is greater than a corresponding broadcasted element in ``max``, behavior is unspecified and thus implementation-dependent.
     - If ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent.
 
+    **Special cases**
+
+    - If ``x_i`` is ``NaN``, the result is ``NaN``.
+    - If ``min_i`` is ``NaN``, the result is ``NaN``.
+    - If ``max_i`` is ``NaN``, the result is ``NaN``.
+
     .. versionadded:: 2023.12
     """
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -808,6 +808,12 @@ def clip(
     - If a broadcasted element in ``min`` is greater than a corresponding broadcasted element in ``max``, behavior is unspecified and thus implementation-dependent.
     - If ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent.
 
+    **Special cases**
+
+    - If ``x_i`` is ``NaN``, the result is ``NaN``.
+    - If ``min_i`` is ``NaN``, the result is ``NaN``.
+    - If ``max_i`` is ``NaN``, the result is ``NaN``.
+
     .. versionadded:: 2023.12
     """
 


### PR DESCRIPTION
This follows the NumPy behavior, where the result is nan if any operand is nan. I checked PyTorch and it seems to do this as well. 