### PR TITLE
fix: clarify that `condition` should have a boolean dtype in `where`

### DIFF
--- a/src/array_api_stubs/_2021_12/searching_functions.py
+++ b/src/array_api_stubs/_2021_12/searching_functions.py
@@ -69,7 +69,7 @@ def where(condition: array, x1: array, x2: array, /) -> array:
     Parameters
     ----------
     condition: array
-        when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
+        when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Should have a boolean data type. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
     x1: array
         first input array. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
     x2: array

--- a/src/array_api_stubs/_2022_12/searching_functions.py
+++ b/src/array_api_stubs/_2022_12/searching_functions.py
@@ -91,7 +91,7 @@ def where(condition: array, x1: array, x2: array, /) -> array:
     Parameters
     ----------
     condition: array
-        when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
+        when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Should have a boolean data type. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
     x1: array
         first input array. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
     x2: array

--- a/src/array_api_stubs/_2023_12/searching_functions.py
+++ b/src/array_api_stubs/_2023_12/searching_functions.py
@@ -146,7 +146,7 @@ def where(condition: array, x1: array, x2: array, /) -> array:
     Parameters
     ----------
     condition: array
-        when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
+        when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Should have a boolean data type. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
     x1: array
         first input array. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
     x2: array

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -146,7 +146,7 @@ def where(condition: array, x1: array, x2: array, /) -> array:
     Parameters
     ----------
     condition: array
-        Should have a boolean data type. When ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
+        when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Should have a boolean data type. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
     x1: array
         first input array. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
     x2: array

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -146,7 +146,7 @@ def where(condition: array, x1: array, x2: array, /) -> array:
     Parameters
     ----------
     condition: array
-        when ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
+        Should have a boolean data type. When ``True``, yield ``x1_i``; otherwise, yield ``x2_i``. Must be compatible with ``x1`` and ``x2`` (see :ref:`broadcasting`).
     x1: array
         first input array. Must be compatible with ``condition`` and ``x2`` (see :ref:`broadcasting`).
     x2: array


### PR DESCRIPTION
Towards https://github.com/data-apis/array-api-extra/issues/49, https://github.com/scipy/scipy/pull/21783

gh-116 removed this detail because it was contained in a type annotation. Unfortunately, that detail hasn't made its way back into the spec yet, which is causing trouble downstream, with array-api-strict supporting non-boolean input, but `torch` from array-api-compat only supporting boolean input.

cc @ev-br @asmeurer 