### PR TITLE
fix: remove recommendation of no other public names in namespace

### DIFF
--- a/src/array_api_stubs/_draft/array_object.py
+++ b/src/array_api_stubs/_draft/array_object.py
@@ -211,7 +211,7 @@ class _array:
         Returns
         -------
         out: Any
-            an object representing the array API namespace. It should have every top-level function defined in the specification as an attribute. It may contain other public names as well, but it is recommended to only include those names that are part of the specification.
+            an object representing the array API namespace. It should have every top-level function defined in the specification as an attribute.
         """
 
     def __bool__(self: array, /) -> bool:


### PR DESCRIPTION
closes gh-928

@kgryte do we want to backport?