### PR TITLE
docs: clarify that implementations may add additional arguments

### DIFF
--- a/spec/draft/purpose_and_scope.md
+++ b/spec/draft/purpose_and_scope.md
@@ -410,8 +410,8 @@ all the functions, arguments, data types, syntax, and semantics described in
 this specification.
 
 A conforming implementation of the array API standard may provide additional
-values, objects, properties, data types, and functions beyond those described
-in this specification.
+features (e.g. values, objects, properties, data types, functions, and function
+arguments) beyond those described in this specification.
 
 Libraries which aim to provide a conforming implementation but haven't yet
 completed such an implementation may, and are encouraged to, provide details on

--- a/spec/draft/purpose_and_scope.md
+++ b/spec/draft/purpose_and_scope.md
@@ -410,7 +410,7 @@ all the functions, arguments, data types, syntax, and semantics described in
 this specification.
 
 A conforming implementation of the array API standard may provide additional
-features (e.g. values, objects, properties, data types, functions, and function
+features (e.g., values, objects, properties, data types, functions, and function
 arguments) beyond those described in this specification.
 
 Libraries which aim to provide a conforming implementation but haven't yet


### PR DESCRIPTION
Closes gh-869 by clarifying that the list of additional features array library implementations may add is not intended to be comprehensive.