### PR TITLE
Small typo in copies and views page

### DIFF
--- a/spec/draft/design_topics/copies_views_and_mutation.rst
+++ b/spec/draft/design_topics/copies_views_and_mutation.rst
@@ -6,7 +6,7 @@ Copy-view behaviour and mutability
 .. admonition:: Mutating views
    :class: important
 
-   Array API consumers are *strongly* advised to avoid *any* mutating operations when an array object may be either a "view" (i.e., an array whose data refers to memory that belongs to another array) or own memory of which one or more other array objects may be views. This admonition may become more strict in the future (e.g., this specification may require that view mutation be prohibited and trigger an exception). Accordingly, only perform mutation operations (e.g., in-place assignment) when absolutely confident that array data belongs to one, and only one, array object.
+   Array API consumers are *strongly* advised to avoid *any* mutating operations when an array object may either be a "view" (i.e., an array whose data refers to memory that belongs to another array) or own memory of which one or more other array objects may be views. This admonition may become more strict in the future (e.g., this specification may require that view mutation be prohibited and trigger an exception). Accordingly, only perform mutation operations (e.g., in-place assignment) when absolutely confident that array data belongs to one, and only one, array object.
 
 Strided array implementations (e.g. NumPy, PyTorch, CuPy, MXNet) typically
 have the concept of a "view", meaning an array containing data in memory that


### PR DESCRIPTION
word order typo, should be "either be a [...] or own [...] who may be"