### PR TITLE
feat: add `isin` to the specification

### DIFF
--- a/spec/draft/API_specification/set_functions.rst
+++ b/spec/draft/API_specification/set_functions.rst
@@ -18,6 +18,7 @@ Objects in API
    :toctree: generated
    :template: method.rst
 
+   isin
    unique_all
    unique_counts
    unique_inverse

--- a/src/array_api_stubs/_draft/set_functions.py
+++ b/src/array_api_stubs/_draft/set_functions.py
@@ -1,7 +1,51 @@
-__all__ = ["unique_all", "unique_counts", "unique_inverse", "unique_values"]
+__all__ = ["isin", "unique_all", "unique_counts", "unique_inverse", "unique_values"]
 
 
 from ._types import Tuple, array
+
+
+def isin(
+    x1: Union[array, int, float, complex, bool],
+    x2: Union[array, int, float, complex, bool],
+    /,
+    *,
+    invert: bool = False,
+) -> array:
+    """
+    Tests whether each element in ``x1`` is in ``x2``.
+
+    Parameters
+    ----------
+    x1: Union[array, int, float, complex, bool]
+        first input array. **May** have any data type.
+    x2: Union[array, int, float, complex, bool]
+        second input array. **May** have any data type.
+    invert: bool
+        boolean indicating whether to invert the test criterion. If ``True``, the function **must** test whether each element in ``x1`` is *not* in ``x2``. If ``False``, the function **must** test whether each element in ``x1`` is in ``x2``. Default: ``False``.
+
+    Returns
+    -------
+    out: array
+        an array containing element-wise test results. The returned array **must** have the same shape as ``x1`` and **must** have a boolean data type.
+
+    Notes
+    -----
+
+    -   At least one of ``x1`` or ``x2`` **must** be an array.
+
+    -   If an element in ``x1`` is in ``x1``, the corresponding element in the output array **must** be ``True``; otherwise, the corresponding element in the output array **must** be ``False``.
+
+    -   Testing whether an element in ``x1`` corresponds to an element in ``x2`` **should** be determined based on value equality (see :func:`~array_api.equal`). For input arrays having floating-point data types, value-based equality implies the following behavior.
+
+        -   As ``nan`` values compare as ``False``, if an element in ``x1`` is ``nan`` and ``invert`` is ``False``, the corresponding element in the returned array **should** be ``False``. Otherwise, if an element in ``x1`` is ``nan`` and ``invert`` is ``True``, the corresponding element in the returned array **should** be ``True``.
+        -   As complex floating-point values having at least one ``nan`` component compare as ``False``, if an element in ``x1`` is a complex floating-point value having one or more ``nan`` components and ``invert`` is ``False``, the corresponding element in the returned array **should** be ``False``. Otherwise, if an element in ``x1`` is a complex floating-point value having one or more ``nan`` components and ``invert`` is ``True``, the corresponding element in the returned array **should** be ``True``.
+        -   As ``-0`` and ``+0`` compare as ``True``, if an element in ``x1`` is ``±0`` and ``x2`` contains at least one element which is ``±0``
+
+            -   if ``invert`` is ``False``, the corresponding element in the returned array **should** be ``True``.
+            -   if ``invert`` is ``True``, the corresponding element in the returned array **should** be ``False``.
+
+    -   Comparison of arrays without a corresponding promotable data type (see :ref:`type-promotion`) is unspecified and thus implementation-defined.
+    """
 
 
 def unique_all(x: array, /) -> Tuple[array, array, array, array]:


### PR DESCRIPTION
This PR:

- resolves https://github.com/data-apis/array-api/issues/854 by adding `isin` to the specification.
- of the keyword arguments determined according to array comparison [data](https://github.com/data-apis/array-api-comparison/blob/8cd85d8bcafdd71b4f18df3e7bd9fccd1507d1ee/signatures/sets/isin.md), this PR chooses to support only the `invert` kwarg. The `assume_unique` kwarg was not included for the following reasons:

    1. not all array libraries support this kwarg (e.g., ndonnx and CuPy). CuPy lists the kwarg in its documentation but states that this kwarg is ignored.
    2. when doing a quick [search](https://github.com/search?q=repo%3Ascikit-learn%2Fscikit-learn+np.isin&type=code&p=1) through sklearn, I was only able to find one usage of `assume_unique` when using `isin` and that was when searching lists of already known unique values.
    3. `assume_unique` is something of a performance optimization/implementation detail which we have generally attempted to avoid when standardizing APIs.

- does not place restrictions on the shape of `x2`. While some libraries may choose to flatten a multi-dimensional `x2`, that is something of an implementation detail and not strictly necessary. For example, an implementation could defer to an "includes" kernel which performs nested loop iteration without needing to perform explicit reshapes/copies.

- adds support for scalar arguments for either `x1` or `x2`. This follows recent general practice in standardized APIs, with the restriction that at least one of `x1` or `x2` must be an array.

- specifies that value equality **should** be used, but not **must** be used. This follows other set APIs (e.g., `unique*`). As a consequence of value equality, `NaN` values can never test as `True` and there is no distinction between signed zeros.

- allows both `x1` and `x2` to be of any data type. However, if `x1` and `x2` have no promotable data type, behavior is left unspecified and thus implementation-defined.

## Questions

- Would we be okay with requiring that value equality **must** be used? Is there a scenario where we want to allow libraries some wiggle room, such as with `NaN` and signed zero comparison?
- Are we okay with leaving out `assume_unique`?
- Are we okay with not mandating reshape behavior if `x2` is multi-dimensional?