### PR TITLE
feat: add `eig` and `eigvals` to the `linalg` extension

### DIFF
--- a/src/array_api_stubs/_draft/linalg.py
+++ b/src/array_api_stubs/_draft/linalg.py
@@ -359,7 +359,6 @@ def eigvals(x: array, /) -> array:
     """
 
 
-
 def inv(x: array, /) -> array:
     r"""
     Returns the multiplicative inverse of a square matrix (or a stack of square matrices) ``x``.


### PR DESCRIPTION
Following up on an RFC at https://github.com/data-apis/array-api/issues/935, add non-symmetric eigenvalue solvers, `eig` and `eigvals`, to the `linalg` extension.

The routines are available in `numpy`, `torch`, `jax.numpy` and `cupy` (as of to-be-released cupy 1.14, cf https://github.com/cupy/cupy/pull/8980). The main point of contention in gh-935 was the behavior for all eigenvalues on the real line. NumPy returns a real array and all other libraries return a complex array (with zero imaginary parts if they happen to be zero). 
Based on the discussion in https://github.com/numpy/numpy/issues/29000, it might it be difficult to change in numpy itself. Therefore, the suggestion is to make the precise dtype implementation-defined.
I believe the benefit of having `eig` in the standard outweighs this wart.

One other minor point of inconsistency is <s>https://github.com/jax-ml/jax/issues/32558: `jax` returns a standard-compliant namedtuple for `eigh` but a bare tuple for `eig`. I believe this is a minor issue though. </s> already fixed. 