### PR TITLE
feat: add scalar support to `where`

### DIFF
--- a/spec/draft/API_specification/type_promotion.rst
+++ b/spec/draft/API_specification/type_promotion.rst
@@ -122,6 +122,7 @@ Notes
 
 
 .. _mixing-scalars-and-arrays:
+
 Mixing arrays with Python scalars
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/spec/draft/API_specification/type_promotion.rst
+++ b/spec/draft/API_specification/type_promotion.rst
@@ -120,6 +120,8 @@ Notes
 .. note::
    Mixed integer and floating-point type promotion rules are not specified because behavior varies between implementations.
 
+
+.. _mixing-scalars-and-arrays:
 Mixing arrays with Python scalars
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -169,5 +169,5 @@ def where(
     -   If either ``x1`` or ``x2`` is a scalar value, the returned array must have a data type determined according to :ref:`mixing-scalars-and-arrays`.
 
     .. versionchanged:: 2024.12
-        ``x1`` and ``x2`` may be scalars.
+        Added support for scalar arguments.
     """

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -153,9 +153,9 @@ def where(
     condition: array
         when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
     x1: Union[array, int, float, complex, bool]
-        first input array or scalar. Scalar values are treated like an array filled with this value. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
+        first input array. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
     x2: Union[array, int, float, complex, bool]
-        second input array or scalar. Scalar values are treated like an array filled with this value. Must be compatible with ``condition`` and ``x1`` (see :ref:`broadcasting`).
+        second input array. Must be compatible with ``condition`` and ``x1`` (see :ref:`broadcasting`).
 
     Returns
     -------

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -151,16 +151,20 @@ def where(
     Parameters
     ----------
     condition: array
-        when ``True``, yield ``x1_i`` (scalar ``x1``); otherwise, yield ``x2_i`` (scalar ``x2``). Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
-    x1: Union[array, int, float, bool]
-        first input array or scalar. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
-    x2: Union[array, int, float, bool]
-        second input array or scalar. Must be compatible with ``condition`` and ``x1`` (see :ref:`broadcasting`).
+        when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
+    x1: Union[array, int, float, complex, bool]
+        first input array or scalar. Scalar values are treated like an array filled with this value. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
+    x2: Union[array, int, float, complex, bool]
+        second input array or scalar. Scalar values are treated like an array filled with this value. Must be compatible with ``condition`` and ``x1`` (see :ref:`broadcasting`).
 
     Returns
     -------
     out: array
         an array with elements from ``x1`` where ``condition`` is ``True``, and elements from ``x2`` elsewhere. The returned array must have a data type determined by :ref:`type-promotion` rules with the arrays ``x1`` and ``x2``.
+
+    Notes
+    -----
+    See :ref:`mixing-scalars-and-arrays` on compatibility requirements and handling of scalar arguments for ``x1`` and ``x2``.
 
     .. versionchanged:: 2024.12
         ``x1`` and ``x2`` may be scalars.

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -1,7 +1,7 @@
 __all__ = ["argmax", "argmin", "nonzero", "searchsorted", "where"]
 
 
-from ._types import Optional, Tuple, Literal, array
+from ._types import Optional, Tuple, Literal, Union, array
 
 
 def argmax(x: array, /, *, axis: Optional[int] = None, keepdims: bool = False) -> array:
@@ -139,21 +139,24 @@ def searchsorted(
     """
 
 
-def where(condition: array, x1: array, x2: array, /) -> array:
+def where(condition: array, x1: Union[array, int, float, bool], x2: Union[array, int, float, bool], /) -> array:
     """
     Returns elements chosen from ``x1`` or ``x2`` depending on ``condition``.
 
     Parameters
     ----------
     condition: array
-        when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
-    x1: array
-        first input array. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
-    x2: array
-        second input array. Must be compatible with ``condition`` and ``x1`` (see :ref:`broadcasting`).
+        when ``True``, yield ``x1_i`` (scalar ``x1``); otherwise, yield ``x2_i`` (scalar ``x2``). Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
+    x1: Union[array, int, float, bool]
+        first input array or scalar. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
+    x2: Union[array, int, float, bool]
+        second input array or scalar. Must be compatible with ``condition`` and ``x1`` (see :ref:`broadcasting`).
 
     Returns
     -------
     out: array
         an array with elements from ``x1`` where ``condition`` is ``True``, and elements from ``x2`` elsewhere. The returned array must have a data type determined by :ref:`type-promotion` rules with the arrays ``x1`` and ``x2``.
+
+    .. versionchanged:: 2024.12
+        ``x1`` and ``x2`` may be scalars.
     """

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -164,7 +164,9 @@ def where(
 
     Notes
     -----
-    See :ref:`mixing-scalars-and-arrays` on compatibility requirements and handling of scalar arguments for ``x1`` and ``x2``.
+
+    -   At least one of  ``x1`` and ``x2`` must be an array.
+    -   If either ``x1`` or ``x2`` is a scalar value, the returned array must have a data type determined according to :ref:`mixing-scalars-and-arrays`.
 
     .. versionchanged:: 2024.12
         ``x1`` and ``x2`` may be scalars.

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -141,8 +141,8 @@ def searchsorted(
 
 def where(
     condition: array,
-    x1: Union[array, int, float, bool],
-    x2: Union[array, int, float, bool],
+    x1: Union[array, int, float, complex, bool],
+    x2: Union[array, int, float, complex, bool],
     /,
 ) -> array:
     """

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -139,7 +139,12 @@ def searchsorted(
     """
 
 
-def where(condition: array, x1: Union[array, int, float, bool], x2: Union[array, int, float, bool], /) -> array:
+def where(
+    condition: array,
+    x1: Union[array, int, float, bool],
+    x2: Union[array, int, float, bool],
+    /,
+) -> array:
     """
     Returns elements chosen from ``x1`` or ``x2`` depending on ``condition``.
 


### PR DESCRIPTION
Towards https://github.com/data-apis/array-api/issues/807

This adds wording to the doc string and function signature to allow scalars in addition to arrays for the second and third argument.

Not super happy with the phrasing for the description of `condition`, maybe someone else has a suggestion for how to explain it without using a lot of words. We can then hopefully reuse that in the description of `out`.

There are a lot more functions that need updating (https://github.com/data-apis/array-api/issues/807#issuecomment-2159156834). I think it make sense to get this one done, and then copy&paste for the others (instead of having a giant diff while discussing things).

There is https://github.com/data-apis/array-api-strict/pull/78 which implements this in array-api-strict.