### PR TITLE
fix: clarify broadcast behavior in `broadcast_to`

### DIFF
--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -42,14 +42,14 @@ def broadcast_to(x: array, /, shape: Tuple[int, ...]) -> array:
     Parameters
     ----------
     x: array
-        array to broadcast.
+        array to broadcast. Must be capable of being broadcast to the specified ``shape`` (see :ref:`broadcasting`). If the array is incompatible with the specified shape, the function should raise an exception.
     shape: Tuple[int, ...]
-        array shape. Must be compatible with ``x`` (see :ref:`broadcasting`). If the array is incompatible with the specified shape, the function should raise an exception.
+        array shape.
 
     Returns
     -------
     out: array
-        an array having a specified shape. Must have the same data type as ``x``.
+        an array having the specified shape. Must have the same data type as ``x``.
     """
 
 


### PR DESCRIPTION
This PR:

- closes https://github.com/data-apis/array-api/issues/823 by clarifying that (a) broadcast compatibility only applies to `x` being capable of being broadcast to a specified shape and (b) the returned array must have **the** specified shape.

## Questions

1. Is this worth backporting to prior revisions?