### PR TITLE
docs: clarify type promotion behavior in `diff`

### DIFF
--- a/src/array_api_stubs/_draft/utility_functions.py
+++ b/src/array_api_stubs/_draft/utility_functions.py
@@ -125,5 +125,5 @@ def diff(
     -----
 
     -   The first-order differences are given by ``out[i] = x[i+1] - x[i]`` along a specified axis. Higher-order differences must be calculated recursively (e.g., by calling ``diff(out, axis=axis, n=n-1)``).
-    -   If a conforming implementation chooses to support ``prepend`` and ``append`` arrays which have a different data type than ``x``, the ``prepend`` and ``append`` arrays should promote to the same data type as ``x`` (see :ref:`type-promotion`). If ``prepend`` and ``append`` do not promote to the same data type as ``x`` or are of a different data type "kind" (integer, real-valued floating-point, or complex floating-point), behavior is unspecified and thus implementation-defined.
+    -   If a conforming implementation chooses to support ``prepend`` and ``append`` arrays which have a different data type than ``x``, behavior is unspecified and thus implementation-defined. Implementations may choose to type promote (:ref:`type-promotion`), cast ``prepend`` and/or ``append`` to the same data type as ``x``, or raise an exception.
     """

--- a/src/array_api_stubs/_draft/utility_functions.py
+++ b/src/array_api_stubs/_draft/utility_functions.py
@@ -125,4 +125,5 @@ def diff(
     -----
 
     -   The first-order differences are given by ``out[i] = x[i+1] - x[i]`` along a specified axis. Higher-order differences must be calculated recursively (e.g., by calling ``diff(out, axis=axis, n=n-1)``).
+    -   If a conforming implementation chooses to support ``prepend`` and ``append`` arrays which have a different data type than ``x``, the ``prepend`` and ``append`` arrays should promote to the same data type as ``x`` (see :ref:`type-promotion`). If ``prepend`` and ``append`` do not promote to the same data type as ``x`` or are of a different data type "kind" (integer, real-valued floating-point, or complex floating-point), behavior is unspecified and thus implementation-defined.
     """


### PR DESCRIPTION
This PR:

- closes: https://github.com/data-apis/array-api/issues/852
- clarifies that, when either `prepend` and `append` are of a different dtype than `x`, behavior is left unspecified, allowing type promotion, casting, or raising an exception.
- maintains the status quo that the only portable behavior is when `append` and `prepend` have the same data type as `x`.

## Notes

NumPy supports type promotion:

```python
In [14]: x = np.ones(10,dtype="float32")

In [15]: x.dtype
Out[15]: dtype('float32')

In [16]: np.diff(x).dtype
Out[16]: dtype('float32')

In [17]: np.diff(x,prepend=np.ones(10))
Out[17]:
array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0.])

In [18]: np.diff(x,prepend=np.ones(10)).dtype
Out[18]: dtype('float64')
```

We have yet, TMK, allowed optional array kwargs to affect the output array dtype. It is not obvious to me that we should establish such a precedent here.