### PR TITLE
fix: resolve typo in `broadcast_to` to require an exception

### DIFF
--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -42,7 +42,7 @@ def broadcast_to(x: array, /, shape: Tuple[int, ...]) -> array:
     Parameters
     ----------
     x: array
-        array to broadcast. Must be capable of being broadcast to the specified ``shape`` (see :ref:`broadcasting`). If the array is incompatible with the specified shape, the function should raise an exception.
+        array to broadcast. Must be capable of being broadcast to the specified ``shape`` (see :ref:`broadcasting`). If the array is incompatible with the specified shape, the function must raise an exception.
     shape: Tuple[int, ...]
         array shape.
 


### PR DESCRIPTION
This PR

- addresses the comment https://github.com/data-apis/array-api/pull/888/files#r1944366064 by changing `should` to `must`. This was an oversight in the original specification, as there isn't a likely scenario in which a library would want to do anything other than raise an exception.