### PR TITLE
fix: address incorrect boundary conditions in `searchsorted`

### DIFF
--- a/src/array_api_stubs/_2023_12/searching_functions.py
+++ b/src/array_api_stubs/_2023_12/searching_functions.py
@@ -109,15 +109,10 @@ def searchsorted(
 
         Let ``x2`` be an array of rank ``N`` where ``v`` is an individual element given by ``v = x2[n,m,...,j]``.
 
-        If ``side == 'left'``, then
-
-        - each returned index ``i`` must satisfy the index condition ``x1[i-1] < v <= x1[i]``.
-        - if no index satisfies the index condition, then the returned index for that element must be ``0``.
-
-        Otherwise, if ``side == 'right'``, then
-
-        - each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
-        - if no index satisfies the index condition, then the returned index for that element must be ``M``, where ``M`` is the number of elements in ``x1``.
+        - If ``v`` is less than all elements in ``x1``, then the returned index for that element must be ``0``.
+        - If ``v`` is greater than all elements in ``x1``, then the returned index for that element must be ``M``, where ``M`` is the number of elements in ``x1``.
+        - If ``side == 'left'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] < v <= x1[i]``.
+        - If ``side == 'right'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
 
         Default: ``'left'``.
     sorter: Optional[array]

--- a/src/array_api_stubs/_2023_12/searching_functions.py
+++ b/src/array_api_stubs/_2023_12/searching_functions.py
@@ -111,8 +111,7 @@ def searchsorted(
 
         - If ``v`` is less than all elements in ``x1``, then the returned index for that element must be ``0``.
         - If ``v`` is greater than all elements in ``x1``, then the returned index for that element must be ``M``, where ``M`` is the number of elements in ``x1``.
-        - If ``side == 'left'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] < v <= x1[i]``.
-        - If ``side == 'right'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
+        - Otherwise, if ``side == 'left'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] < v <= x1[i]``. If ``side == 'right'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
 
         Default: ``'left'``.
     sorter: Optional[array]

--- a/src/array_api_stubs/_2023_12/searching_functions.py
+++ b/src/array_api_stubs/_2023_12/searching_functions.py
@@ -107,7 +107,7 @@ def searchsorted(
     side: Literal['left', 'right']
         argument controlling which index is returned if a value lands exactly on an edge.
 
-        Let ``x`` be an array of rank ``N`` where ``v`` is an individual element given by ``v = x2[n,m,...,j]``.
+        Let ``x2`` be an array of rank ``N`` where ``v`` is an individual element given by ``v = x2[n,m,...,j]``.
 
         If ``side == 'left'``, then
 

--- a/src/array_api_stubs/_2023_12/searching_functions.py
+++ b/src/array_api_stubs/_2023_12/searching_functions.py
@@ -107,11 +107,13 @@ def searchsorted(
     side: Literal['left', 'right']
         argument controlling which index is returned if a value lands exactly on an edge.
 
-        Let ``x2`` be an array of rank ``N`` where ``v`` is an individual element given by ``v = x2[n,m,...,j]``.
+        Let ``v`` be an element of ``x2`` given by ``v = x2[j]``, where ``j`` refers to a valid scalar or tuple index.
 
-        - If ``v`` is less than all elements in ``x1``, then the returned index for that element must be ``0``.
-        - If ``v`` is greater than all elements in ``x1``, then the returned index for that element must be ``M``, where ``M`` is the number of elements in ``x1``.
-        - Otherwise, if ``side == 'left'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] < v <= x1[i]``. If ``side == 'right'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
+        - If ``v`` is less than all elements in ``x1``, then ``out[j]`` must be ``0``.
+        - If ``v`` is greater than all elements in ``x1``, then ``out[j]`` must be ``M``, where ``M`` is the number of elements in ``x1``.
+        - Otherwise, each returned index ``i = out[j]`` must satisfy an index condition:
+          - If ``side == 'left'``, then ``x1[i-1] < v <= x1[i]``. 
+          - If ``side == 'right'``, then ``x1[i-1] <= v < x1[i]``.
 
         Default: ``'left'``.
     sorter: Optional[array]

--- a/src/array_api_stubs/_2023_12/searching_functions.py
+++ b/src/array_api_stubs/_2023_12/searching_functions.py
@@ -117,7 +117,7 @@ def searchsorted(
         Otherwise, if ``side == 'right'``, then
 
         - each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
-        - if no index satisfies the index condition, then the returned index for that element must be ``N``, where ``N`` is the number of elements in ``x1``.
+        - if no index satisfies the index condition, then the returned index for that element must be ``M``, where ``M`` is the number of elements in ``x1``.
 
         Default: ``'left'``.
     sorter: Optional[array]

--- a/src/array_api_stubs/_2023_12/searching_functions.py
+++ b/src/array_api_stubs/_2023_12/searching_functions.py
@@ -107,12 +107,13 @@ def searchsorted(
     side: Literal['left', 'right']
         argument controlling which index is returned if a value lands exactly on an edge.
 
-        Let ``v`` be an element of ``x2`` given by ``v = x2[j]``, where ``j`` refers to a valid scalar or tuple index.
+        Let ``v`` be an element of ``x2`` given by ``v = x2[j]``, where ``j`` refers to a valid index (see :ref:`indexing`).
 
         - If ``v`` is less than all elements in ``x1``, then ``out[j]`` must be ``0``.
         - If ``v`` is greater than all elements in ``x1``, then ``out[j]`` must be ``M``, where ``M`` is the number of elements in ``x1``.
         - Otherwise, each returned index ``i = out[j]`` must satisfy an index condition:
-          - If ``side == 'left'``, then ``x1[i-1] < v <= x1[i]``. 
+
+          - If ``side == 'left'``, then ``x1[i-1] < v <= x1[i]``.
           - If ``side == 'right'``, then ``x1[i-1] <= v < x1[i]``.
 
         Default: ``'left'``.

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -138,15 +138,10 @@ def searchsorted(
 
         Let ``x2`` be an array of rank ``N`` where ``v`` is an individual element given by ``v = x2[n,m,...,j]``.
 
-        If ``side == 'left'``, then
-
-        - each returned index ``i`` must satisfy the index condition ``x1[i-1] < v <= x1[i]``.
-        - if no index satisfies the index condition, then the returned index for that element must be ``0``.
-
-        Otherwise, if ``side == 'right'``, then
-
-        - each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
-        - if no index satisfies the index condition, then the returned index for that element must be ``M``, where ``M`` is the number of elements in ``x1``.
+        - If ``v`` is less than all elements in ``x1``, then the returned index for that element must be ``0``.
+        - If ``v`` is greater than all elements in ``x1``, then the returned index for that element must be ``M``, where ``M`` is the number of elements in ``x1``.
+        - If ``side == 'left'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] < v <= x1[i]``.
+        - If ``side == 'right'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
 
         Default: ``'left'``.
     sorter: Optional[array]

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -140,8 +140,7 @@ def searchsorted(
 
         - If ``v`` is less than all elements in ``x1``, then the returned index for that element must be ``0``.
         - If ``v`` is greater than all elements in ``x1``, then the returned index for that element must be ``M``, where ``M`` is the number of elements in ``x1``.
-        - If ``side == 'left'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] < v <= x1[i]``.
-        - If ``side == 'right'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
+        - Otherwise, if ``side == 'left'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] < v <= x1[i]``. If ``side == 'right'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
 
         Default: ``'left'``.
     sorter: Optional[array]

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -136,7 +136,7 @@ def searchsorted(
     side: Literal['left', 'right']
         argument controlling which index is returned if a value lands exactly on an edge.
 
-        Let ``x`` be an array of rank ``N`` where ``v`` is an individual element given by ``v = x2[n,m,...,j]``.
+        Let ``x2`` be an array of rank ``N`` where ``v`` is an individual element given by ``v = x2[n,m,...,j]``.
 
         If ``side == 'left'``, then
 

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -136,11 +136,14 @@ def searchsorted(
     side: Literal['left', 'right']
         argument controlling which index is returned if a value lands exactly on an edge.
 
-        Let ``x2`` be an array of rank ``N`` where ``v`` is an individual element given by ``v = x2[n,m,...,j]``.
+        Let ``v`` be an element of ``x2`` given by ``v = x2[j]``, where ``j`` refers to a valid index (see :ref:`indexing`).
 
-        - If ``v`` is less than all elements in ``x1``, then the returned index for that element must be ``0``.
-        - If ``v`` is greater than all elements in ``x1``, then the returned index for that element must be ``M``, where ``M`` is the number of elements in ``x1``.
-        - Otherwise, if ``side == 'left'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] < v <= x1[i]``. If ``side == 'right'``, then each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
+        - If ``v`` is less than all elements in ``x1``, then ``out[j]`` must be ``0``.
+        - If ``v`` is greater than all elements in ``x1``, then ``out[j]`` must be ``M``, where ``M`` is the number of elements in ``x1``.
+        - Otherwise, each returned index ``i = out[j]`` must satisfy an index condition:
+
+          - If ``side == 'left'``, then ``x1[i-1] < v <= x1[i]``.
+          - If ``side == 'right'``, then ``x1[i-1] <= v < x1[i]``.
 
         Default: ``'left'``.
     sorter: Optional[array]

--- a/src/array_api_stubs/_draft/searching_functions.py
+++ b/src/array_api_stubs/_draft/searching_functions.py
@@ -146,7 +146,7 @@ def searchsorted(
         Otherwise, if ``side == 'right'``, then
 
         - each returned index ``i`` must satisfy the index condition ``x1[i-1] <= v < x1[i]``.
-        - if no index satisfies the index condition, then the returned index for that element must be ``N``, where ``N`` is the number of elements in ``x1``.
+        - if no index satisfies the index condition, then the returned index for that element must be ``M``, where ``M`` is the number of elements in ``x1``.
 
         Default: ``'left'``.
     sorter: Optional[array]


### PR DESCRIPTION
This PR

- closes https://github.com/data-apis/array-api/issues/861 by fixing boundary conditions in `searchsorted`. The original specification incorrectly described behavior when an index fails to satisfy the index condition. This bug has been addressed and backported to the v2023 revision of the standard.
- fixes typos in the original specification and current draft.

cc @mdhaber 