### PR TITLE
fix: address typo in return type for `nonzero`

### DIFF
--- a/src/array_api_stubs/_2021_12/searching_functions.py
+++ b/src/array_api_stubs/_2021_12/searching_functions.py
@@ -57,7 +57,7 @@ def nonzero(x: array, /) -> Tuple[array, ...]:
 
     Returns
     -------
-    out: Typle[array, ...]
+    out: Tuple[array, ...]
         a tuple of ``k`` arrays, one for each dimension of ``x`` and each of size ``n`` (where ``n`` is the total number of non-zero elements), containing the indices of the non-zero elements in that dimension. The indices must be returned in row-major, C-style order. The returned array must have the default array index data type.
     """
 

--- a/src/array_api_stubs/_2022_12/searching_functions.py
+++ b/src/array_api_stubs/_2022_12/searching_functions.py
@@ -73,7 +73,7 @@ def nonzero(x: array, /) -> Tuple[array, ...]:
 
     Returns
     -------
-    out: Typle[array, ...]
+    out: Tuple[array, ...]
         a tuple of ``k`` arrays, one for each dimension of ``x`` and each of size ``n`` (where ``n`` is the total number of non-zero elements), containing the indices of the non-zero elements in that dimension. The indices must be returned in row-major, C-style order. The returned array must have the default array index data type.
 
     Notes

--- a/src/array_api_stubs/_2023_12/searching_functions.py
+++ b/src/array_api_stubs/_2023_12/searching_functions.py
@@ -76,7 +76,7 @@ def nonzero(x: array, /) -> Tuple[array, ...]:
 
     Returns
     -------
-    out: Typle[array, ...]
+    out: Tuple[array, ...]
         a tuple of ``k`` arrays, one for each dimension of ``x`` and each of size ``n`` (where ``n`` is the total number of non-zero elements), containing the indices of the non-zero elements in that dimension. The indices must be returned in row-major, C-style order. The returned array must have the default array index data type.
 
     Notes


### PR DESCRIPTION
This PR

- addresses a typo in the return type of `nonzero`. This typo has already been fixed in the current draft specification. This PR simply backports this fix to previous specification versions.