### PR TITLE
feat!: return tuples rather than lists in `meshgrid`, `broadcast_arrays`, and `info.devices`

### DIFF
--- a/src/array_api_stubs/_draft/creation_functions.py
+++ b/src/array_api_stubs/_draft/creation_functions.py
@@ -451,7 +451,7 @@ def linspace(
     """
 
 
-def meshgrid(*arrays: array, indexing: Literal["xy", "ij"] = "xy") -> List[array]:
+def meshgrid(*arrays: array, indexing: Literal["xy", "ij"] = "xy") -> Tuple[array, ...]:
     """
     Returns coordinate matrices from coordinate vectors.
 
@@ -464,8 +464,8 @@ def meshgrid(*arrays: array, indexing: Literal["xy", "ij"] = "xy") -> List[array
 
     Returns
     -------
-    out: List[array]
-        list of N arrays, where ``N`` is the number of provided one-dimensional input arrays. Each returned array must have rank ``N``. For ``N`` one-dimensional arrays having lengths ``Ni = len(xi)``,
+    out: Tuple[array, ...]
+        tuple of N arrays, where ``N`` is the number of provided one-dimensional input arrays. Each returned array must have rank ``N``. For ``N`` one-dimensional arrays having lengths ``Ni = len(xi)``,
 
         - if matrix indexing ``ij``, then each returned array must have the shape ``(N1, N2, N3, ..., Nn)``.
         - if Cartesian indexing ``xy``, then each returned array must have shape ``(N2, N1, N3, ..., Nn)``.

--- a/src/array_api_stubs/_draft/info.py
+++ b/src/array_api_stubs/_draft/info.py
@@ -172,19 +172,19 @@ def dtypes(
     """
 
 
-def devices() -> List[device]:
+def devices() -> Tuple[device, ...]:
     """
     Returns a list of supported devices which are available at runtime.
 
     Returns
     -------
-    out: List[device]
-        a list of supported devices.
+    out: Tuple[device, ...]
+        tuple containing a list of supported devices.
 
     Notes
     -----
 
-    -   Each device object (see :ref:`device-support`) in the list of returned devices **must** be an object which can be provided as a valid keyword-argument to array creation functions.
+    -   Each device object (see :ref:`device-support`) in the tuple of returned devices **must** be an object which can be provided as a valid keyword-argument to array creation functions.
 
     Notes
     -----

--- a/src/array_api_stubs/_draft/manipulation_functions.py
+++ b/src/array_api_stubs/_draft/manipulation_functions.py
@@ -19,7 +19,7 @@ __all__ = [
 from ._types import List, Optional, Tuple, Union, array
 
 
-def broadcast_arrays(*arrays: array) -> List[array]:
+def broadcast_arrays(*arrays: array) -> Tuple[array, ...]:
     """
     Broadcasts one or more arrays against one another.
 
@@ -30,8 +30,8 @@ def broadcast_arrays(*arrays: array) -> List[array]:
 
     Returns
     -------
-    out: List[array]
-        a list of broadcasted arrays. Each array **must** have the same shape. Each array **must** have the same dtype as its corresponding input array.
+    out: Tuple[array, ...]
+        tuple of broadcasted arrays. Each array **must** have the same shape. Each array **must** have the same dtype as its corresponding input array.
     """
 
 


### PR DESCRIPTION
This PR

- resolves https://github.com/data-apis/array-api/issues/938
- updates `meshgrid` to return a `tuple` rather than a list. This follows NumPy and PyTorch.
- updates `broadcast_arrays` to return a `tuple` rather than a list. This follows NumPy.
- updates `info.devices` to return a `tuple` rather than a list. This ensures consistency with the rest of the specification where we always return `tuples`, rather than lists.

This changes benefits Array API consumers such as Numba, where working with tuples facilitates optimizations.

Note that this is a breaking specification change. 