### PR TITLE
docs: add `eig` and `eigvals` to linear algebra functions list

### DIFF
--- a/spec/draft/extensions/linear_algebra_functions.rst
+++ b/spec/draft/extensions/linear_algebra_functions.rst
@@ -97,6 +97,8 @@ A conforming implementation of this ``linalg`` extension must provide and suppor
    diagonal
    eigh
    eigvalsh
+   eig
+   eigvals
    inv
    matmul
    matrix_norm


### PR DESCRIPTION
Otherwise the docs are missing them: https://data-apis.org/array-api/draft/extensions/linear_algebra_functions.html

Not sure what is the best way to add them to both 2025 and draft pages, is it update in two places or is there some backport process.