### PR TITLE
docs: `default_device()` can be `None`

### DIFF
--- a/src/array_api_stubs/_draft/info.py
+++ b/src/array_api_stubs/_draft/info.py
@@ -80,12 +80,12 @@ def default_device() -> device:
     Returns
     -------
     out: device
-        an object corresponding to the default device or ``None``.
-        A conforming array library may return ``None`` if the default device is not
-        predictable due to library specific device placement rules.
+        an object (including ``None``) corresponding to the default device.
 
     Notes
     -----
+
+    -   A conforming array library may return ``None`` if the default device is not predictable due to library specific device placement rules.
 
     .. versionadded: 2023.12
     """


### PR DESCRIPTION
closes gh-923.

Per discussion in the community meeting, https://hackmd.io/zn5bvdZTQIeJmb3RW1B-8g#Meeting-minutes-15-May-2025 and the resolution of https://github.com/data-apis/array-api/issues/923#issuecomment-2885639657, spell out explicitly that `None` is an allowed return value of the `default_device`.