### PR TITLE
docs: add note that iteration is defined for 1-D arrays

### DIFF
--- a/src/array_api_stubs/_2021_12/array_object.py
+++ b/src/array_api_stubs/_2021_12/array_object.py
@@ -465,6 +465,8 @@ class _array:
         """
         Returns ``self[key]``.
 
+        See :ref:`indexing` for details on supported indexing semantics.
+
         Parameters
         ----------
         self: array
@@ -913,6 +915,8 @@ class _array:
     ) -> None:
         """
         Sets ``self[key]`` to ``value``.
+
+        See :ref:`indexing` for details on supported indexing semantics.
 
         Parameters
         ----------

--- a/src/array_api_stubs/_2022_12/array_object.py
+++ b/src/array_api_stubs/_2022_12/array_object.py
@@ -489,6 +489,8 @@ class _array:
         """
         Returns ``self[key]``.
 
+        See :ref:`indexing` for details on supported indexing semantics.
+
         Parameters
         ----------
         self: array
@@ -936,6 +938,8 @@ class _array:
     ) -> None:
         """
         Sets ``self[key]`` to ``value``.
+
+        See :ref:`indexing` for details on supported indexing semantics.
 
         Parameters
         ----------

--- a/src/array_api_stubs/_2023_12/array_object.py
+++ b/src/array_api_stubs/_2023_12/array_object.py
@@ -616,6 +616,8 @@ class _array:
         """
         Returns ``self[key]``.
 
+        See :ref:`indexing` for details on supported indexing semantics.
+
         Parameters
         ----------
         self: array
@@ -1084,6 +1086,8 @@ class _array:
     ) -> None:
         """
         Sets ``self[key]`` to ``value``.
+
+        See :ref:`indexing` for details on supported indexing semantics.
 
         Parameters
         ----------

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -631,7 +631,7 @@ class _array:
             an array containing the accessed value(s). The returned array must have the same data type as ``self``.
 
         .. note::
-           When ``__getitem__`` is defined on an object, Python will automatically define iteration (i.e., the behavior from ``iter(x)``) as  ``x[0]``, ``x[1]``, .... This can also be implemented directly by defining ``__iter__``. Therefore, for 1-D arrays, iteration should produce the sequence ``x[0]``, ``x[1]``, ... of 0-D arrays. Iteration behavior for arrays with more than one dimension is unspecified and thus implementation-defined.
+           When ``__getitem__`` is defined on an object, Python will automatically define iteration (i.e., the behavior from ``iter(x)``) as  ``x[0]``, ``x[1]``, and so forth. This can also be implemented directly by defining ``__iter__``. Therefore, for one-dimensional arrays, iteration should produce the sequence ``x[0]``, ``x[1]``, ... of zero-dimensional arrays. Iteration behavior for arrays having more than one dimension is unspecified and thus implementation-defined.
 
         """
 

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -631,7 +631,7 @@ class _array:
             an array containing the accessed value(s). The returned array must have the same data type as ``self``.
 
         .. note::
-           When ``__getitem__`` is defined on an object, Python will automatically define iteration (i.e., the behavior from ``iter(x)``) as  ``x[0]``, ``x[1]``, ..., ``x[N-1]``. This can also be implemented directly by defining ``__iter__``. Therefore, for a one-dimensional array ``x``, iteration should produce a sequence of zero-dimensional arrays ``x[0]``, ``x[1]``, ..., ``x[N-1]``, where ``N`` is the number of elements in the array. Iteration behavior for arrays having more than one dimension is unspecified and thus implementation-defined.
+           When ``__getitem__`` is defined on an object, Python will automatically define iteration (i.e., the behavior from ``iter(x)``) as  ``x[0]``, ``x[1]``, ..., ``x[N-1]``. This can also be implemented directly by defining ``__iter__``. Therefore, for a one-dimensional array ``x``, iteration should produce a sequence of zero-dimensional arrays ``x[0]``, ``x[1]``, ..., ``x[N-1]``, where ``N`` is the number of elements in the array. Iteration behavior for arrays having zero dimensions or more than one dimension is unspecified and thus implementation-defined.
 
         """
 

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -629,6 +629,10 @@ class _array:
         -------
         out: array
             an array containing the accessed value(s). The returned array must have the same data type as ``self``.
+
+        .. note::
+           When ``__getitem__`` is defined on an object, Python will automatically define iteration (i.e., the behavior from ``iter(x)``) as  ``x[0]``, ``x[1]``, .... This can also be implemented directly by defining ``__iter__``. Therefore, for 1-D arrays, iteration should produce the sequence ``x[0]``, ``x[1]``, ... of 0-D arrays. Iteration behavior for arrays with more than one dimension is unspecified and thus implementation-defined.
+
         """
 
     def __gt__(self: array, other: Union[int, float, array], /) -> array:

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -616,6 +616,8 @@ class _array:
         """
         Returns ``self[key]``.
 
+        See :ref:`indexing` for details on supported indexing semantics.
+
         Parameters
         ----------
         self: array
@@ -1084,6 +1086,8 @@ class _array:
     ) -> None:
         """
         Sets ``self[key]`` to ``value``.
+
+        See :ref:`indexing` for details on supported indexing semantics.
 
         Parameters
         ----------

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -631,7 +631,7 @@ class _array:
             an array containing the accessed value(s). The returned array must have the same data type as ``self``.
 
         .. note::
-           When ``__getitem__`` is defined on an object, Python will automatically define iteration (i.e., the behavior from ``iter(x)``) as  ``x[0]``, ``x[1]``, and so forth. This can also be implemented directly by defining ``__iter__``. Therefore, for one-dimensional arrays, iteration should produce a sequence of zero-dimensional arrays ``x[0]``, ``x[1]``, and so forth. Iteration behavior for arrays having more than one dimension is unspecified and thus implementation-defined.
+           When ``__getitem__`` is defined on an object, Python will automatically define iteration (i.e., the behavior from ``iter(x)``) as  ``x[0]``, ``x[1]``, ..., ``x[N-1]``. This can also be implemented directly by defining ``__iter__``. Therefore, for a one-dimensional array ``x``, iteration should produce a sequence of zero-dimensional arrays ``x[0]``, ``x[1]``, ..., ``x[N-1]``, where ``N`` is the number of elements in the array. Iteration behavior for arrays having more than one dimension is unspecified and thus implementation-defined.
 
         """
 

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -631,7 +631,7 @@ class _array:
             an array containing the accessed value(s). The returned array must have the same data type as ``self``.
 
         .. note::
-           When ``__getitem__`` is defined on an object, Python will automatically define iteration (i.e., the behavior from ``iter(x)``) as  ``x[0]``, ``x[1]``, and so forth. This can also be implemented directly by defining ``__iter__``. Therefore, for one-dimensional arrays, iteration should produce the sequence ``x[0]``, ``x[1]``, ... of zero-dimensional arrays. Iteration behavior for arrays having more than one dimension is unspecified and thus implementation-defined.
+           When ``__getitem__`` is defined on an object, Python will automatically define iteration (i.e., the behavior from ``iter(x)``) as  ``x[0]``, ``x[1]``, and so forth. This can also be implemented directly by defining ``__iter__``. Therefore, for one-dimensional arrays, iteration should produce a sequence of zero-dimensional arrays ``x[0]``, ``x[1]``, and so forth. Iteration behavior for arrays having more than one dimension is unspecified and thus implementation-defined.
 
         """
 


### PR DESCRIPTION
Fixes #818

I also added a cross-reference to the indexing page to the `__getitem__` and `__setitem__` docs.