### PR TITLE
docs: clarify that `sqrt` must be correctly rounded in accordance with IEEE 754

### DIFF
--- a/spec/draft/design_topics/accuracy.rst
+++ b/spec/draft/design_topics/accuracy.rst
@@ -25,6 +25,8 @@ including the corresponding element-wise array APIs defined in this standard
 
 for real-valued floating-point operands must return the correctly rounded value according to IEEE 754-2019 and a supported rounding mode. By default, the rounding mode should be ``roundTiesToEven`` (i.e., round to nearest with ties rounded toward the nearest value with an even least significant bit).
 
+IEEE 754-2019 requires support for subnormal (a.k.a., denormal) numbers, which are useful for supporting gradual underflow. However, hardware support for subnormal numbers is not universal, and many platforms (e.g., accelerators) and compilers support toggling denormals-are-zero (DAZ) and/or flush-to-zero (FTZ) behavior to increase performance and to guard against timing attacks. Accordingly, conforming implementations may vary in their support for subnormal numbers.
+
 Mathematical Functions
 ----------------------
 

--- a/spec/draft/design_topics/accuracy.rst
+++ b/spec/draft/design_topics/accuracy.rst
@@ -23,7 +23,7 @@ including the corresponding element-wise array APIs defined in this standard
 -   multiply
 -   divide
 
-for real-valued floating-point operands must return the correctly rounded value according to IEEE 754-2019 and a supported rounding mode. By default, the rounding mode should be ``roundTiesToEven`` (i.e., round to nearest with ties rounded toward the nearest value with an even least significant bit).
+for real-valued floating-point operands must return a correctly rounded value according to IEEE 754-2019 and a supported rounding mode. By default, the rounding mode should be ``roundTiesToEven`` (i.e., round to nearest with ties rounded toward the nearest value with an even least significant bit).
 
 IEEE 754-2019 requires support for subnormal (a.k.a., denormal) numbers, which are useful for supporting gradual underflow. However, hardware support for subnormal numbers is not universal, and many platforms (e.g., accelerators) and compilers support toggling denormals-are-zero (DAZ) and/or flush-to-zero (FTZ) behavior to increase performance and to guard against timing attacks. Accordingly, conforming implementations may vary in their support for subnormal numbers.
 
@@ -35,7 +35,7 @@ The results of the following functions
 -   reciprocal
 -   sqrt
 
-for real-valued floating-point operands must return the nearest representable value according to IEEE 754-2019 and a supported rounding mode.
+for real-valued floating-point operands must return a correctly rounded value according to IEEE 754-2019 and a supported rounding mode.
 
 This specification does **not** precisely define the behavior of the following functions
 

--- a/spec/draft/design_topics/accuracy.rst
+++ b/spec/draft/design_topics/accuracy.rst
@@ -23,7 +23,7 @@ including the corresponding element-wise array APIs defined in this standard
 -   multiply
 -   divide
 
-for real-valued floating-point operands must return the nearest representable value according to IEEE 754-2019 and a supported rounding mode. By default, the rounding mode should be ``roundTiesToEven`` (i.e., round to nearest with ties rounded toward the nearest value with an even least significant bit).
+for real-valued floating-point operands must return the correctly rounded value according to IEEE 754-2019 and a supported rounding mode. By default, the rounding mode should be ``roundTiesToEven`` (i.e., round to nearest with ties rounded toward the nearest value with an even least significant bit).
 
 Mathematical Functions
 ----------------------

--- a/spec/draft/design_topics/accuracy.rst
+++ b/spec/draft/design_topics/accuracy.rst
@@ -23,10 +23,17 @@ including the corresponding element-wise array APIs defined in this standard
 -   multiply
 -   divide
 
-for floating-point operands must return the nearest representable value according to IEEE 754-2019 and a supported rounding mode. By default, the rounding mode should be ``roundTiesToEven`` (i.e., round to nearest with ties rounded toward the nearest value with an even least significant bit).
+for real-valued floating-point operands must return the nearest representable value according to IEEE 754-2019 and a supported rounding mode. By default, the rounding mode should be ``roundTiesToEven`` (i.e., round to nearest with ties rounded toward the nearest value with an even least significant bit).
 
 Mathematical Functions
 ----------------------
+
+The results of the following functions
+
+-   reciprocal
+-   sqrt
+
+for real-valued floating-point operands must return the nearest representable value according to IEEE 754-2019 and a supported rounding mode.
 
 This specification does **not** precisely define the behavior of the following functions
 
@@ -41,10 +48,12 @@ This specification does **not** precisely define the behavior of the following f
 -   cosh
 -   exp
 -   expm1
+-   hypot
 -   log
 -   log1p
 -   log2
 -   log10
+-   logaddexp
 -   pow
 -   sin
 -   sinh
@@ -75,3 +84,8 @@ Linear Algebra
 --------------
 
 This specification does not specify accuracy requirements for linear algebra functions; however, this specification does expect that a conforming implementation of the array API standard will make a best-effort attempt to ensure that its implementations are theoretically sound and numerically robust.
+
+Operations Involving Complex Numbers
+------------------------------------
+
+This specification does not specify accuracy requirements for arithmetic or functional operations involving complex-valued floating-point operands; however, this specification does expect that a conforming implementation of the array API standard will make a best-effort attempt to ensure that its implementations are theoretically sound and numerically robust.


### PR DESCRIPTION
This PR:

- closes https://github.com/data-apis/array-api/issues/826 and closes https://github.com/data-apis/array-api/issues/830
- clarifies that `sqrt` should follow IEEE 754 and always return correctly rounded result. This was implied (i.e., conforming implementations should be IEEE 754 compliant), but never made explicit.
- clarifies that accuracy requirements apply to real-valued floating-point operands and not complex-valued floating-point operands.
- adds missing functions to list of functions not covered by accuracy requirements.
- specifies that subnormals may or may not be supported.