### PR TITLE
fix: resolve conflicting exception guidance in `__dlpack__`

### DIFF
--- a/src/array_api_stubs/_2023_12/array_object.py
+++ b/src/array_api_stubs/_2023_12/array_object.py
@@ -364,7 +364,7 @@ class _array:
             ``__dlpack__`` to return a capsule referencing an array whose underlying memory is
             accessible to the Python interpreter (represented by the ``kDLCPU`` enumerator in DLPack).
             If a copy must be made to enable this support but ``copy`` is set to ``False``, the
-            function must raise ``ValueError``.
+            function must raise ``BufferError``.
 
             Other device kinds will be considered for standardization in a future version of this
             API standard.

--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -364,7 +364,7 @@ class _array:
             ``__dlpack__`` to return a capsule referencing an array whose underlying memory is
             accessible to the Python interpreter (represented by the ``kDLCPU`` enumerator in DLPack).
             If a copy must be made to enable this support but ``copy`` is set to ``False``, the
-            function must raise ``ValueError``.
+            function must raise ``BufferError``.
 
             Other device kinds will be considered for standardization in a future version of this
             API standard.


### PR DESCRIPTION
This PR:

- resolves #831 by fixing the conflicting guidance regarding raised exceptions in `__dlpack__`.
- backports the fix to the `2023.12` revision of the standard.