### PR TITLE
docs: add missing subscripts in `sign` definition

### DIFF
--- a/src/array_api_stubs/_2022_12/elementwise_functions.py
+++ b/src/array_api_stubs/_2022_12/elementwise_functions.py
@@ -2065,7 +2065,7 @@ def sign(x: array, /) -> array:
     .. math::
        \operatorname{sign}(x_i) = \begin{cases}
        0 & \textrm{if } x_i = 0 \\
-       \frac{x}{|x|} & \textrm{otherwise}
+       \frac{x_i}{|x_i|} & \textrm{otherwise}
        \end{cases}
 
     where :math:`|x_i|` is the absolute value of :math:`x_i`.

--- a/src/array_api_stubs/_2023_12/elementwise_functions.py
+++ b/src/array_api_stubs/_2023_12/elementwise_functions.py
@@ -2335,7 +2335,7 @@ def sign(x: array, /) -> array:
     .. math::
        \operatorname{sign}(x_i) = \begin{cases}
        0 & \textrm{if } x_i = 0 \\
-       \frac{x}{|x|} & \textrm{otherwise}
+       \frac{x_i}{|x_i|} & \textrm{otherwise}
        \end{cases}
 
     where :math:`|x_i|` is the absolute value of :math:`x_i`.

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -2389,7 +2389,7 @@ def sign(x: array, /) -> array:
     .. math::
        \operatorname{sign}(x_i) = \begin{cases}
        0 & \textrm{if } x_i = 0 \\
-       \frac{x}{|x|} & \textrm{otherwise}
+       \frac{x_i}{|x_i|} & \textrm{otherwise}
        \end{cases}
 
     where :math:`|x_i|` is the absolute value of :math:`x_i`.


### PR DESCRIPTION
Looked like these subscripts were omitted.

LMK if this should be adjusted in 2012/2013 standards, but I think the intent is obvious enough that it doesn't need to be fixed in old versions.