### PR TITLE
docs: fix reference to eigh/eigvalsh

### DIFF
--- a/spec/2021.12/extensions/linear_algebra_functions.rst
+++ b/spec/2021.12/extensions/linear_algebra_functions.rst
@@ -48,8 +48,8 @@ Accordingly, the standardization process affords the opportunity to reduce inter
 
     In general, interfaces should avoid polymorphic return values (e.g., returning an array **or** a namedtuple, dependent on, e.g., an optional keyword argument). Dedicated interfaces for each return value type are preferred, as dedicated interfaces are easier to reason about at both the implementation level and user level. Example interfaces which could be combined into a single overloaded interface, but are not, include:
 
-    -   ``eig``: computing both eigenvalues and eignvectors.
-    -   ``eigvals``: computing only eigenvalues.
+    -   ``eigh``: computing both eigenvalues and eigenvectors.
+    -   ``eigvalsh``: computing only eigenvalues.
 
 4.  **Implementation agnosticism**: a standardized interface should eschew parameterization (including keyword arguments) biased toward particular implementations.
 

--- a/spec/2022.12/extensions/linear_algebra_functions.rst
+++ b/spec/2022.12/extensions/linear_algebra_functions.rst
@@ -51,8 +51,8 @@ Accordingly, the standardization process affords the opportunity to reduce inter
 
     In general, interfaces should avoid polymorphic return values (e.g., returning an array **or** a namedtuple, dependent on, e.g., an optional keyword argument). Dedicated interfaces for each return value type are preferred, as dedicated interfaces are easier to reason about at both the implementation level and user level. Example interfaces which could be combined into a single overloaded interface, but are not, include:
 
-    -   ``eig``: computing both eigenvalues and eignvectors.
-    -   ``eigvals``: computing only eigenvalues.
+    -   ``eigh``: computing both eigenvalues and eigenvectors.
+    -   ``eigvalsh``: computing only eigenvalues.
 
 4.  **Implementation agnosticism**: a standardized interface should eschew parameterization (including keyword arguments) biased toward particular implementations.
 

--- a/spec/2023.12/extensions/linear_algebra_functions.rst
+++ b/spec/2023.12/extensions/linear_algebra_functions.rst
@@ -51,8 +51,8 @@ Accordingly, the standardization process affords the opportunity to reduce inter
 
     In general, interfaces should avoid polymorphic return values (e.g., returning an array **or** a namedtuple, dependent on, e.g., an optional keyword argument). Dedicated interfaces for each return value type are preferred, as dedicated interfaces are easier to reason about at both the implementation level and user level. Example interfaces which could be combined into a single overloaded interface, but are not, include:
 
-    -   ``eig``: computing both eigenvalues and eignvectors.
-    -   ``eigvals``: computing only eigenvalues.
+    -   ``eigh``: computing both eigenvalues and eigenvectors.
+    -   ``eigvalsh``: computing only eigenvalues.
 
 4.  **Implementation agnosticism**: a standardized interface should eschew parameterization (including keyword arguments) biased toward particular implementations.
 

--- a/spec/draft/extensions/linear_algebra_functions.rst
+++ b/spec/draft/extensions/linear_algebra_functions.rst
@@ -51,8 +51,8 @@ Accordingly, the standardization process affords the opportunity to reduce inter
 
     In general, interfaces should avoid polymorphic return values (e.g., returning an array **or** a namedtuple, dependent on, e.g., an optional keyword argument). Dedicated interfaces for each return value type are preferred, as dedicated interfaces are easier to reason about at both the implementation level and user level. Example interfaces which could be combined into a single overloaded interface, but are not, include:
 
-    -   ``eig``: computing both eigenvalues and eignvectors.
-    -   ``eigvals``: computing only eigenvalues.
+    -   ``eigh``: computing both eigenvalues and eigenvectors.
+    -   ``eigvalsh``: computing only eigenvalues.
 
 4.  **Implementation agnosticism**: a standardized interface should eschew parameterization (including keyword arguments) biased toward particular implementations.
 


### PR DESCRIPTION
The linear algebra extension specification refers to `eig`/`eigvals` as an example of dedicated interfaces rather than a single interface with polymorphic return type. 

`eig`/`eigvals` are not yet in the standard, so this PR replaces these references with `eigh`/`eigvalsh`.

(I went ahead and changed the `202x.12` versions in addition to `draft`; if that's not right, it should be easy to revert them.)