### PR TITLE
docs: add note regarding unspecified behavior for 0d arrays in `cumulative_sum`

### DIFF
--- a/src/array_api_stubs/_draft/statistical_functions.py
+++ b/src/array_api_stubs/_draft/statistical_functions.py
@@ -18,7 +18,7 @@ def cumulative_sum(
     Parameters
     ----------
     x: array
-        input array. Should have a numeric data type.
+        input array. Should have one or more dimensions (axes). Should have a numeric data type.
     axis: Optional[int]
         axis along which a cumulative sum must be computed. If ``axis`` is negative, the function must determine the axis along which to compute a cumulative sum by counting from the last dimension.
 
@@ -47,6 +47,8 @@ def cumulative_sum(
 
     Notes
     -----
+
+    -   When ``x`` is a zero-dimensional array, behavior is unspecified and thus implementation-defined.
 
     **Special Cases**
 


### PR DESCRIPTION
This PR

- Closes https://github.com/data-apis/array-api/issues/797.
- updates specification language to limit input arrays to those having one or more dimensions. Conforming implementations are permitted to support 0d arrays for backward-compatibility, but this should not be considered portable behavior due to ambiguities arising from expected output for 0d input (e.g., when providing `include_initial`, what should be the dimensionality of the output? what should happen with the `axis` kwarg? etc).
- aligns the specification based on discussions in #797 and the Consortium workgroup meeting on May 2, 2024.