### PR TITLE
docs: clarify `clip` behavior when arguments have different data types

### DIFF
--- a/src/array_api_stubs/_2023_12/elementwise_functions.py
+++ b/src/array_api_stubs/_2023_12/elementwise_functions.py
@@ -791,9 +791,9 @@ def clip(
     x: array
       input array. Should have a real-valued data type.
     min: Optional[Union[int, float, array]]
-      lower-bound of the range to which to clamp. If ``None``, no lower bound must be applied. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
+      lower-bound of the range to which to clamp. If ``None``, no lower bound must be applied. Must be compatible with ``x`` and ``max`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
     max: Optional[Union[int, float, array]]
-      upper-bound of the range to which to clamp. If ``None``, no upper bound must be applied. Must be compatible with ``x1`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
+      upper-bound of the range to which to clamp. If ``None``, no upper bound must be applied. Must be compatible with ``x`` and ``min`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
 
     Returns
     -------

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -831,7 +831,7 @@ def clip(
     Returns
     -------
     out: array
-      an array containing element-wise results. The returned array must have the same data type as ``x``.
+      an array containing element-wise results. The returned array should have the same data type as ``x``.
 
     Notes
     -----

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -841,7 +841,7 @@ def clip(
     - If a broadcasted element in ``min`` is greater than a corresponding broadcasted element in ``max``, behavior is unspecified and thus implementation-dependent.
     - For scalar ``min`` and/or ``max``, the scalar values should follow type promotion rules for operations involving arrays and scalar operands (see :ref:`type-promotion`). Hence, if ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent.
     - If ``x`` has an integral data type and a broadcasted element in ``min`` or ``max`` is outside the bounds of the data type of ``x``, behavior is unspecified and thus implementation-dependent.
-    - If ``x`` and either ``min`` or ``max`` is an array having a different data type, behavior is unspecified and thus implementation-dependent.
+    - If either ``min`` or ``max`` is an array having a different data type than ``x``, behavior is unspecified and thus implementation-dependent.
 
     **Special cases**
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -839,7 +839,7 @@ def clip(
     - This function is conceptually equivalent to ``maximum(minimum(x, max), min)`` when ``x``, ``min``, and ``max`` have the same data type.
     - If both ``min`` and ``max`` are ``None``, the elements of the returned array must equal the respective elements in ``x``.
     - If a broadcasted element in ``min`` is greater than a corresponding broadcasted element in ``max``, behavior is unspecified and thus implementation-dependent.
-    - For scalar ``min`` and/or ``max``, the scalar values should follow type promotion rules (see :ref:`type-promotion`). If ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent
+    - For scalar ``min`` and/or ``max``, the scalar values should follow type promotion rules (see :ref:`type-promotion`). Hence, if ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent
     - If ``x`` has an integral data type and a broadcasted element in ``min`` or ``max`` is outside the bounds of the data type of ``x``, behavior is unspecified and thus implementation-dependent.
     - If ``x`` and either ``min`` or ``max`` is an array having a different data type, behavior is unspecified and thus implementation-dependent.
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -839,7 +839,7 @@ def clip(
     - This function is conceptually equivalent to ``maximum(minimum(x, max), min)`` when ``x``, ``min``, and ``max`` have the same data type.
     - If both ``min`` and ``max`` are ``None``, the elements of the returned array must equal the respective elements in ``x``.
     - If a broadcasted element in ``min`` is greater than a corresponding broadcasted element in ``max``, behavior is unspecified and thus implementation-dependent.
-    - For scalar ``min`` and/or ``max``, the scalar values should follow type promotion rules (see :ref:`type-promotion`). Hence, if ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent
+    - For scalar ``min`` and/or ``max``, the scalar values should follow type promotion rules for operations involving arrays and scalar operands (see :ref:`type-promotion`). Hence, if ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent.
     - If ``x`` has an integral data type and a broadcasted element in ``min`` or ``max`` is outside the bounds of the data type of ``x``, behavior is unspecified and thus implementation-dependent.
     - If ``x`` and either ``min`` or ``max`` is an array having a different data type, behavior is unspecified and thus implementation-dependent.
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -837,11 +837,11 @@ def clip(
     -----
 
     - This function is conceptually equivalent to ``maximum(minimum(x, max), min)`` when ``x``, ``min``, and ``max`` have the same data type.
-    - For scalar ``min`` and/or ``max``, the scalar values must be converted to zero-dimensional arrays having the same data type as ``x`` prior to broadcasting.
     - If both ``min`` and ``max`` are ``None``, the elements of the returned array must equal the respective elements in ``x``.
     - If a broadcasted element in ``min`` is greater than a corresponding broadcasted element in ``max``, behavior is unspecified and thus implementation-dependent.
+    - For scalar ``min`` and/or ``max``, the scalar values should follow type promotion rules (see :ref:`type-promotion`). If ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent
     - If ``x`` has an integral data type and a broadcasted element in ``min`` or ``max`` is outside the bounds of the data type of ``x``, behavior is unspecified and thus implementation-dependent.
-    - If ``x`` and either ``min`` or ``max`` have different data types and/or data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent.
+    - If ``x`` and either ``min`` or ``max`` is an array having a different data type, behavior is unspecified and thus implementation-dependent.
 
     **Special cases**
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -824,9 +824,9 @@ def clip(
     x: array
       input array. Should have a real-valued data type.
     min: Optional[Union[int, float, array]]
-      lower-bound of the range to which to clamp. If ``None``, no lower bound must be applied. Must be compatible with ``x`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
+      lower-bound of the range to which to clamp. If ``None``, no lower bound must be applied. Must be compatible with ``x`` (see :ref:`broadcasting`). Should have the same data type as ``x``. Default: ``None``.
     max: Optional[Union[int, float, array]]
-      upper-bound of the range to which to clamp. If ``None``, no upper bound must be applied. Must be compatible with ``x`` (see :ref:`broadcasting`). Should have a real-valued data type. Default: ``None``.
+      upper-bound of the range to which to clamp. If ``None``, no upper bound must be applied. Must be compatible with ``x`` (see :ref:`broadcasting`). Should have the same data type as ``x``. Default: ``None``.
 
     Returns
     -------
@@ -836,10 +836,12 @@ def clip(
     Notes
     -----
 
+    - This function is conceptually equivalent to ``maximum(minimum(x, max), min)`` when ``x``, ``min``, and ``max`` have the same data type.
+    - For scalar ``min`` and/or ``max``, the scalar values must be converted to zero-dimensional arrays having the same data type as ``x`` prior to broadcasting.
     - If both ``min`` and ``max`` are ``None``, the elements of the returned array must equal the respective elements in ``x``.
     - If a broadcasted element in ``min`` is greater than a corresponding broadcasted element in ``max``, behavior is unspecified and thus implementation-dependent.
     - If ``x`` has an integral data type and a broadcasted element in ``min`` or ``max`` is outside the bounds of the data type of ``x``, behavior is unspecified and thus implementation-dependent.
-    - If ``x`` and either ``min`` or ``max`` have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent.
+    - If ``x`` and either ``min`` or ``max`` have different data types and/or data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent.
 
     **Special cases**
 

--- a/src/array_api_stubs/_draft/elementwise_functions.py
+++ b/src/array_api_stubs/_draft/elementwise_functions.py
@@ -824,9 +824,9 @@ def clip(
     x: array
       input array. Should have a real-valued data type.
     min: Optional[Union[int, float, array]]
-      lower-bound of the range to which to clamp. If ``None``, no lower bound must be applied. Must be compatible with ``x`` (see :ref:`broadcasting`). Should have the same data type as ``x``. Default: ``None``.
+      lower-bound of the range to which to clamp. If ``None``, no lower bound must be applied. Must be compatible with ``x`` and ``max`` (see :ref:`broadcasting`). Should have the same data type as ``x``. Default: ``None``.
     max: Optional[Union[int, float, array]]
-      upper-bound of the range to which to clamp. If ``None``, no upper bound must be applied. Must be compatible with ``x`` (see :ref:`broadcasting`). Should have the same data type as ``x``. Default: ``None``.
+      upper-bound of the range to which to clamp. If ``None``, no upper bound must be applied. Must be compatible with ``x`` and ``min`` (see :ref:`broadcasting`). Should have the same data type as ``x``. Default: ``None``.
 
     Returns
     -------


### PR DESCRIPTION
This PR

- follows up on https://github.com/data-apis/array-api/pull/814#issuecomment-2639228207 and https://github.com/data-apis/array-api/issues/807 and supersedes https://github.com/data-apis/array-api/pull/811 to indicate that behavior is only defined when `min` and `max` have the same data type as `x`. After reviewing SciPy and scikit-learn usage of `xp.clip` and `np.clip`, the overwhelming usage was using scalar `min` and `max`. For all instances that I found with array `min` and `max`, type promotion behavior was not expected. Given the various edge cases when `min` and `max` are not the same type as `x`, it seems prudent to limit portable behavior to the scenario which avoids edge cases altogether.
- clarifies the definition of `clamp` as suggested in https://github.com/data-apis/array-api/pull/814#issuecomment-2428088370.
- specifies behavior when `min` and/or `max` are scalar values.
- clarifies three-way broadcasting as done in https://github.com/data-apis/array-api/pull/811.
- relaxes the output array data type requirement in order to accommodate libraries such as NumPy which support type promotion behavior and cannot adopt a stricter implementation due to backward compatibility concerns.
- backports a typo fix to the v2023 revision.