### PR TITLE
fix: update type signature of `eigh`

### DIFF
--- a/src/array_api_stubs/_2021_12/linalg.py
+++ b/src/array_api_stubs/_2021_12/linalg.py
@@ -86,7 +86,7 @@ def diagonal(x: array, /, *, offset: int = 0) -> array:
     """
 
 
-def eigh(x: array, /) -> Tuple[array]:
+def eigh(x: array, /) -> Tuple[array, array]:
     """
     Returns an eigendecomposition x = QLQᵀ of a symmetric matrix (or a stack of symmetric matrices) ``x``, where ``Q`` is an orthogonal matrix (or a stack of matrices) and ``L`` is a vector (or a stack of vectors).
 
@@ -106,7 +106,7 @@ def eigh(x: array, /) -> Tuple[array]:
 
     Returns
     -------
-    out: Tuple[array]
+    out: Tuple[array, array]
         a namedtuple (``eigenvalues``, ``eigenvectors``) whose
 
         -   first element must have the field name ``eigenvalues`` (corresponding to ``L`` above) and must be an array consisting of computed eigenvalues. The array containing the eigenvalues must have shape ``(..., M)``.

--- a/src/array_api_stubs/_2022_12/linalg.py
+++ b/src/array_api_stubs/_2022_12/linalg.py
@@ -134,7 +134,7 @@ def diagonal(x: array, /, *, offset: int = 0) -> array:
     """
 
 
-def eigh(x: array, /) -> Tuple[array]:
+def eigh(x: array, /) -> Tuple[array, array]:
     r"""
     Returns an eigenvalue decomposition of a complex Hermitian or real symmetric matrix (or a stack of matrices) ``x``.
 
@@ -168,7 +168,7 @@ def eigh(x: array, /) -> Tuple[array]:
 
     Returns
     -------
-    out: Tuple[array]
+    out: Tuple[array, array]
         a namedtuple (``eigenvalues``, ``eigenvectors``) whose
 
         -   first element must have the field name ``eigenvalues`` (corresponding to :math:`\operatorname{diag}\Lambda` above) and must be an array consisting of computed eigenvalues. The array containing the eigenvalues must have shape ``(..., M)`` and must have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then ``eigenvalues`` must be ``float64``).

--- a/src/array_api_stubs/_2023_12/linalg.py
+++ b/src/array_api_stubs/_2023_12/linalg.py
@@ -163,7 +163,7 @@ def diagonal(x: array, /, *, offset: int = 0) -> array:
     """
 
 
-def eigh(x: array, /) -> Tuple[array]:
+def eigh(x: array, /) -> Tuple[array, array]:
     r"""
     Returns an eigenvalue decomposition of a complex Hermitian or real symmetric matrix (or a stack of matrices) ``x``.
 
@@ -197,7 +197,7 @@ def eigh(x: array, /) -> Tuple[array]:
 
     Returns
     -------
-    out: Tuple[array]
+    out: Tuple[array, array]
         a namedtuple (``eigenvalues``, ``eigenvectors``) whose
 
         -   first element must have the field name ``eigenvalues`` (corresponding to :math:`\operatorname{diag}\Lambda` above) and must be an array consisting of computed eigenvalues. The array containing the eigenvalues must have shape ``(..., M)`` and must have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then ``eigenvalues`` must be ``float64``).

--- a/src/array_api_stubs/_2024_12/linalg.py
+++ b/src/array_api_stubs/_2024_12/linalg.py
@@ -163,7 +163,7 @@ def diagonal(x: array, /, *, offset: int = 0) -> array:
     """
 
 
-def eigh(x: array, /) -> Tuple[array]:
+def eigh(x: array, /) -> Tuple[array, array]:
     r"""
     Returns an eigenvalue decomposition of a complex Hermitian or real symmetric matrix (or a stack of matrices) ``x``.
 
@@ -197,7 +197,7 @@ def eigh(x: array, /) -> Tuple[array]:
 
     Returns
     -------
-    out: Tuple[array]
+    out: Tuple[array, array]
         a namedtuple (``eigenvalues``, ``eigenvectors``) whose
 
         -   first element must have the field name ``eigenvalues`` (corresponding to :math:`\operatorname{diag}\Lambda` above) and must be an array consisting of computed eigenvalues. The array containing the eigenvalues must have shape ``(..., M)`` and must have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then ``eigenvalues`` must be ``float64``).

--- a/src/array_api_stubs/_draft/linalg.py
+++ b/src/array_api_stubs/_draft/linalg.py
@@ -163,7 +163,7 @@ def diagonal(x: array, /, *, offset: int = 0) -> array:
     """
 
 
-def eigh(x: array, /) -> Tuple[array]:
+def eigh(x: array, /) -> Tuple[array, array]:
     r"""
     Returns an eigenvalue decomposition of a complex Hermitian or real symmetric matrix (or a stack of matrices) ``x``.
 
@@ -197,7 +197,7 @@ def eigh(x: array, /) -> Tuple[array]:
 
     Returns
     -------
-    out: Tuple[array]
+    out: Tuple[array, array]
         a namedtuple (``eigenvalues``, ``eigenvectors``) whose
 
         -   first element must have the field name ``eigenvalues`` (corresponding to :math:`\operatorname{diag}\Lambda` above) and must be an array consisting of computed eigenvalues. The array containing the eigenvalues must have shape ``(..., M)`` and must have a real-valued floating-point data type whose precision matches the precision of ``x`` (e.g., if ``x`` is ``complex128``, then ``eigenvalues`` must be ``float64``).


### PR DESCRIPTION
Fixes #922 

The type signature of `eigh` has been updated from `Tuple[array]` to `Tuple[array, array]`.

I am not sure how things are backported in this repository, but for now I have updated the signature in all the versions. Please let me know if this should be changed!