### PR TITLE
feat: add support for real-valued arrays in `real` and `conj`

### DIFF
--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -881,8 +881,9 @@ def conj(x: array, /) -> array:
 
     .. versionadded:: 2022.12
 
-    If ``x`` array has a real floating-point dtype, the returned array is a copy of ``x``.
-
+    A conforming implementation may return a "view" into the input array or a copy. Therefore, whether
+    the output array and the input array share the underlying memory buffer is unspecified and
+    thus implementation-defined.
     """
 
 
@@ -2361,8 +2362,9 @@ def real(x: array, /) -> array:
 
     .. versionadded:: 2022.12
 
-    If ``x`` array has a real floating-point dtype, the returned array is a copy of ``x``.
-
+    A conforming implementation may return a "view" into the input array or a copy. Therefore, whether
+    the output array and the input array share the underlying memory buffer is unspecified and
+    thus implementation-defined.
     """
 
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -869,7 +869,7 @@ def conj(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a floating-point data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------
@@ -2350,7 +2350,7 @@ def real(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a floating-point data type.
+        input array. Should have a numeric data type.
 
     Returns
     -------

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -869,7 +869,7 @@ def conj(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a complex floating-point data type.
+        input array. Should have a floating-point data type.
 
     Returns
     -------
@@ -880,6 +880,9 @@ def conj(x: array, /) -> array:
     -----
 
     .. versionadded:: 2022.12
+
+    If ``x`` array has a real floating-point dtype, the returned array is a copy of ``x``.
+
     """
 
 
@@ -2346,7 +2349,7 @@ def real(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a complex floating-point data type.
+        input array. Should have a floating-point data type.
 
     Returns
     -------
@@ -2357,6 +2360,9 @@ def real(x: array, /) -> array:
     -----
 
     .. versionadded:: 2022.12
+
+    If ``x`` array has a real floating-point dtype, the returned array is a copy of ``x``.
+
     """
 
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -879,7 +879,7 @@ def conj(x: array, /) -> array:
     Notes
     -----
 
-    -   Whether or not the returned array and the input array share the same underlying memory is unspecified and thus implementation-defined.
+    -   Whether the returned array and the input array share the same underlying memory is unspecified and thus implementation-defined.
 
     .. versionadded:: 2022.12
     """
@@ -2358,7 +2358,7 @@ def real(x: array, /) -> array:
     Notes
     -----
 
-    -   Whether or not the returned array and the input array share the same underlying memory is unspecified and thus implementation-defined.
+    -   Whether the returned array and the input array share the same underlying memory is unspecified and thus implementation-defined.
 
     .. versionadded:: 2022.12
     """

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -869,7 +869,7 @@ def conj(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a numeric data type.
+        input array. Must have a numeric data type.
 
     Returns
     -------
@@ -879,11 +879,9 @@ def conj(x: array, /) -> array:
     Notes
     -----
 
-    .. versionadded:: 2022.12
+    -   Whether or not the returned array and the input array share the same underlying memory is unspecified and thus implementation-defined.
 
-    A conforming implementation may return a "view" into the input array or a copy. Therefore, whether
-    the output array and the input array share the underlying memory buffer is unspecified and
-    thus implementation-defined.
+    .. versionadded:: 2022.12
     """
 
 
@@ -2350,7 +2348,7 @@ def real(x: array, /) -> array:
     Parameters
     ----------
     x: array
-        input array. Should have a numeric data type.
+        input array. Must have a numeric data type.
 
     Returns
     -------
@@ -2360,11 +2358,9 @@ def real(x: array, /) -> array:
     Notes
     -----
 
-    .. versionadded:: 2022.12
+    -   Whether or not the returned array and the input array share the same underlying memory is unspecified and thus implementation-defined.
 
-    A conforming implementation may return a "view" into the input array or a copy. Therefore, whether
-    the output array and the input array share the underlying memory buffer is unspecified and
-    thus implementation-defined.
+    .. versionadded:: 2022.12
     """
 
 


### PR DESCRIPTION
Closes https://github.com/data-apis/array-api/issues/824 by allowing `real` and `conj` to accept real-valued arrays, and leaving `imag` to still require complex-valued arguments.

One possibly thorny issue is whether `xp.real(x)` is a view or a copy of of `x`. This is also discussed in gh-824, not 100% sure what the resolution is though.
In this PR, err on the side of caution and require that both `real` and `conj` always return copies. 

Prior art is not very consistent AFAICS: numpy can return either a view or a copy depending on the dtype, not sure what other libraries do. 

OTOH, 

1. if we always require a copy, we can consider allowing `imag` to create a new array of zeros.
2. or maybe we can leave it unspecified and implementation dependent.