### PR TITLE
feat: add support for negative axes to `permute_dims`

### DIFF
--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -159,7 +159,7 @@ def permute_dims(x: array, /, axes: Tuple[int, ...]) -> array:
     x: array
         input array.
     axes: Tuple[int, ...]
-        tuple containing a permutation of ``(0, 1, ..., N-1)`` where ``N`` is the number of axes in ``x``.
+        tuple containing a permutation of axes. A valid axis **must** be an integer on the interval ``[-N, N)``, where ``N`` is the number of axes in ``x``. If an axis is specified as a negative integer, the function **must** determine the respective axis index by counting backward from the last axis (where ``-1`` refers to the last axis). If provided an invalid axis, the function **must** raise an exception.
 
     Returns
     -------


### PR DESCRIPTION
This PR

- adds support for negative axes in `permute_dims`. This was discussed in a workgroup meeting where consensus was achieved for moving https://github.com/data-apis/array-api/issues/962 forward. The principle holdout was JAX; however, given upstream NumPy support, JAX was in favor of moving forward.
- uses language with other APIs in the specification supporting negative axis indices.