### PR TITLE
Clarify input arrays in device placement

### DIFF
--- a/spec/2021.12/design_topics/device_support.rst
+++ b/spec/2021.12/design_topics/device_support.rst
@@ -81,9 +81,11 @@ rather than hard requirements:
 
   1. If ``device=`` keyword is specified, that always takes precedence
 
-  2. If ``device=None``, then use the setting from a context manager, if set.
+  2. If ``device=None``, then use the device of the input array(s), if any.
 
-  3. If no context manager was used, then use the global default device/strategy
+  3. If there are no input arrays, then use the setting from a context manager, if set.
+
+  4. If no context manager was used, then use the global default device/strategy
 
 .. _device-out-of-scope:
 

--- a/spec/2022.12/design_topics/device_support.rst
+++ b/spec/2022.12/design_topics/device_support.rst
@@ -81,9 +81,11 @@ rather than hard requirements:
 
   1. If ``device=`` keyword is specified, that always takes precedence
 
-  2. If ``device=None``, then use the setting from a context manager, if set.
+  2. If ``device=None``, then use the device of the input array(s), if any.
 
-  3. If no context manager was used, then use the global default device/strategy
+  3. If there are no input arrays, then use the setting from a context manager, if set.
+
+  4. If no context manager was used, then use the global default device/strategy
 
 .. _device-out-of-scope:
 

--- a/spec/2023.12/design_topics/device_support.rst
+++ b/spec/2023.12/design_topics/device_support.rst
@@ -82,9 +82,11 @@ rather than hard requirements:
 
   1. If ``device=`` keyword is specified, that always takes precedence
 
-  2. If ``device=None``, then use the setting from a context manager, if set.
+  2. If ``device=None``, then use the device of the input array(s), if any.
 
-  3. If no context manager was used, then use the global default device/strategy
+  3. If there are no input arrays, then use the setting from a context manager, if set.
+
+  4. If no context manager was used, then use the global default device/strategy
 
 .. _device-out-of-scope:
 

--- a/spec/2024.12/design_topics/device_support.rst
+++ b/spec/2024.12/design_topics/device_support.rst
@@ -82,9 +82,11 @@ rather than hard requirements:
 
   1. If ``device=`` keyword is specified, that always takes precedence
 
-  2. If ``device=None``, then use the setting from a context manager, if set.
+  2. If ``device=None``, then use the device of the input array(s), if any.
 
-  3. If no context manager was used, then use the global default device/strategy
+  3. If there are no input arrays, then use the setting from a context manager, if set.
+
+  4. If no context manager was used, then use the global default device/strategy
 
 .. _device-out-of-scope:
 

--- a/spec/draft/design_topics/device_support.rst
+++ b/spec/draft/design_topics/device_support.rst
@@ -82,9 +82,11 @@ rather than hard requirements:
 
   1. If ``device=`` keyword is specified, that always takes precedence
 
-  2. If ``device=None``, then use the setting from a context manager, if set.
+  2. If ``device=None``, then use the device of the input array(s), if any.
 
-  3. If no context manager was used, then use the global default device/strategy
+  3. If there are no input arrays, then use the setting from a context manager, if set.
+
+  4. If no context manager was used, then use the global default device/strategy
 
 .. _device-out-of-scope:
 


### PR DESCRIPTION
Clarify that input arrays should be considered for device placement.
This new line is a repetition of bullet point 2, three lines above. However, I am observing very high levels of ambiguity among the community in the interpretation of this paragraph, where I've had multiple people insist that the device set in the context manager or global default device should trump the device of input arrays.