### PR TITLE
fix: address default value regression for `axis` kwarg in `vecdot`

### DIFF
--- a/src/array_api_stubs/_2021_12/linalg.py
+++ b/src/array_api_stubs/_2021_12/linalg.py
@@ -474,7 +474,7 @@ def trace(x: array, /, *, offset: int = 0) -> array:
     """
 
 
-def vecdot(x1: array, x2: array, /, *, axis: int = None) -> array:
+def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     """
     Alias for :func:`~array_api.vecdot`.
     """

--- a/src/array_api_stubs/_2022_12/linalg.py
+++ b/src/array_api_stubs/_2022_12/linalg.py
@@ -755,7 +755,7 @@ def trace(x: array, /, *, offset: int = 0, dtype: Optional[dtype] = None) -> arr
     """
 
 
-def vecdot(x1: array, x2: array, /, *, axis: int = None) -> array:
+def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     """Alias for :func:`~array_api.vecdot`."""
 
 

--- a/src/array_api_stubs/_2023_12/linalg.py
+++ b/src/array_api_stubs/_2023_12/linalg.py
@@ -781,7 +781,7 @@ def trace(x: array, /, *, offset: int = 0, dtype: Optional[dtype] = None) -> arr
     """
 
 
-def vecdot(x1: array, x2: array, /, *, axis: int = None) -> array:
+def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     """Alias for :func:`~array_api.vecdot`."""
 
 

--- a/src/array_api_stubs/_draft/linalg.py
+++ b/src/array_api_stubs/_draft/linalg.py
@@ -781,7 +781,7 @@ def trace(x: array, /, *, offset: int = 0, dtype: Optional[dtype] = None) -> arr
     """
 
 
-def vecdot(x1: array, x2: array, /, *, axis: int = None) -> array:
+def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     """Alias for :func:`~array_api.vecdot`."""
 
 


### PR DESCRIPTION
This PR:

- closes: https://github.com/data-apis/array-api/issues/804
- addresses a regression introduced in https://github.com/data-apis/array-api/commit/cbbab62922ab7ddd4f31302c21f22d2db62d6f16.
- was previously fixed in https://github.com/data-apis/array-api/pull/358
- backports changes to previous specification versions.