### PR TITLE
docs: clarify behavior when providing a zero-dimensional array to `take`

### DIFF
--- a/src/array_api_stubs/_draft/indexing_functions.py
+++ b/src/array_api_stubs/_draft/indexing_functions.py
@@ -13,7 +13,7 @@ def take(x: array, indices: array, /, *, axis: Optional[int] = None) -> array:
     Parameters
     ----------
     x: array
-        input array.
+        input array. Should have one or more dimensions (axes).
     indices: array
         array indices. The array must be one-dimensional and have an integer data type.
 
@@ -33,15 +33,12 @@ def take(x: array, indices: array, /, *, axis: Optional[int] = None) -> array:
     Notes
     -----
 
-    Behavior for 0-dimensional arrays is unspecified.
+    -   When ``x`` is a zero-dimensional array, behavior is unspecified and thus implementation-defined.
 
     .. versionadded:: 2022.12
 
     .. versionchanged:: 2023.12
        Out-of-bounds behavior is explicitly left unspecified.
-
-    .. versionchanged:: 2024.12
-       Behavior for 0-dimensional arrays is explicitly left unspecified.
     """
 
 

--- a/src/array_api_stubs/_draft/indexing_functions.py
+++ b/src/array_api_stubs/_draft/indexing_functions.py
@@ -33,10 +33,15 @@ def take(x: array, indices: array, /, *, axis: Optional[int] = None) -> array:
     Notes
     -----
 
+    Behavior for 0-dimensional arrays is unspecified.
+
     .. versionadded:: 2022.12
 
     .. versionchanged:: 2023.12
        Out-of-bounds behavior is explicitly left unspecified.
+
+    .. versionchanged:: 2024.12
+       Behavior for 0-dimensional arrays is explicitly left unspecified.
     """
 
 


### PR DESCRIPTION
closes gh-855