### PR TITLE
feat: add `bincount` to the specification

### DIFF
--- a/spec/draft/API_specification/statistical_functions.rst
+++ b/spec/draft/API_specification/statistical_functions.rst
@@ -18,6 +18,7 @@ Objects in API
    :toctree: generated
    :template: method.rst
 
+   bincount
    cumulative_prod
    cumulative_sum
    max

--- a/src/array_api_stubs/_draft/statistical_functions.py
+++ b/src/array_api_stubs/_draft/statistical_functions.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "bincount",
     "cumulative_sum",
     "cumulative_prod",
     "max",
@@ -12,6 +13,45 @@ __all__ = [
 
 
 from ._types import Optional, Tuple, Union, array, dtype
+
+
+def bincount(
+    x: array, /, weights: Optional[array] = None, *, minlength: int = 0
+) -> array:
+    """
+    Counts the number of occurrences of each element in ``x``.
+
+    .. admonition:: Data-dependent output shape
+        :class: important
+
+        The shape of the output array for this function depends on the data values in ``x``; hence, array libraries which build computation graphs (e.g., JAX, Dask, etc.) can find this function difficult to implement without knowing the values in ``x``. Accordingly, such libraries **may** choose to omit this function. See :ref:`data-dependent-output-shapes` section for more details.
+
+    Parameters
+    ----------
+    x: array
+        input array. **Should** be a one-dimensional array. **Must** have an integer data type.
+    weights: Optional[array]
+        an array of weights for each element in ``x``. **Must** have the same shape as ``x``. **Must** have a numeric data type. If not provided, each bin in the returned array **must** give the number of occurrences of its index value in ``x``. If provided, each bin in the returned array **must** be a sum of the weights corresponding to the respective index values in ``x`` (i.e., if value ``n`` is found at index ``i`` in ``x``, then ``out[n] += weights[i]``, instead of ``out[n] += 1``). Default: ``None``.
+    minlength: int
+        minimum number of bins. **Must** be a nonnegative integer. Default: ``0``.
+
+    Returns
+    -------
+    out: array
+        an array containing the number of occurrences. Let ``N`` equal ``max(xp.max(x)+1, minlength)``. The returned array **should** have shape ``(N,)``.
+
+        If ``weights`` is not ``None``, the returned array **must** have the same data type as ``weights``.
+
+        If ``weights`` is ``None``, the returned array **must** have the same data type as ``x``, unless ``x`` has an integer data type supporting a smaller range of values than the default integer data type (e.g., ``x`` has an ``int16`` or ``uint32`` data type and the default integer data type is ``int64``). In those latter cases:
+
+        -   if ``x`` has a signed integer data type (e.g., ``int16``), the returned array **must** have the default integer data type.
+        -   if ``x`` has an unsigned integer data type (e.g., ``uint16``), the returned array **must** have an unsigned integer data type having the same number of bits as the default integer data type (e.g., if the default integer data type is ``int32``, the returned array **must** have a ``uint32`` data type).
+
+    Notes
+    -----
+
+    -   If ``x`` contains negative values, behavior is unspecified and thus implementation-defined.
+    """
 
 
 def cumulative_prod(


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/812 by adding `bincount` to the specification for counting the number of occurrences of each element in an input integer array.
- based on [comparison data](https://github.com/data-apis/array-api-comparison/blob/312c75bb5589a1c5fe8c6de6f8b8a196dc5f1e71/signatures/statistics/bincount.md), only supports a `minlength` keyword argument.
- allows `weights` to be both a positional and keyword argument.
- allows `weights` to have any numeric data type, including complex.
- specifies that, when `weights` is not provided, the output data type must be an integer data type. The data type rules follow other statistical functions (e.g., `sum`), where a minimum precision is required.
- specifies that, when `weights` is provided, the output data type must have the same data type as `weights`.
- specifies that an input array `x` **should** (not **must**) be a one-dimensional array. TensorFlow allows `x` to be multi-dimensional, and this PR chooses to provide wiggle room to allow supporting multi-dimensional arrays. One reason this isn't commonly supported in other libraries is that `bincount` has a data-dependent output shape; however, TF supports kwargs which allow specifying a static output shape, thus allowing `bincount` to generalize to multiple dimensions.
- includes an admonition that `bincount` has a data-dependent output shape and thus certain libraries are allowed to omit this function if too difficult to implement. This follows similar practice for other APIs having data-dependent output shapes (e.g., `unique*`).
- specifies that, if `x` contains negative values, behavior is unspecified and thus implementation-defined. NumPy raises an exception, while JAX clips.
- specifies that `weights` have the same shape as `x`; although, IMO, this restriction is not necessary and could be relaxed to broadcast-compatibility.
- specifies that the returned array **should** (not **must**) have shape `(N,)`, where `N = max(xp.max(x)+1, minlength)`. The use of **should** is intentional, in order to allow libraries such as JAX and TF to support other keyword arguments which may constrain the output shape.
- specifies that the default value of `minlength` must be `0`. According to docs, both CuPy and TF use a default of `None`.

## Questions

- Are we okay with allowing `weights` to be complex? This does not appear to be supported in NumPy (ref: https://github.com/numpy/numpy/issues/23313 and https://github.com/numpy/numpy/issues/16903); however, there isn't a technical reason why weights cannot be complex, as summation is well-defined for complex numbers.
- Similar to `sum` and other statistical functions, should we support an output `dtype` kwarg (e.g., in order to support overriding the default integer output type behavior)?
- Are we okay with `weights` being both positional and a keyword argument?