### PR TITLE
docs: highlight RFC 2119 keywords in data type functions

### DIFF
--- a/src/array_api_stubs/_draft/data_types.py
+++ b/src/array_api_stubs/_draft/data_types.py
@@ -11,9 +11,9 @@ def __eq__(self: dtype, other: dtype, /) -> bool:
     Parameters
     ----------
     self: dtype
-        data type instance. May be any supported data type.
+        data type instance. **Should** be any supported data type.
     other: dtype
-        other data type instance. May be any supported data type.
+        other data type instance. **Should** be any supported data type.
 
     Returns
     -------


### PR DESCRIPTION
This PR

- performs maintenance by partially addressing https://github.com/data-apis/array-api/issues/397 by marking in bold applicable RFC 2119 keywords in data type functions.
- changes the normative word `may` to `should` to align with RFC 2119 conventions as used in this specification.